### PR TITLE
Throw descriptive error when nonexistent field set.

### DIFF
--- a/src/freenet/io/comm/MessageType.java
+++ b/src/freenet/io/comm/MessageType.java
@@ -83,6 +83,10 @@ public class MessageType {
 			return false;
 		}
 		Class<?> defClass = _fields.get(fieldName);
+		if (defClass == null) {
+			throw new IllegalStateException("Cannot set field \"" + fieldName + "\" which is not defined" +
+			                                " in the message type \"" + getName() + "\".");
+		}
 		Class<?> valueClass = fieldValue.getClass();
 		if(defClass == valueClass) return true;
 		if(defClass.isAssignableFrom(valueClass)) return true;


### PR DESCRIPTION
Without this set()ing a field which does not exist in that MessageType
results in an NPE. This is a programming error, so make lots of noise
about it.
