### PR TITLE
Detect html5 charset

### DIFF
--- a/src/freenet/client/filter/HTMLFilter.java
+++ b/src/freenet/client/filter/HTMLFilter.java
@@ -2370,7 +2370,7 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
 			/* try HTML5 meta charset declaration. */
 			String charset = getHashString(h, "charset");
 			if (charset != null) {
-				if (pc.detectedCharset != null) {
+				if ((pc.detectedCharset != null) && !charset.equals(pc.detectedCharset)) {
 					throwFilterException(l10n("multipleCharsetsInMeta"));
 				}
 				pc.detectedCharset = charset;


### PR DESCRIPTION
This allows the HTML5 <meta charset> declaration to be parsed by Freenet’s HTML filter. Because it is valid to specify both charset and content type (using “http-equiv”) the content type parsed from the charset attribute will be accepted if either no charset has been previously detected or it matches the previously detected charset.
