### PR TITLE
req can be null in rare instances of database poisoning by floghelper...

### DIFF
--- a/src/freenet/node/fcp/FCPClient.java
+++ b/src/freenet/node/fcp/FCPClient.java
@@ -393,7 +393,7 @@ public class FCPClient {
 			while(i.hasNext()) {
 				ClientRequest req = i.next();
 				if(container != null) container.activate(req, 1);
-				if(req.isPersistentForever() || !onlyForever)
+				if((req != null && req.isPersistentForever()) || !onlyForever)
 					v.add(req);
 			}
 			if(container != null) {


### PR DESCRIPTION
..., adding a check here allows startup.

TODO: figure out how floghelper manages to mess up node.db4o in the first place.
