### PR TITLE
Fix filter not properly escaping external links to external link toadlet.

### DIFF
--- a/src/freenet/client/filter/GenericReadFilterCallback.java
+++ b/src/freenet/client/filter/GenericReadFilterCallback.java
@@ -246,7 +246,7 @@ public class GenericReadFilterCallback implements FilterCallback, URIProcessor {
 		if(forBaseHref)
 			throw new CommentException(l10n("bogusBaseHref"));
 		if(GenericReadFilterCallback.allowedProtocols.contains(uri.getScheme()))
-			return ExternalLinkToadlet.PATH+'?'+ExternalLinkToadlet.magicHTTPEscapeString+'='+uri;
+			return ExternalLinkToadlet.escape(uri.toString());
 		else {
 			if(uri.getScheme() == null) {
 				throw new CommentException(reason);


### PR DESCRIPTION
As saces pointed out, the filter did not properly point to the external link toadlet.
