### PR TITLE
Fix filter test failing on external link escaping

### DIFF
--- a/src/freenet/clients/http/ExternalLinkToadlet.java
+++ b/src/freenet/clients/http/ExternalLinkToadlet.java
@@ -18,7 +18,7 @@ public class ExternalLinkToadlet extends Toadlet {
 
 	private static final int MAX_URL_LENGTH = 1024 * 1024;
 	public static final String PATH = "/external-link/";
-	public static final String magicHTTPEscapeString = "_CHECKED_HTTP_";
+	private static final String magicHTTPEscapeString = "_CHECKED_HTTP_";
 
 	private final Node node;
 	private final NodeClientCore core;

--- a/test/freenet/client/filter/ContentFilterTest.java
+++ b/test/freenet/client/filter/ContentFilterTest.java
@@ -140,7 +140,7 @@ public class ContentFilterTest extends TestCase {
 		assertEquals(INTERNAL_RELATIVE_LINK, HTMLFilter(INTERNAL_ABSOLUTE_LINK));
 		// are external links stripped out ?
 		assertTrue(HTMLFilter(EXTERNAL_LINK_CHECK1).startsWith(EXTERNAL_LINK_OK));
-		assertTrue(HTMLFilter(EXTERNAL_LINK_CHECK2).contains(ExternalLinkToadlet.magicHTTPEscapeString));
+		assertTrue(HTMLFilter(EXTERNAL_LINK_CHECK2).contains(ExternalLinkToadlet.PATH));
 		assertTrue(HTMLFilter(EXTERNAL_LINK_CHECK3).startsWith(EXTERNAL_LINK_OK));
 
 		// regression testing
@@ -159,7 +159,7 @@ public class ContentFilterTest extends TestCase {
 		// bug #2451
 		assertEquals(POUNT_CHARACTER_ENCODING_TEST_RESULT, HTMLFilter(POUNT_CHARACTER_ENCODING_TEST));
 		// bug #2297
-		assertTrue(HTMLFilter(PREVENT_FPROXY_ACCESS).contains(ExternalLinkToadlet.magicHTTPEscapeString));
+		assertTrue(HTMLFilter(PREVENT_FPROXY_ACCESS).contains(ExternalLinkToadlet.PATH));
 		// bug #2921
 		assertTrue(HTMLFilter(PREVENT_EXTERNAL_ACCESS_CSS_SIMPLE).contains("div { }"));
 		assertTrue(HTMLFilter(PREVENT_EXTERNAL_ACCESS_CSS_ESCAPE).contains("div { }"));
@@ -213,7 +213,7 @@ public class ContentFilterTest extends TestCase {
 	private static final String META_BOGUS_REDIRECT6 = "<meta http-equiv=\"refresh\" content=\"30; /KSK@gpl.txt\">";
 	private static final String META_BOGUS_REDIRECT1_OUT = "<!-- Malformed URL (relative): There is no @ in that URI! ()-->";
 	private static final String META_BOGUS_REDIRECT2_OUT = "<!-- Malformed URL (relative): There is no @ in that URI! (plugins)-->";
-	private static final String META_BOGUS_REDIRECT3_OUT = "<meta http-equiv=\"refresh\" content=\"30; url=/?_CHECKED_HTTP_=http://www.google.com\">";
+	private static final String META_BOGUS_REDIRECT3_OUT = "<meta http-equiv=\"refresh\" content=\"30; url=/external-link/?_CHECKED_HTTP_=http://www.google.com\">";
 	private static final String META_BOGUS_REDIRECT4_OUT = "<!-- Deleted invalid or dangerous URI-->";
 	private static final String META_BOGUS_REDIRECT5_OUT = "<!-- Malformed URL (relative): Invalid key type: \"/KSK-->";
 	private static final String META_BOGUS_REDIRECT_NO_URL = "<!-- no url but doesn't parse as number in meta refresh -->";


### PR DESCRIPTION
The external link test now passes again. Please let me know if I changed the tests in a reasonable way; I'm not well-versed in tests yet. This also makes the magic escaping string private.
