### PR TITLE
Backwards compatibility for escaped URLs.

### DIFF
--- a/src/freenet/clients/http/WelcomeToadlet.java
+++ b/src/freenet/clients/http/WelcomeToadlet.java
@@ -134,7 +134,7 @@ public class WelcomeToadlet extends Toadlet {
             writeHTMLReply(ctx, 200, "OK", pageNode.generate());
             Logger.normal(this, "Node is updating/restarting");
             node.getNodeUpdater().arm();
-        } else if (request.getPartAsString("update", 32).length() > 0) {
+        } else if (request.getPartAsStringFailsafe("update", 32).length() > 0) {
         	PageNode page = ctx.getPageMaker().getPageNode(l10n("nodeUpdateConfirmTitle"), ctx);
             HTMLNode pageNode = page.outer;
             HTMLNode contentNode = page.content;
@@ -144,7 +144,7 @@ public class WelcomeToadlet extends Toadlet {
             updateForm.addChild("input", new String[]{"type", "name", "value"}, new String[]{"submit", "cancel", NodeL10n.getBase().getString("Toadlet.cancel")});
             updateForm.addChild("input", new String[]{"type", "name", "value"}, new String[]{"submit", "updateconfirm", l10n("update")});
             writeHTMLReply(ctx, 200, "OK", pageNode.generate());
-        } else if (request.isPartSet("getThreadDump")) {
+	} else if (request.isPartSet("getThreadDump")) {
             if (noPassword) {
                 redirectToRoot(ctx);
                 return;
@@ -392,7 +392,11 @@ public class WelcomeToadlet extends Toadlet {
 
                 this.writeHTMLReply(ctx, 200, "OK", pageNode.generate());
                 return;
-            }
+        } else if (uri.getQuery() != null && uri.getQuery().contains("_CHECKED_HTTP_=")) {
+		//Redirect requests for escaped URLs using the old destination to ExternalLinkToadlet.
+		super.writeTemporaryRedirect(ctx, "Depreciated", ExternalLinkToadlet.PATH+'?'+uri.getQuery());
+		return;
+        }
         }
 
         PageNode page = ctx.getPageMaker().getPageNode(l10n("homepageFullTitleWithName", "name", node.getMyName()), ctx);


### PR DESCRIPTION
This should redirect requests for link confirmation from / to /external-link/ so that plugins don't have to change.
