### PR TITLE
OSX startup plist

### DIFF
--- a/README
+++ b/README
@@ -49,11 +49,14 @@ http://freenetproject.org/donate.html
 Press enquiries should be directed to Ian Clarke.
 
 ALWAYS ON:
-On OS/X and unix-based systems, Freenet will create a cron job to run Freenet 
-on startup. On Windows it creates a user for Freenet to run under, and a service 
-to start it. You should run Freenet as close to 24x7 as possible for good 
-performance. It is however possible to remove the cron job (with the remove cron 
-job script in bin/), or to remove the service (from the services panel in Control Panel).
+On OSX, Freenet will create a configuration file at 
+~/Library/LaunchAgents/com.freenet.startup.plist. On other unix-based systems,
+Freenet will create a cron job to run Freenet on startup. On Windows, it creates
+a user for Freenet to run under, and a service to start it. You should run
+Freenet as close to 24x7 as possible for good performance. It is however
+possible to remove the plist, to remove the cron job (with the remove cron job
+script in bin/), or to remove the service (from the services panel in Control
+Panel).
 
 BASIC SECURITY:
 The easiest option is to use the system tray applet to launch Freenet. This will try to


### PR DESCRIPTION
Since Freenet doesn't use a cron job for OSX anymore, I changed the README to point the user to the appropriate file in ~/Library/LaunchAgents
