### PR TITLE
Fix startup for db4o 8.0

### DIFF
--- a/src/freenet/node/NodeCrypto.java
+++ b/src/freenet/node/NodeCrypto.java
@@ -616,16 +616,23 @@ public class NodeCrypto {
 		} else {
 			while(true) {
 				handle = random.nextLong();
-				HandlePortTuple tuple = new HandlePortTuple();
-				tuple.handle = handle;
-				// Double-check with QBE, just in case the RNG is broken (similar things have happened before!)
-				ObjectSet os = setupContainer.get(tuple);
+				final HandlePortTuple newTuple = new HandlePortTuple();
+				newTuple.handle = handle;
+				// Double-check just in case the RNG is broken (similar things have happened before!)
+				ObjectSet<HandlePortTuple> os = setupContainer.query(new Predicate<HandlePortTuple>() {
+					private static final long serialVersionUID = 7850460146922879499L;
+
+					@Override
+					public boolean match(HandlePortTuple tuple) {
+						return tuple.handle == newTuple.handle;
+					}
+				});
 				if(os.hasNext()) {
 					System.err.println("Generating database handle for node: already taken: "+handle);
 					continue;
 				}
-				tuple.portNumber = portNumber;
-				setupContainer.store(tuple);
+				newTuple.portNumber = portNumber;
+				setupContainer.store(newTuple);
 				setupContainer.commit();
 				if(logMINOR) Logger.minor(this, "COMMITTED");
 				System.err.println("Generated and stored database handle for node on port "+portNumber+": "+handle);


### PR DESCRIPTION
The node previously wouldn't start up with db4o8.0, this commit fixes it.

The error message was:
NFO   | jvm 1    | 2013/01/03 13:54:42 | WrapperManager Error: Error in WrapperListener.start callback.  java.lang.NoSuchMethodError: com.db4o.ObjectContainer.get(Ljava/lang/Object;)Lcom/db4o/ObjectSet;
INFO   | jvm 1    | 2013/01/03 13:54:42 | WrapperManager Error: java.lang.NoSuchMethodError: com.db4o.ObjectContainer.get(Ljava/lang/Object;)Lcom/db4o/ObjectSet;
INFO   | jvm 1    | 2013/01/03 13:54:42 | WrapperManager Error:         at freenet.node.NodeCrypto.getNodeHandle(NodeCrypto.java:622)
INFO   | jvm 1    | 2013/01/03 13:54:42 | WrapperManager Error:         at freenet.node.Node.<init>(Node.java:1539)
INFO   | jvm 1    | 2013/01/03 13:54:42 | WrapperManager Error:         at freenet.node.NodeStarter.start(NodeStarter.java:196)
INFO   | jvm 1    | 2013/01/03 13:54:42 | WrapperManager Error:         at org.tanukisoftware.wrapper.WrapperManager$11.run(WrapperManager.java:2979)
INFO   | jvm 1    | 2013/01/03 13:54:43 | Shutting down...
