### PR TITLE
Junit changes for use with Jenkins

### DIFF
--- a/build-clean.xml
+++ b/build-clean.xml
@@ -302,7 +302,7 @@ maintainers may prefer to use this instead of build.xml.
 	</target>
 
 	<target name="unit" depends="unit-build" unless="${test.skip}">
-		<junit printsummary="yes" fork="yes" haltonfailure="yes" dir="${test.dst}">
+		<junit printsummary="yes" fork="yes" haltonfailure="${test.haltonfailure}" dir="${test.dst}">
 			<classpath refid="libtest.path"/>
 			<formatter type="plain" usefile="false"/>
 			<formatter type="xml" if="${test.xml_output}"/>

--- a/build.properties
+++ b/build.properties
@@ -74,6 +74,7 @@ test.verbose=false
 test.benchmark=false
 test.extensive=false
 test.xml_output=false
+test.haltonfailure=yes
 
 # select a single test to run
 #test.class=


### PR DESCRIPTION
Adds two new properties for controlling the jUnit run. Jenkins can pick up the jUnit results from the XML output if test.xml_output=true and test.haltonfailure=no and a jUnit post-build action is added to Jenkins with TEST-*.xml as the report format.
