### PR TITLE
Fix the N2N "Send message" button in simple mode

### DIFF
--- a/src/freenet/clients/http/N2NTMToadlet.java
+++ b/src/freenet/clients/http/N2NTMToadlet.java
@@ -151,7 +151,7 @@ public class N2NTMToadlet extends Toadlet {
 			return;
 		}
 
-		if (request.isPartSet("n2nm-upload") || request.isPartSet("select-file")) {
+		if (request.isPartSet("n2nm-upload") || request.isPartSet("select-file") || request.isPartSet("send")) {
 			File filename = null;
 			String message = request.getPartAsStringFailsafe("message", 5 * 1024);
 			message = message.trim();


### PR DESCRIPTION
It worked in advanced due to the "n2nm-upload" file selection, but in simple, as "send" was not checked for, the message was not sent when pressing "Send message". This bug was introduced [here](https://github.com/freenet/fred-staging/commit/24cb8160c94bbbddaab6ba3578c7c39c43151c56#L3L138).
