### PR TITLE
Use URIs to generate welcome page redirect target.

### DIFF
--- a/src/freenet/clients/http/FProxyToadlet.java
+++ b/src/freenet/clients/http/FProxyToadlet.java
@@ -511,6 +511,7 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
 				 */
 				Logger.error(FProxyToadlet.class, "Unexpected syntax error in URI: " + e);
 				writeTemporaryRedirect(ctx, "Internal error. Please check logs and report.", WelcomeToadlet.PATH);
+				return;
 			}
 		}else if(ks.equals("/favicon.ico")){
 			byte[] buf = new byte[1024];


### PR DESCRIPTION
This caused requests like `http://localhost:8888/?_CHECKED_HTTP_=https://www.wolframalpha.com/input/?i=1%2F(x%2Bsqrt(1-x%5E2))` to be parsed as Freenet keys because they caused an unhandled
URISyntaxException.
