### PR TITLE
Path field length fix

### DIFF
--- a/src/freenet/clients/http/FProxyToadlet.java
+++ b/src/freenet/clients/http/FProxyToadlet.java
@@ -330,9 +330,10 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
 			NodeL10n.getBase().addL10nSubstitution(optionForm, "FProxyToadlet.downloadInBackgroundToDisk",
 			        new String[] { "dir", "page" },
 			        new HTMLNode[] { new HTMLNode("input",
-			                new String[] { "type", "name", "value", "size" },
+			                new String[] { "type", "name", "value", "maxlength", "size" },
 			                new String[] { "text", "path", downloadLocation,
-			                        Integer.toString(QueueToadlet.MAX_FILENAME_LENGTH) }),
+			                        Integer.toString(QueueToadlet.MAX_FILENAME_LENGTH),
+			                        String.valueOf(downloadLocation.length())}),
 			                DOWNLOADS_LINK });
 			optionForm.addChild("input",
 			        new String[] { "type", "name", "value" },
@@ -956,9 +957,7 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
 
 	private boolean isBrowser(String ua) {
 		if(ua == null) return false;
-		if(ua.indexOf("Mozilla/") > -1) return true;
-		if(ua.indexOf("Opera/") > -1) return true;
-		return false;
+		return (ua.contains("Mozilla/") || ua.contains("Opera/"));
 	}
 
 	private static String writeSizeAndMIME(HTMLNode fileInformationList, FetchException e) {

--- a/src/freenet/clients/http/QueueToadlet.java
+++ b/src/freenet/clients/http/QueueToadlet.java
@@ -1902,8 +1902,9 @@ public class QueueToadlet extends Toadlet implements RequestCompletionCallback, 
 			downloadLocation = core.getAllowedDownloadDirs()[0].getAbsolutePath();
 		}
 		node.addChild("input",
-		        new String[] { "type", "name", "value", "size" },
-		        new String[] { "text", "path", downloadLocation, Integer.toString(MAX_FILENAME_LENGTH)});
+		        new String[] { "type", "name", "value", "maxlength", "size" },
+		        new String[] { "text", "path", downloadLocation, Integer.toString(MAX_FILENAME_LENGTH),
+		                String.valueOf(downloadLocation.length())});
 		node.addChild("input",
 		        new String[] { "type", "name", "value" },
 		        new String[] { "submit", "select-location", l10n("browseToChange")+"..." });


### PR DESCRIPTION
Setting the size of the path field to MAX_FILENAME_LENGTH makes the page unusably wide. This sets the size to that of the default valid path, and the maxlength to MAX_FILENAME_LENGTH.
