### PR TITLE
Don’t show empty groups in simple mode.

### DIFF
--- a/src/freenet/clients/http/PproxyToadlet.java
+++ b/src/freenet/clients/http/PproxyToadlet.java
@@ -384,7 +384,7 @@ public class PproxyToadlet extends Toadlet {
 				/* sort available plugins into groups. */
 				SortedMap<String, List<OfficialPluginDescription>> groupedAvailablePlugins = new TreeMap<String, List<OfficialPluginDescription>>();
 				for (OfficialPluginDescription pluginDescription : availablePlugins) {
-					if (advancedModeEnabled && (pluginDescription.advanced || pluginDescription.experimental || pluginDescription.deprecated)) {
+					if (!advancedModeEnabled && (pluginDescription.advanced || pluginDescription.experimental || pluginDescription.deprecated)) {
 						continue;
 					}
 					String translatedGroup = l10n("pluginGroup." + pluginDescription.group);


### PR DESCRIPTION
In simple mode some plugins are not shown, causing empty groups to appear. That does not look good.
