### PR TITLE
Disallow 1.0 as a target location. Should be [0, 1).

### DIFF
--- a/src/freenet/node/ProbeRequestSender.java
+++ b/src/freenet/node/ProbeRequestSender.java
@@ -73,7 +73,7 @@ public class ProbeRequestSender implements PrioRunnable, ByteCounter {
         this.uniqueCounter = 1;
         logMINOR = Logger.shouldLog(LogLevel.MINOR, this);
     	updateBest();
-    	if(target < 0.0 || target > 1.0)
+    	if(target < 0.0 || target >= 1.0)
     		throw new IllegalArgumentException();
     }
 


### PR DESCRIPTION
The probe code seems to regard 1.0 as a valid target, which according to the wiki's [definition of location](http://new-wiki.freenetproject.org/Location) it is not.
