### PR TITLE
Forward link types

### DIFF
--- a/src/freenet/clients/http/PageNode.java
+++ b/src/freenet/clients/http/PageNode.java
@@ -18,7 +18,43 @@ public class PageNode extends InfoboxNode {
 	 *            The URL of the custom style sheet
 	 */
 	public void addCustomStyleSheet(String customStyleSheet) {
-		headNode.addChild("link", new String[] { "rel", "href", "type", "media" }, new String[] { "stylesheet", customStyleSheet, "text/css", "screen" });
+		addForwardLink("stylesheet", customStyleSheet, "text/css", "screen");
+	}
+
+	/**
+	 * Adds a document relationship forward link to the HTML document's HEAD
+	 * node.
+	 *
+	 * @param linkType
+	 *            The link type (e.g. "stylesheet" or "shortcut icon")
+	 * @param href
+	 *            The link
+	 */
+	public void addForwardLink(String linkType, String href) {
+		addForwardLink(linkType, href, null, null);
+	}
+
+	/**
+	 * Adds a document relationship forward link to the HTML document's HEAD
+	 * node.
+	 *
+	 * @param linkType
+	 *            The link type (e.g. "stylesheet" or "shortcut icon")
+	 * @param href
+	 *            The link
+	 * @param type
+	 *            The type of the referenced data
+	 * @param media
+	 *            The media for which this link is valid
+	 */
+	public void addForwardLink(String linkType, String href, String type, String media) {
+		HTMLNode linkNode = headNode.addChild("link", new String[] { "rel", "href" }, new String[] { linkType, href });
+		if (type != null) {
+			linkNode.addAttribute("type", type);
+		}
+		if (media != null) {
+			linkNode.addAttribute("media", media);
+		}
 	}
 
 }


### PR DESCRIPTION
This patch enables toadlet and plugin developers to set additional “forward-link type” headers, examples of which would be “stylesheet” (we already support that one) or “icon” (for shortcut icons/favicon).
