### PR TITLE
Remove finished uploads

### DIFF
--- a/src/freenet/l10n/freenet.l10n.da.properties
+++ b/src/freenet/l10n/freenet.l10n.da.properties
@@ -71,6 +71,7 @@ NodeIPDectector.ipOverride=Overstyring af IP adresse
 NodeIPDectector.ipOverrideLong=IP adresse overstyring (normalt ikke nødvendigt) - sæt kun hvis du har en *statisk* IP adresse eller et domæne navn (f.eks. via dyndns), og du er bag en firewall.
 NodeIPDectector.tempAddressHint=Midlertidigt IP adresse hint
 NodeIPDectector.tempAddressHintLong=Midlertidigt hint om hvad din IP adresse kan være; bliver slettet efter brug
+QueueToadlet.removeFinishedUploads=Fjern færdige uploads
 StatisticsToadlet.allocMemory=Allokeret Java hukommelse: ${memory}
 StatisticsToadlet.bandwidthTitle=Båndbredte
 StatisticsToadlet.cpus=Tilgængelige Processorer: ${count}

--- a/src/freenet/l10n/freenet.l10n.de.properties
+++ b/src/freenet/l10n/freenet.l10n.de.properties
@@ -1597,6 +1597,7 @@ QueueToadlet.recommendToFriends=Freunden empfehlen
 QueueToadlet.remove=Entfernen aus der Liste
 QueueToadlet.removeFilesFromList=LÖSCHEN aus der Liste
 QueueToadlet.removeFinishedDownloads=Fertige Downloads entfernen
+QueueToadlet.removeFinishedUploads=Fertige uploads entfernen
 QueueToadlet.requestNavigation=Anfragen - Menü und Überblick
 QueueToadlet.restart=Neustart
 QueueToadlet.restartDownloads=Neustart von Downloads

--- a/src/freenet/l10n/freenet.l10n.en.properties
+++ b/src/freenet/l10n/freenet.l10n.en.properties
@@ -1580,6 +1580,7 @@ QueueToadlet.reason=Reason
 QueueToadlet.remove=Remove from list
 QueueToadlet.removeFilesFromList=Remove files from list
 QueueToadlet.removeFinishedDownloads=Remove finished Downloads
+QueueToadlet.removeFinishedUploads=Remove finished uploads
 QueueToadlet.requestNavigation=Request Navigation and Totals
 QueueToadlet.restart=Restart
 QueueToadlet.restartDownloads=Restart downloads

--- a/src/freenet/l10n/freenet.l10n.es.properties
+++ b/src/freenet/l10n/freenet.l10n.es.properties
@@ -1320,6 +1320,7 @@ QueueToadlet.recommendToFriends=Recomendar a amigos
 QueueToadlet.remove=Eliminar
 QueueToadlet.removeFilesFromList=Eliminar archivos de la lista
 QueueToadlet.removeFinishedDownloads=Eliminar descargas finalizadas
+QueueToadlet.removeFinishedUploads=Eliminar archivos terminados
 QueueToadlet.requestNavigation=Navegación de la petición
 QueueToadlet.restart=Reiniciar
 QueueToadlet.restartDownloads=Reiniciar descargas

--- a/src/freenet/l10n/freenet.l10n.fi.properties
+++ b/src/freenet/l10n/freenet.l10n.fi.properties
@@ -694,6 +694,7 @@ QueueToadlet.priority6=ei tule valmistumaan
 QueueToadlet.progress=Edistyminen
 QueueToadlet.reason=Syy
 QueueToadlet.remove=Poista
+QueueToadlet.removeFinishedUploads=Poista valmiit kuvat
 QueueToadlet.requestNavigation=Pyyntövalikko
 QueueToadlet.restart=Uudelleenkäynnistä
 QueueToadlet.size=Koko

--- a/src/freenet/l10n/freenet.l10n.fr.properties
+++ b/src/freenet/l10n/freenet.l10n.fr.properties
@@ -1338,6 +1338,7 @@ QueueToadlet.recommendToFriends=Recommander aux amis
 QueueToadlet.remove=Supprimer
 QueueToadlet.removeFilesFromList=Supprimer les fichiers de la liste
 QueueToadlet.removeFinishedDownloads=Enlever les téléchargements terminés
+QueueToadlet.removeFinishedUploads=Retirer ajouts finis
 QueueToadlet.requestNavigation=Parcours des requètes
 QueueToadlet.restart=Redémarrer
 QueueToadlet.restartDownloads=Redémarrer les téléchargements

--- a/src/freenet/l10n/freenet.l10n.it.properties
+++ b/src/freenet/l10n/freenet.l10n.it.properties
@@ -1413,6 +1413,7 @@ QueueToadlet.recommendFilesToFriends=Raccomanda dei file agli amici
 QueueToadlet.recommendToFriends=Raccomanda ad amici
 QueueToadlet.remove=Elimina
 QueueToadlet.removeFilesFromList=Elimina i file dall'elenco
+QueueToadlet.removeFinishedUploads=Rimuovere arrivi finiti
 QueueToadlet.requestNavigation=Esplora Richieste
 QueueToadlet.restart=Riavvia
 QueueToadlet.restartDownloads=Riavvia i download

--- a/src/freenet/l10n/freenet.l10n.ja.properties
+++ b/src/freenet/l10n/freenet.l10n.ja.properties
@@ -781,6 +781,7 @@ QueueToadlet.priority5=低低
 QueueToadlet.priority6=一時停止中
 QueueToadlet.reason=理由
 QueueToadlet.removeFinishedDownloads=完了したダウンロードを消去する
+QueueToadlet.removeFinishedUploads=完成したアップロードを削除
 QueueToadlet.siteUploadSucceeded=あなたのFreeSite: ${filename} (${files} ファイル, ${size} 総容量) はFreenetにうまくアップロードされました。 ${link}ここ${/link}をクリックするとサイトのホームページへ移動します。
 SSL.enable=SSLサポートを有効にしますか?
 SSL.enableLong=SSLサポートを有効にしますか?

--- a/src/freenet/l10n/freenet.l10n.nl.properties
+++ b/src/freenet/l10n/freenet.l10n.nl.properties
@@ -1445,6 +1445,7 @@ QueueToadlet.recommendToFriends=Aanbevelen aan Vrienden
 QueueToadlet.remove=Verwijderen uit lijst
 QueueToadlet.removeFilesFromList=Verwijder bestanden uit overzicht
 QueueToadlet.removeFinishedDownloads=Verwijder voltooide downloads
+QueueToadlet.removeFinishedUploads=Verwijder voltooide uploads
 QueueToadlet.requestNavigation=Navigatie door verzoeken en totalen
 QueueToadlet.restart=Opnieuw starten
 QueueToadlet.restartDownloads=Herstart downloads

--- a/src/freenet/l10n/freenet.l10n.no.properties
+++ b/src/freenet/l10n/freenet.l10n.no.properties
@@ -582,6 +582,7 @@ QueueToadlet.progress=Fremgang
 QueueToadlet.progressbarAccurate=Denne fremgangsverdien er nøyaktig
 QueueToadlet.reason=Grunn
 QueueToadlet.remove=Fjern
+QueueToadlet.removeFinishedUploads=Fjern ferdige opplastninger
 QueueToadlet.restart=Start på nytt
 QueueToadlet.size=Størrelse
 QueueToadlet.starting=STARTER

--- a/src/freenet/l10n/freenet.l10n.pl.properties
+++ b/src/freenet/l10n/freenet.l10n.pl.properties
@@ -182,6 +182,7 @@ QueueToadlet.reason=Powód
 QueueToadlet.recommendFilesToFriends=Zaproponuj plik przyjacielowi
 QueueToadlet.removeFilesFromList=Usuń pliki z listy
 QueueToadlet.removeFinishedDownloads=Usuń zakończone pobierania
+QueueToadlet.removeFinishedUploads=Usuń gotowych dodane
 QueueToadlet.titleUploads=Wysyłania
 QueueToadlet.totalQueuedDownloads=Całkowita kolejka pobierań: ${size}
 QueueToadlet.totalQueuedUploads=Całkowita kolejka wysyłania: ${size}

--- a/src/freenet/l10n/freenet.l10n.ru.properties
+++ b/src/freenet/l10n/freenet.l10n.ru.properties
@@ -1601,6 +1601,7 @@ QueueToadlet.recommendToFriends=Предложить файл друзьям
 QueueToadlet.remove=Удалить из списка
 QueueToadlet.removeFilesFromList=Убрать файлы из списка
 QueueToadlet.removeFinishedDownloads=Убрать завершенные загрузки
+QueueToadlet.removeFinishedUploads=Удалить готовой добавления
 QueueToadlet.requestNavigation=Статистика
 QueueToadlet.restart=Перезапуск
 QueueToadlet.restartDownloads=Перезапустить

--- a/src/freenet/l10n/freenet.l10n.se.properties
+++ b/src/freenet/l10n/freenet.l10n.se.properties
@@ -814,6 +814,7 @@ QueueToadlet.recommendDescription=Beskrivning av filen:
 QueueToadlet.recommendToFriends=Rekommendera till vänner
 QueueToadlet.remove=Ta bort
 QueueToadlet.removeFilesFromList=Ta bort filer från listan
+QueueToadlet.removeFinishedUploads=Ta bort färdiga uppladdningar
 QueueToadlet.requestNavigation=Navigation
 QueueToadlet.restart=Omstart
 QueueToadlet.returnToQueuePage=Återvänd till ${link}kösidan${/link}.

--- a/src/freenet/l10n/freenet.l10n.zh-cn.properties
+++ b/src/freenet/l10n/freenet.l10n.zh-cn.properties
@@ -1319,6 +1319,7 @@ QueueToadlet.recommendFilesToFriends=向好友推荐文件
 QueueToadlet.recommendToFriends=推荐给好友
 QueueToadlet.remove=从列表中移除
 QueueToadlet.removeFilesFromList=从列表中移除文件
+QueueToadlet.removeFinishedUploads=删除成品上传
 QueueToadlet.requestNavigation=统计摘要
 QueueToadlet.restart=重新开始
 QueueToadlet.restartDownloads=重新开始下载

--- a/src/freenet/l10n/freenet.l10n.zh-tw.properties
+++ b/src/freenet/l10n/freenet.l10n.zh-tw.properties
@@ -1043,6 +1043,7 @@ QueueToadlet.recommend=推薦
 QueueToadlet.recommendAFileToFriends=推薦檔案給朋友
 QueueToadlet.recommendToFriends=推薦給朋友
 QueueToadlet.remove=移除
+QueueToadlet.removeFinishedUploads=刪除成品上傳
 QueueToadlet.requestNavigation=需求總覽
 QueueToadlet.restart=重啟
 QueueToadlet.siteUploadSucceeded=你的 freesite ${filename} (${files} 個檔案, 總計大小為 ${size}) 已經成功上傳至 Freenet 了. ${link}按這裡${/link}來開啟該網站首頁.


### PR DESCRIPTION
Added a button to remove all finished uploads from the upload pane in
one go as a fix to the bug
https://bugs.freenetproject.org/view.php?id=1969

e.g. 2 finished uploads and one upload in progress

![1](https://f.cloud.github.com/assets/4464019/521490/882e36be-bfab-11e2-8ecc-315370657941.png)

After clicking on the button, the finished uploads are removed from list while not affecting upload in progress
![2](https://f.cloud.github.com/assets/4464019/521491/8a07417e-bfab-11e2-8e52-2ad9ae87953b.png)
