### PR TITLE
Unit tests for PeerMessageQueue

### DIFF
--- a/test/freenet/node/PeerMessageQueueTest.java
+++ b/test/freenet/node/PeerMessageQueueTest.java
@@ -1,3 +1,6 @@
+/* This code is part of Freenet. It is distributed under the GNU General
+ * Public License, version 2 (or at your option any later version). See
+ * http://www.gnu.org/ for further details of the GPL. */
 package freenet.node;
 
 import junit.framework.TestCase;


### PR DESCRIPTION
Adds a few tests for PeerMessageQueue, most importantly a test checking that getNextUrgentTime() returns the correct value, even when the least urgent MessageItem is queued first (covers the bug fixed in 88d2c14a). This partially fixes bug 4786.
