### PR TITLE
Fix compress setting in simple mode insert wizard

### DIFF
--- a/src/freenet/clients/http/FileInsertWizardToadlet.java
+++ b/src/freenet/clients/http/FileInsertWizardToadlet.java
@@ -125,8 +125,8 @@ public class FileInsertWizardToadlet extends Toadlet implements LinkEnabledCallb
 			        NodeL10n.getBase().getString("QueueToadlet.insertFileCompressLabel"));
 		} else {
 			insertForm.addChild("input",
-			        new String[] { "type", "value" },
-			        new String[] { "hidden", "true" });
+			        new String[] { "type", "name", "value" },
+			        new String[] { "hidden", "compress", "true" });
 		}
 		if(isAdvancedModeEnabled) {
 			insertForm.addChild("br");


### PR DESCRIPTION
Patch courtesy of Eleriseth Eleriseth@WPECGLtYbVi8Rl6Y7Vzl2Lvd2EUVW99v3yNV3IWROG8.fms:

Simple mode inserts ended up as uncompressed due to missing hidden field
name.
