### PR TITLE
Have fred execute in background mode (reduced I/O priority) on windows NT

### DIFF
--- a/src/freenet/node/NodeStarter.java
+++ b/src/freenet/node/NodeStarter.java
@@ -24,6 +24,7 @@ import freenet.support.SimpleFieldSet;
 import freenet.support.Logger.LogLevel;
 import freenet.support.LoggerHook.InvalidThresholdException;
 import freenet.support.io.NativeThread;
+import freenet.support.ProcessPriority;
 
 /**
  *  @author nextgens
@@ -233,6 +234,10 @@ public class NodeStarter implements WrapperListener {
 	 * Main Method
 	 *-------------------------------------------------------------*/
 	public static void main(String[] args) {
+		// Immediately try entering background mode. This way also class
+		//  loading will be subject to reduced priority. 
+		ProcessPriority.backgroundMode(true);
+		
 		// Start the application.  If the JVM was launched from the native
 		//  Wrapper then the application will wait for the native Wrapper to
 		//  call the application's start method.  Otherwise the start method

--- a/src/freenet/support/ProcessPriority.java
+++ b/src/freenet/support/ProcessPriority.java
@@ -49,7 +49,7 @@ public class ProcessPriority {
                 if (win.SetPriorityClass(win.GetCurrentProcess(), Kernel32.PROCESS_MODE_BACKGROUND_BEGIN))
                     return background = true;
                 else if (win.GetLastError() == Kernel32.ERROR_PROCESS_MODE_ALREADY_BACKGROUND)
-                    throw new Exception("Illegal state");
+                    throw new IllegalStateException();
         return background;
     }
 
@@ -61,7 +61,7 @@ public class ProcessPriority {
                 if (win.SetPriorityClass(win.GetCurrentProcess(), Kernel32.PROCESS_MODE_BACKGROUND_END))
                     return background = false;
                 else if (win.GetLastError() == Kernel32.ERROR_PROCESS_MODE_NOT_BACKGROUND)
-                    throw new Exception("Illegal state");
+                    throw new IllegalStateException();
         return background;
     }
     

--- a/src/freenet/support/ProcessPriority.java
+++ b/src/freenet/support/ProcessPriority.java
@@ -1,0 +1,83 @@
+package freenet.support;
+
+import com.sun.jna.*;
+import com.sun.jna.win32.StdCallLibrary;
+
+public class ProcessPriority {
+    private static boolean inited = false;
+    private static boolean background = false;
+    
+    /// Windows interface (kernel32.dll) ///
+
+    private interface Kernel32 extends StdCallLibrary {
+        /* HANDLE -> Pointer, DWORD -> int */
+        public boolean SetPriorityClass(Pointer hProcess, int dwPriorityClass);
+        public Pointer GetCurrentProcess();
+        public int GetLastError();
+
+        public static int PROCESS_MODE_BACKGROUND_BEGIN         = 0x00100000;
+        public static int PROCESS_MODE_BACKGROUND_END           = 0x00200000;
+        public static int ERROR_THREAD_MODE_ALREADY_BACKGROUND  = 402;
+        public static int ERROR_THREAD_MODE_NOT_BACKGROUND      = 403;
+    }
+
+    private static Kernel32 win = null;
+    
+    /// Implementation
+
+    private static boolean init() {
+        if (!inited) {
+            try {
+                if (Platform.isWindows()) {
+                    win = (Kernel32) Native.loadLibrary("kernel32", Kernel32.class);
+                    inited = true;
+                }
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+        return inited;
+    }
+    
+    private static boolean enterBackgroundMode() throws Exception {
+        if (!init())
+            return false;
+        if (!background)
+            if (Platform.isWindows())
+                if (win.SetPriorityClass(win.GetCurrentProcess(), Kernel32.PROCESS_MODE_BACKGROUND_BEGIN))
+                    return background = true;
+                else if (win.GetLastError() == Kernel32.ERROR_THREAD_MODE_ALREADY_BACKGROUND)
+                    throw new Exception("Illegal state");
+        return background;
+    }
+
+    private static boolean exitBackgroundMode() throws Exception {
+        if (!init())
+            return false;
+        if (background)
+            if (Platform.isWindows())
+                if (win.SetPriorityClass(win.GetCurrentProcess(), Kernel32.PROCESS_MODE_BACKGROUND_END))
+                    return background = false;
+                else if (win.GetLastError() == Kernel32.ERROR_THREAD_MODE_NOT_BACKGROUND)
+                    throw new Exception("Illegal state");
+        return background;
+    }
+    
+    /// Public methods ///////////////////////////////////
+    
+    public static boolean isBackgroundMode() {
+    	return background;
+    }
+
+    public static boolean backgroundMode(boolean bg) {
+    	try {
+    		if (bg)
+    			enterBackgroundMode();
+    		else
+    			exitBackgroundMode();
+    	} catch (Exception e) {
+    	}
+    	return isBackgroundMode();
+    }
+}
+

--- a/src/freenet/support/ProcessPriority.java
+++ b/src/freenet/support/ProcessPriority.java
@@ -1,3 +1,7 @@
+/* This code is part of Freenet. It is distributed under the GNU General
+ * Public License, version 2 (or at your option any later version). See
+ * http://www.gnu.org/ for further details of the GPL. */
+
 package freenet.support;
 
 import com.sun.jna.Native;
@@ -5,6 +9,22 @@ import com.sun.jna.Platform;
 import com.sun.jna.Pointer;
 import com.sun.jna.win32.StdCallLibrary;
 
+/**
+ * A class to control the global priority of the current process.
+ * Microsoft suggests flagging daemon/server processes with the BACKGROUND_MODE
+ * priority class so that they don't interfere with the responsiveness of the
+ * rest of the system. This is especially important when freenet is started at
+ * system startup.
+ * We use JNA to call the OS libraries directly without needing JNI wrappers.
+ * Its usage is really simple: just call ProcessPriority.backgroundMode(true).
+ * If the OS doesn't support it or if the process doesn't have the appropriate
+ * permissions, the above call is simply a no-op.
+ *
+ * @author Carlo Alberto Ferraris &lt;cafxx@strayorange.com&gt;
+ *
+ * TODO: emulate the BACKGROUND_MODE priority class on other OSes (linux, mac)
+ */
+ 
 public class ProcessPriority {
     private static boolean inited = false;
     private static boolean background = false;

--- a/src/freenet/support/ProcessPriority.java
+++ b/src/freenet/support/ProcessPriority.java
@@ -1,6 +1,8 @@
 package freenet.support;
 
-import com.sun.jna.*;
+import com.sun.jna.Native;
+import com.sun.jna.Platform;
+import com.sun.jna.Pointer;
 import com.sun.jna.win32.StdCallLibrary;
 
 public class ProcessPriority {
@@ -17,8 +19,8 @@ public class ProcessPriority {
 
         public static int PROCESS_MODE_BACKGROUND_BEGIN         = 0x00100000;
         public static int PROCESS_MODE_BACKGROUND_END           = 0x00200000;
-        public static int ERROR_THREAD_MODE_ALREADY_BACKGROUND  = 402;
-        public static int ERROR_THREAD_MODE_NOT_BACKGROUND      = 403;
+        public static int ERROR_PROCESS_MODE_ALREADY_BACKGROUND = 402;
+        public static int ERROR_PROCESS_MODE_NOT_BACKGROUND     = 403;
     }
 
     private static Kernel32 win = null;
@@ -46,7 +48,7 @@ public class ProcessPriority {
             if (Platform.isWindows())
                 if (win.SetPriorityClass(win.GetCurrentProcess(), Kernel32.PROCESS_MODE_BACKGROUND_BEGIN))
                     return background = true;
-                else if (win.GetLastError() == Kernel32.ERROR_THREAD_MODE_ALREADY_BACKGROUND)
+                else if (win.GetLastError() == Kernel32.ERROR_PROCESS_MODE_ALREADY_BACKGROUND)
                     throw new Exception("Illegal state");
         return background;
     }
@@ -58,7 +60,7 @@ public class ProcessPriority {
             if (Platform.isWindows())
                 if (win.SetPriorityClass(win.GetCurrentProcess(), Kernel32.PROCESS_MODE_BACKGROUND_END))
                     return background = false;
-                else if (win.GetLastError() == Kernel32.ERROR_THREAD_MODE_NOT_BACKGROUND)
+                else if (win.GetLastError() == Kernel32.ERROR_PROCESS_MODE_NOT_BACKGROUND)
                     throw new Exception("Illegal state");
         return background;
     }


### PR DESCRIPTION
Have fred execute in background mode (reduced I/O priority) on windows NT6+
This patch uses JNA (3.2.7) to call the native OS libraries.
jna.jar is not included in the patch but can be fetched from http://java.net/projects/jna/downloads