### PR TITLE
MergeSFS: default write changes; add --sdout, help

### DIFF
--- a/src/freenet/tools/MergeSFS.java
+++ b/src/freenet/tools/MergeSFS.java
@@ -2,7 +2,9 @@ package freenet.tools;
 
 import java.io.BufferedWriter;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 
@@ -15,14 +17,27 @@ public class MergeSFS {
 	 * @throws IOException 
 	 */
 	public static void main(String[] args) throws IOException {
+		if (args.length < 2 || args.length > 3) {
+			System.out.println("Merges changes made in a SFS override file to a SFS source file.");
+			System.out.println("Usage: source-file override-file [--stdout]");
+			System.out.println("    By default the merged file is written to source-file.");
+			System.out.println("    --stdout writes to standard output instead.");
+			return;
+		}
 		File f1 = new File(args[0]);
 		File f2 = new File(args[1]);
+		final OutputStream os;
+		if (args.length == 3 && args[2].equals("--stdout")) {
+			os = System.out;
+		} else {
+			os = new FileOutputStream(f1);
+		}
 		SimpleFieldSet fs1 = SimpleFieldSet.readFrom(f1, false, true);
 		SimpleFieldSet fs2 = SimpleFieldSet.readFrom(f2, false, true);
 		fs1.putAllOverwrite(fs2);
 		// Force output to UTF-8. A PrintStream is still an OutputStream.
 		// These files are always UTF-8, and stdout is likely to be redirected into one.
-		Writer w = new BufferedWriter(new OutputStreamWriter(System.out, "UTF-8"));
+		Writer w = new BufferedWriter(new OutputStreamWriter(os, "UTF-8"));
 		fs1.writeToOrdered(w);
 		w.flush();
 	}


### PR DESCRIPTION
Writing changes to the source file avoids the potentially awkward
MergeSFS source override > temp; cp temp source.
