### PR TITLE
FIX: theme: rabbit-hole on dark background.

### DIFF
--- a/src/freenet/clients/http/staticfiles/themes/rabbit-hole/theme.css
+++ b/src/freenet/clients/http/staticfiles/themes/rabbit-hole/theme.css
@@ -10,6 +10,12 @@
 /* First: Progress bars */
 /* @import url(/static/themes/clean/theme.css); */
 
+/* basic colors */
+body {
+    color: black;
+    background-color: white;
+}
+
 /* alerts */
 
 .alert-error {
@@ -556,8 +562,6 @@ div#content {
     margin: 0px;
     margin-left: 83px;
     margin-right: 83px;
-}
-
 }
 
 /* rabbit hole */


### PR DESCRIPTION
theme: rabbit-hole: set white background color and black text as default, so it works with browsers in dark mode.
