### PR TITLE
Fix config page behavior on enter

### DIFF
--- a/src/freenet/clients/http/ConfigToadlet.java
+++ b/src/freenet/clients/http/ConfigToadlet.java
@@ -307,6 +307,12 @@ public class ConfigToadlet extends Toadlet implements LinkEnabledCallback {
 		HTMLNode configNode = infobox.addChild("div", "class", "infobox-content");
 		HTMLNode formNode = ctx.addFormChild(configNode, path(), "configForm");
 
+		//Invisible apply button at the top so that an enter keypress will apply settings instead of
+		//going to a directory browser if present.
+		formNode.addChild("input",
+		        new String[] { "type", "value", "style" },
+		        new String[] { "submit", l10n("apply"), "visibility:hidden"});
+
 		if(subConfig.getPrefix().equals("node") && WrapperConfig.canChangeProperties()) {
 			String configName = "wrapper.java.maxmemory";
 			String curValue = WrapperConfig.getWrapperProperty(configName);


### PR DESCRIPTION
Adds a hidden "apply" button at the top of the form. This is to address [bug #5090](https://bugs.freenetproject.org/view.php?id=5090), where pressing enter would enter the directory browser instead of applying settings. I didn't use display:none because the button is ignored (at least by Chrome) in that case. I'm not confident in my HTML/CSS, so if there's a better way to do this please let me know.
