### PR TITLE
Don’t return stopping plugins when looking for an FCP plugin.

### DIFF
--- a/src/freenet/pluginmanager/PluginManager.java
+++ b/src/freenet/pluginmanager/PluginManager.java
@@ -893,7 +893,7 @@ public class PluginManager {
 		synchronized(pluginWrappers) {
 			for(int i = 0; i < pluginWrappers.size(); i++) {
 				PluginInfoWrapper pi = pluginWrappers.get(i);
-				if(pi.isFCPPlugin() && pi.getPluginClassName().equals(plugname))
+				if(pi.isFCPPlugin() && pi.getPluginClassName().equals(plugname) && !pi.isStopping())
 					return (FredPluginFCP) pi.plug;
 			}
 		}


### PR DESCRIPTION
While plugins are stopping it is possible for a plugin to get a reference to another plugin that is already stopping and not responding anymore. (In the concrete case, this prevents the node from shutting down because Sone waits for a reply from WoT which will never come because WoT has already stopped.)
