### PR TITLE
Allow IPv6 scope identifier. This was not being recognised.

### DIFF
--- a/src/freenet/io/AddressIdentifier.java
+++ b/src/freenet/io/AddressIdentifier.java
@@ -61,7 +61,7 @@ public class AddressIdentifier {
 	 *         otherwise
 	 */
 	public static AddressType getAddressType(String address) {
-		return AddressIdentifier.getAddressType(address,false);
+		return AddressIdentifier.getAddressType(address,true);
 	}
 
 	/**


### PR DESCRIPTION
Hence we would have hostName of a freenetInetAddress set, instead of the IPv6.

For e.g. if the NAT returned 2001:0db8:85a3:0000:0000:8a2e:0370:7334%3
then the INET wouldn't be constructed in this case. Instead the FreenetInetAddress would be constructed as type OTHER, with String hostName = address.
