### PR TITLE
Specify class that could not be found in UI.

### DIFF
--- a/src/freenet/pluginmanager/PluginManager.java
+++ b/src/freenet/pluginmanager/PluginManager.java
@@ -1440,7 +1440,8 @@ public class PluginManager {
 				Logger.error(this, "could not find plugin class", cnfe1);
 				pluginFile.delete();
 				if(!downloaded) continue;
-				throw new PluginNotFoundException("could not find plugin class", cnfe1);
+				throw new PluginNotFoundException(
+					"could not find plugin class: \"" + cnfe1.getMessage() + "\"", cnfe1);
 			} catch(InstantiationException ie1) {
 				Logger.error(this, "could not instantiate plugin", ie1);
 				pluginFile.delete();


### PR DESCRIPTION
It's already in the logs but this could make it more straightforward. This was prompted by confusion over a trailing space after a class name.

Results in something like
`could not find plugin class: "could not find jar entry for class plugins.HelloWorld.HelloWorld "`
