### PR TITLE
Note in version if working directory is dirty

### DIFF
--- a/build-clean.xml
+++ b/build-clean.xml
@@ -77,6 +77,7 @@ build-dependency on ant-optional, libbsf-java and rhino.
 		<arg value="describe" />
 		<arg value="--always" />
 		<arg value="--abbrev=4" />
+		<arg value="--dirty" />
 	</exec>
 	<condition property="git.revision" value="${git.describe}" else="@unknown@">
 		<and>


### PR DESCRIPTION
This adds -dirty to the description if there are uncommitted changes in
the working directory when building
