### PR TITLE
Use TimeUnit constants instead of calculating milliseconds.

### DIFF
--- a/src/freenet/client/async/BackgroundBlockEncoder.java
+++ b/src/freenet/client/async/BackgroundBlockEncoder.java
@@ -1,5 +1,7 @@
 package freenet.client.async;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import java.lang.ref.SoftReference;
 import java.util.ArrayList;
 
@@ -90,7 +92,7 @@ public class BackgroundBlockEncoder implements PrioRunnable {
 			synchronized(this) {
 				while(queue.isEmpty()) {
 					try {
-						wait(100*1000);
+						wait(SECONDS.toMillis(100));
 					} catch (InterruptedException e) {
 						// Ignore
 					}

--- a/src/freenet/client/async/ClientRequestScheduler.java
+++ b/src/freenet/client/async/ClientRequestScheduler.java
@@ -3,6 +3,8 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.client.async;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -434,7 +436,7 @@ public class ClientRequestScheduler implements RequestScheduler {
 	 * the above limit. So we have a higher limit before we complain that 
 	 * something odd is happening.. (e.g. leaking PersistentChosenRequest's). */
 	static final int WARNING_STARTER_QUEUE_SIZE = 800;
-	private static final long WAIT_AFTER_NOTHING_TO_START = 60*1000;
+	private static final long WAIT_AFTER_NOTHING_TO_START = SECONDS.toMillis(60);
 	
 	private final transient LinkedList<PersistentChosenRequest> starterQueue = new LinkedList<PersistentChosenRequest>();
 	

--- a/src/freenet/client/async/ClientRequestSchedulerCore.java
+++ b/src/freenet/client/async/ClientRequestSchedulerCore.java
@@ -3,6 +3,7 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.client.async;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
 import com.db4o.ObjectContainer;
 import com.db4o.ObjectSet;
 import com.db4o.query.Predicate;
@@ -234,7 +235,7 @@ class ClientRequestSchedulerCore extends ClientRequestSchedulerBase {
 					return false;
 				}
 			}
-			long deadline = System.currentTimeMillis() + 10*1000;
+			long deadline = System.currentTimeMillis() + SECONDS.toMillis(10);
 			if(registerMeSet == null) {
 				Logger.error(this, "registerMeSet is null for "+ClientRequestSchedulerCore.this+" ( "+this+" )");
 				return false;

--- a/src/freenet/client/async/ClientRequester.java
+++ b/src/freenet/client/async/ClientRequester.java
@@ -3,6 +3,7 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.client.async;
 
+import static java.util.concurrent.TimeUnit.MINUTES;
 import java.util.WeakHashMap;
 
 import org.tanukisoftware.wrapper.WrapperManager;
@@ -439,7 +440,7 @@ public abstract class ClientRequester {
 					if(!req.checkForBrokenClient(container, clientContext))
 						if(logMINOR) Logger.minor(req, "Request is clean.");
 					else {
-						WrapperManager.signalStarting(5*60*1000);
+						WrapperManager.signalStarting((int) MINUTES.toMillis(5));
 						container.commit();
 					}
 				}

--- a/src/freenet/client/async/CooldownTracker.java
+++ b/src/freenet/client/async/CooldownTracker.java
@@ -1,5 +1,7 @@
 package freenet.client.async;
 
+import static java.util.concurrent.TimeUnit.MINUTES;
+
 import java.lang.ref.WeakReference;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -308,7 +310,7 @@ public class CooldownTracker {
 		if(logMINOR) Logger.minor(this, "Removed "+removedPersistent+" persistent cooldown cache items and "+removedTransient+" transient cooldown cache items");
 	}
 	
-	private static final long MAINTENANCE_PERIOD = 10*60*1000;
+	private static final long MAINTENANCE_PERIOD = MINUTES.toMillis(10);
 	
 	public void startMaintenance(final Ticker ticker) {
 		ticker.queueTimedJob(new Runnable() {

--- a/src/freenet/client/async/DatastoreChecker.java
+++ b/src/freenet/client/async/DatastoreChecker.java
@@ -1,5 +1,7 @@
 package freenet.client.async;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Random;
@@ -412,7 +414,7 @@ public class DatastoreChecker implements PrioRunnable {
 				waited = true;
 				try {
 					// Wait for anything.
-					wait(100*1000);
+					wait(SECONDS.toMillis(100));
 				} catch (InterruptedException e) {
 					// Ok
 				}

--- a/src/freenet/client/async/SplitFileFetcherKeyListener.java
+++ b/src/freenet/client/async/SplitFileFetcherKeyListener.java
@@ -1,5 +1,7 @@
 package freenet.client.async;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import java.io.DataInputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -65,7 +67,7 @@ public class SplitFileFetcherKeyListener implements KeyListener {
 	 * The filter is only ever subtracted from, so if we crash we just have a
 	 * few more false positives. On a fast node with slow disk, writing on every 
 	 * completed block could become a major bottleneck. */
-	private static final int WRITE_DELAY = 60*1000;
+	private static final long WRITE_DELAY = SECONDS.toMillis(60);
 	private short prio;
 	/** Used only if we reach the per-segment bloom filters. The overall bloom
 	 * filters use the global salt. */

--- a/src/freenet/client/async/USKFetcher.java
+++ b/src/freenet/client/async/USKFetcher.java
@@ -3,6 +3,9 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.client.async;
 
+import static java.util.concurrent.TimeUnit.HOURS;
+import static java.util.concurrent.TimeUnit.MINUTES;
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PipedInputStream;
@@ -493,10 +496,10 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
 
 	final long origMinFailures;
 	boolean firstLoop;
-	
-	static final int origSleepTime = 30 * 60 * 1000;
-	static final int maxSleepTime = 24 * 60 * 60 * 1000;
-	int sleepTime = origSleepTime;
+
+	static final long origSleepTime = MINUTES.toMillis(30);
+	static final long maxSleepTime = HOURS.toMillis(24);
+	long sleepTime = origSleepTime;
 
 	private long valueAtSchedule;
 	
@@ -716,10 +719,10 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
 				started = false; // don't finish before have rescheduled
                 
                 //Find out when we should check next ('end'), in an increasing delay (unless we make progress).
-                int newSleepTime = sleepTime * 2;
+                long newSleepTime = sleepTime * 2;
 				if(newSleepTime > maxSleepTime) newSleepTime = maxSleepTime;
 				sleepTime = newSleepTime;
-				end = now + context.random.nextInt(sleepTime);
+				end = now + context.random.nextInt((int) sleepTime);
 
 				if(valAtEnd > valueAtSchedule && valAtEnd > origUSK.suggestedEdition) {
 					// We have advanced; keep trying as if we just started.

--- a/src/freenet/client/async/USKManager.java
+++ b/src/freenet/client/async/USKManager.java
@@ -3,6 +3,8 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.client.async;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import java.net.MalformedURLException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -384,7 +386,7 @@ public class USKManager {
 		}
 	}
 	
-	static final int PREFETCH_DELAY = 60*1000;
+	static final long PREFETCH_DELAY = SECONDS.toMillis(60);
 	
 	private void schedulePrefetchChecker() {
 		context.ticker.queueTimedJob(prefetchChecker, "Check for USKs to prefetch", PREFETCH_DELAY, false, true);

--- a/src/freenet/clients/http/ConnectionsToadlet.java
+++ b/src/freenet/clients/http/ConnectionsToadlet.java
@@ -1,5 +1,9 @@
 package freenet.clients.http;
 
+import static java.util.concurrent.TimeUnit.HOURS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.StringWriter;
@@ -254,13 +258,13 @@ public abstract class ConnectionsToadlet extends Toadlet {
 			if(advancedMode) {
 
 				/* node status values */
-				long nodeUptimeSeconds = (now - node.startupTime) / 1000;
+				long nodeUptimeSeconds = SECONDS.convert(now - node.startupTime, MILLISECONDS);
 				int bwlimitDelayTime = (int) stats.getBwlimitDelayTime();
 				int nodeAveragePingTime = (int) stats.getNodeAveragePingTime();
 				int networkSizeEstimateSession = stats.getDarknetSizeEstimate(-1);
 				int networkSizeEstimateRecent = 0;
-				if(nodeUptimeSeconds > (48*60*60)) {  // 48 hours
-					networkSizeEstimateRecent = stats.getDarknetSizeEstimate(now - (48*60*60*1000));  // 48 hours
+				if(nodeUptimeSeconds > HOURS.toSeconds(48)) {
+					networkSizeEstimateRecent = stats.getDarknetSizeEstimate(now - HOURS.toMillis(48));
 				}
 				DecimalFormat fix4 = new DecimalFormat("0.0000");
 				double routingMissDistanceLocal =  stats.routingMissDistanceLocal.currentValue();
@@ -269,8 +273,8 @@ public abstract class ConnectionsToadlet extends Toadlet {
 				double routingMissDistanceBulk =  stats.routingMissDistanceBulk.currentValue();
 				double routingMissDistanceRT =  stats.routingMissDistanceRT.currentValue();
 				double backedOffPercent =  stats.backedOffPercent.currentValue();
-				String nodeUptimeString = TimeUtil.formatTime(nodeUptimeSeconds * 1000);  // *1000 to convert to milliseconds
-				
+				String nodeUptimeString = TimeUtil.formatTime(MILLISECONDS.convert(nodeUptimeSeconds, SECONDS));
+
 				// BEGIN OVERVIEW TABLE
 				HTMLNode overviewTable = contentNode.addChild("table", "class", "column");
 				HTMLNode overviewTableRow = overviewTable.addChild("tr");
@@ -283,7 +287,7 @@ public abstract class ConnectionsToadlet extends Toadlet {
 				overviewList.addChild("li", "bwlimitDelayTime:\u00a0" + bwlimitDelayTime + "ms");
 				overviewList.addChild("li", "nodeAveragePingTime:\u00a0" + nodeAveragePingTime + "ms");
 				overviewList.addChild("li", "darknetSizeEstimateSession:\u00a0" + networkSizeEstimateSession + "\u00a0nodes");
-				if(nodeUptimeSeconds > (48*60*60)) {  // 48 hours
+				if(nodeUptimeSeconds > HOURS.toSeconds(48)) {
 					overviewList.addChild("li", "darknetSizeEstimateRecent:\u00a0" + networkSizeEstimateRecent + "\u00a0nodes");
 				}
 				overviewList.addChild("li", "nodeUptime:\u00a0" + nodeUptimeString);

--- a/src/freenet/clients/http/FProxyFetchInProgress.java
+++ b/src/freenet/clients/http/FProxyFetchInProgress.java
@@ -1,5 +1,7 @@
 package freenet.clients.http;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -429,7 +431,7 @@ public class FProxyFetchInProgress implements ClientEventListener, ClientGetCall
 	}
 
 	/** Keep for 30 seconds after last access */
-	static final int LIFETIME = 30 * 1000;
+	static final long LIFETIME = SECONDS.toMillis(30);
 	
 	/** Caller should take the lock on FProxyToadlet.fetchers, then call this 
 	 * function, if it returns true then finish the cancel outside the lock.

--- a/src/freenet/clients/http/FProxyToadlet.java
+++ b/src/freenet/clients/http/FProxyToadlet.java
@@ -1,5 +1,8 @@
 package freenet.clients.http;
 
+import static java.util.concurrent.TimeUnit.HOURS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.IOException;
@@ -84,7 +87,7 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
 	}
 
 	// ?force= links become invalid after 2 hours.
-	private static final long FORCE_GRAIN_INTERVAL = 60*60*1000;
+	private static final long FORCE_GRAIN_INTERVAL = HOURS.toMillis(1);
 	/** Maximum size for transparent pass-through, should be a config option */
 	public static long MAX_LENGTH_WITH_PROGRESS = (5*1024*1024 * 11) / 10; // 2MB plus a bit due to buggy inserts
 	public static long MAX_LENGTH_NO_PROGRESS = (2*1024*1024 * 11) / 10; // 2MB plus a bit due to buggy inserts
@@ -660,7 +663,7 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
 						@Override
 						public void run() {
 							for(FreenetURI uri : uris) {
-								client.prefetch(uri, 60*1000, 512*1024, prefetchAllowedTypes);
+								client.prefetch(uri, SECONDS.toMillis(60), 512*1024, prefetchAllowedTypes);
 							}
 						}
 						

--- a/src/freenet/clients/http/PproxyToadlet.java
+++ b/src/freenet/clients/http/PproxyToadlet.java
@@ -1,5 +1,7 @@
 package freenet.clients.http;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import java.io.IOException;
 import java.net.SocketException;
 import java.net.URI;
@@ -38,7 +40,7 @@ import freenet.support.api.HTTPRequest;
 public class PproxyToadlet extends Toadlet {
 	private static final int MAX_PLUGIN_NAME_LENGTH = 1024;
 	/** Maximum time to wait for a threaded plugin to exit */
-	private static final int MAX_THREADED_UNLOAD_WAIT_TIME = 60*1000;
+	private static final long MAX_THREADED_UNLOAD_WAIT_TIME = SECONDS.toMillis(60);
 	private final Node node;
 
         private static volatile boolean logMINOR;

--- a/src/freenet/clients/http/SessionManager.java
+++ b/src/freenet/clients/http/SessionManager.java
@@ -3,6 +3,9 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.clients.http;
 
+import static java.util.concurrent.TimeUnit.HOURS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.text.ParseException;
@@ -52,7 +55,7 @@ public final class SessionManager {
 	/**
 	 * The amount of milliseconds after which a session is deleted due to expiration.
 	 */
-	public static final long MAX_SESSION_IDLE_TIME = 1 * 60 * 60 * 1000;
+	public static final long MAX_SESSION_IDLE_TIME = HOURS.toMillis(1);
 	
 	public static final String SESSION_COOKIE_NAME = "SessionID"; 
 	
@@ -419,7 +422,7 @@ public final class SessionManager {
 			Session session = sessions.nextElement();
 			
 			if(session.getExpirationTime() < previousTime) {
-				long sessionAge = (CurrentTimeUTC.getInMillis() - session.getExpirationTime()) / (60 * 60 * 1000);
+				long sessionAge = HOURS.convert(CurrentTimeUTC.getInMillis() - session.getExpirationTime(), MILLISECONDS);
 				Logger.error(this, "Session LRU queue out of order! Found session which is " + sessionAge + " hour old: " + session); 
 				Logger.error(this, "Deleting all sessions...");
 				

--- a/src/freenet/clients/http/StatisticsToadlet.java
+++ b/src/freenet/clients/http/StatisticsToadlet.java
@@ -1,5 +1,10 @@
 package freenet.clients.http;
 
+import static java.util.concurrent.TimeUnit.DAYS;
+import static java.util.concurrent.TimeUnit.HOURS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import java.io.IOException;
 import java.net.URI;
 import java.text.DecimalFormat;
@@ -908,7 +913,7 @@ public class StatisticsToadlet extends Toadlet {
 		int swapsRejectedRecognizedID = node.getSwapsRejectedRecognizedID();
 		double locChangeSession = node.getLocationChangeSession();
 		int averageSwapTime = node.getAverageOutgoingSwapTime();
-		int sendSwapInterval = node.getSendSwapInterval();
+		long sendSwapInterval = node.getSendSwapInterval();
 
 		HTMLNode locationSwapInfoboxContent = locationSwapInfobox.addChild("div", "class", "infobox-content");
 		HTMLNode locationSwapList = locationSwapInfoboxContent.addChild("ul");
@@ -1260,21 +1265,21 @@ public class StatisticsToadlet extends Toadlet {
 		int darknetSizeEstimateSession = stats.getDarknetSizeEstimate(-1);
 		int darknetSizeEstimate24h = 0;
 		int darknetSizeEstimate48h = 0;
-		if(nodeUptimeSeconds > (24*60*60)) {  // 24 hours
-			darknetSizeEstimate24h = stats.getDarknetSizeEstimate(now - (24*60*60*1000));  // 48 hours
+		if(nodeUptimeSeconds > HOURS.toSeconds(24)) {
+			darknetSizeEstimate24h = stats.getDarknetSizeEstimate(now - HOURS.toMillis(24));
 		}
-		if(nodeUptimeSeconds > (48*60*60)) {  // 48 hours
-			darknetSizeEstimate48h = stats.getDarknetSizeEstimate(now - (48*60*60*1000));  // 48 hours
+		if(nodeUptimeSeconds > HOURS.toSeconds(48)) {
+			darknetSizeEstimate48h = stats.getDarknetSizeEstimate(now - HOURS.toMillis(48));
 		}
 		// Opennet
 		int opennetSizeEstimateSession = stats.getOpennetSizeEstimate(-1);
 		int opennetSizeEstimate24h = 0;
 		int opennetSizeEstimate48h = 0;
-		if (nodeUptimeSeconds > (24 * 60 * 60)) { // 24 hours
-			opennetSizeEstimate24h = stats.getOpennetSizeEstimate(now - (24 * 60 * 60 * 1000)); // 48 hours
+		if (nodeUptimeSeconds > HOURS.toSeconds(24)) {
+			opennetSizeEstimate24h = stats.getOpennetSizeEstimate(now - HOURS.toMillis(24));
 		}
-		if (nodeUptimeSeconds > (48 * 60 * 60)) { // 48 hours
-			opennetSizeEstimate48h = stats.getOpennetSizeEstimate(now - (48 * 60 * 60 * 1000)); // 48 hours
+		if (nodeUptimeSeconds > HOURS.toSeconds(48)) {
+			opennetSizeEstimate48h = stats.getOpennetSizeEstimate(now - HOURS.toMillis(48));
 		}
 		
 		double routingMissDistanceLocal =  stats.routingMissDistanceLocal.currentValue();
@@ -1288,23 +1293,23 @@ public class StatisticsToadlet extends Toadlet {
 		overviewList.addChild("li", "bwlimitDelayTimeRT:\u00a0" + bwlimitDelayTimeRT + "ms");
 		overviewList.addChild("li", "nodeAveragePingTime:\u00a0" + nodeAveragePingTime + "ms");
 		overviewList.addChild("li", "darknetSizeEstimateSession:\u00a0" + darknetSizeEstimateSession + "\u00a0nodes");
-		if(nodeUptimeSeconds > (24*60*60)) {  // 24 hours
+		if(nodeUptimeSeconds > DAYS.toSeconds(1)) {
 			overviewList.addChild("li", "darknetSizeEstimate24h:\u00a0" + darknetSizeEstimate24h + "\u00a0nodes");
 		}
-		if(nodeUptimeSeconds > (48*60*60)) {  // 48 hours
+		if(nodeUptimeSeconds > DAYS.toSeconds(2)) {
 			overviewList.addChild("li", "darknetSizeEstimate48h:\u00a0" + darknetSizeEstimate48h + "\u00a0nodes");
 		}
 		overviewList.addChild("li", "opennetSizeEstimateSession:\u00a0" + opennetSizeEstimateSession + "\u00a0nodes");
-		if (nodeUptimeSeconds > (24 * 60 * 60)) { // 24 hours
+		if (nodeUptimeSeconds > DAYS.toSeconds(1)) {
 			overviewList.addChild("li", "opennetSizeEstimate24h:\u00a0" + opennetSizeEstimate24h + "\u00a0nodes");
 		}
-		if (nodeUptimeSeconds > (48 * 60 * 60)) { // 48 hours
+		if (nodeUptimeSeconds > DAYS.toSeconds(2)) {
 			overviewList.addChild("li", "opennetSizeEstimate48h:\u00a0" + opennetSizeEstimate48h + "\u00a0nodes");
 		}
 		if ((numberOfRemotePeerLocationsSeenInSwaps > 0.0) && ((swaps > 0.0) || (noSwaps > 0.0))) {
 			overviewList.addChild("li", "avrConnPeersPerNode:\u00a0" + fix6p6.format(numberOfRemotePeerLocationsSeenInSwaps/(swaps+noSwaps)) + "\u00a0peers");
 		}
-		overviewList.addChild("li", "nodeUptimeSession:\u00a0" + TimeUtil.formatTime(nodeUptimeSeconds * 1000));
+		overviewList.addChild("li", "nodeUptimeSession:\u00a0" + TimeUtil.formatTime(MILLISECONDS.convert(nodeUptimeSeconds, SECONDS)));
 		overviewList.addChild("li", "nodeUptimeTotal:\u00a0" + TimeUtil.formatTime(nodeUptimeTotal));
 		overviewList.addChild("li", "routingMissDistanceLocal:\u00a0" + fix1p4.format(routingMissDistanceLocal));
 		overviewList.addChild("li", "routingMissDistanceRemote:\u00a0" + fix1p4.format(routingMissDistanceRemote));
@@ -1383,7 +1388,7 @@ public class StatisticsToadlet extends Toadlet {
 	private final static int PEER_CIRCLE_RADIUS = 100;
 	private final static int PEER_CIRCLE_INNER_RADIUS = 60;
 	private final static int PEER_CIRCLE_ADDITIONAL_FREE_SPACE = 10;
-	private final static long MAX_CIRCLE_AGE_THRESHOLD = 24l*60*60*1000;   // 24 hours
+	private final static long MAX_CIRCLE_AGE_THRESHOLD = HOURS.toMillis(24);
 	private final static int HISTOGRAM_LENGTH = 10;
 
 	private void addNodeCircle (HTMLNode circleTable, double myLocation) {

--- a/src/freenet/clients/http/ToadletContextImpl.java
+++ b/src/freenet/clients/http/ToadletContextImpl.java
@@ -1,5 +1,7 @@
 package freenet.clients.http;
 
+import static java.util.concurrent.TimeUnit.DAYS;
+
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -347,7 +349,7 @@ public class ToadletContextImpl implements ToadletContext {
 			expiresTime = "Thu, 01 Jan 1970 00:00:00 GMT";
 		} else {
 			// use an expiry time of 1 day, somewhat arbitrarily
-			expiresTime = TimeUtil.makeHTTPDate(mTime.getTime() + (24 * 60 * 60 * 1000));
+			expiresTime = TimeUtil.makeHTTPDate(mTime.getTime() + DAYS.toMillis(1));
 		}
 		mvt.put("expires", expiresTime);
 		

--- a/src/freenet/clients/http/bookmark/BookmarkManager.java
+++ b/src/freenet/clients/http/bookmark/BookmarkManager.java
@@ -3,6 +3,8 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.clients.http.bookmark;
 
+import static java.util.concurrent.TimeUnit.MINUTES;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -123,7 +125,7 @@ public class BookmarkManager implements RequestClient {
 		public void onFoundEdition(long edition, USK key, ObjectContainer container, ClientContext context, boolean wasMetadata, short codec, byte[] data, boolean newKnownGood, boolean newSlotToo) {
 			if(!newKnownGood) {
 				FreenetURI uri = key.copy(edition).getURI();
-				node.makeClient(PRIORITY_PROGRESS, false, false).prefetch(uri, 60*60*1000, FProxyToadlet.MAX_LENGTH_WITH_PROGRESS, null, PRIORITY_PROGRESS);
+				node.makeClient(PRIORITY_PROGRESS, false, false).prefetch(uri, MINUTES.toMillis(60), FProxyToadlet.MAX_LENGTH_WITH_PROGRESS, null, PRIORITY_PROGRESS);
 				return;
 			}
 			List<BookmarkItem> items = MAIN_CATEGORY.getAllItems();
@@ -344,8 +346,8 @@ public class BookmarkManager implements RequestClient {
 						isSavingBookmarksLazy = false;
 					}
 				}
-				
-			}, 5*60*1000);
+
+			}, MINUTES.toMillis(5));
 		}
 	}
 

--- a/src/freenet/crypt/Yarrow.java
+++ b/src/freenet/crypt/Yarrow.java
@@ -3,6 +3,8 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.crypt;
 
+import static java.util.concurrent.TimeUnit.HOURS;
+
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.DataInputStream;
@@ -271,7 +273,7 @@ public class Yarrow extends RandomSource {
 		if(!force)
 			synchronized(this) {
 				long now = System.currentTimeMillis();
-				if(now - timeLastWroteSeed <= 60 * 60 * 1000 /* once per hour */)
+				if(now - timeLastWroteSeed <= HOURS.toMillis(1) /* once per hour */)
 					return;
 				else
 					timeLastWroteSeed = now;

--- a/src/freenet/io/AddressTracker.java
+++ b/src/freenet/io/AddressTracker.java
@@ -15,6 +15,10 @@
  */
 package freenet.io;
 
+import static java.util.concurrent.TimeUnit.HOURS;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.BufferedReader;
@@ -229,13 +233,13 @@ public class AddressTracker {
 	
 	/** If the minimum gap is at least this, we might be port forwarded.
 	 * RFC 4787 requires at least 2 minutes, but many NATs have shorter timeouts. */
-	public final static long MAYBE_TUNNEL_LENGTH = ((5 * 60) + 1) * 1000L;
+	public final static long MAYBE_TUNNEL_LENGTH = MINUTES.toMillis(5) + SECONDS.toMillis(1);
 	/** If the minimum gap is at least this, we are almost certainly port forwarded.
 	 * Some stateful firewalls do at least 30 minutes. Hopefully the below is
 	 * sufficiently over the top! */
-	public final static long DEFINITELY_TUNNEL_LENGTH = (12 * 60 + 1) * 60 * 1000L;
+	public final static long DEFINITELY_TUNNEL_LENGTH = HOURS.toMillis(12) + MINUTES.toMillis(1);
 	/** Time after which we ignore evidence that we are port forwarded */
-	public static final long HORIZON = 24*60*60*1000L;
+	public static final long HORIZON = HOURS.toMillis(24);
 
 	public long getLongestSendReceiveGap() {
 		return getLongestSendReceiveGap(HORIZON);

--- a/src/freenet/io/comm/MessageCore.java
+++ b/src/freenet/io/comm/MessageCore.java
@@ -18,6 +18,10 @@
  */
 package freenet.io.comm;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -56,11 +60,11 @@ public class MessageCore {
 	private final LinkedList<MessageFilter> _filters = new LinkedList<MessageFilter>();
 	private final LinkedList<Message> _unclaimed = new LinkedList<Message>();
 	private static final int MAX_UNMATCHED_FIFO_SIZE = 50000;
-	private static final long MAX_UNCLAIMED_FIFO_ITEM_LIFETIME = 10*60*1000;  // 10 minutes; maybe this should be per message type??
+	private static final long MAX_UNCLAIMED_FIFO_ITEM_LIFETIME = MINUTES.toMillis(10);  // maybe this should be per message type??
 	// FIXME do we need MIN_FILTER_REMOVE_TIME? Can we make this more efficient?
 	// FIXME may not work well for newly added filters with timeouts close to the minimum, or filters with timeouts close to the minimum in general.
-	private static final int MAX_FILTER_REMOVE_TIME = 1000;
-	private static final int MIN_FILTER_REMOVE_TIME = 100;
+	private static final long MAX_FILTER_REMOVE_TIME = SECONDS.toMillis(1);
+	private static final long MIN_FILTER_REMOVE_TIME = MILLISECONDS.toMillis(100);
 	private long startedTime;
 	
 	public synchronized long getStartedTime() {

--- a/src/freenet/io/comm/MessageFilter.java
+++ b/src/freenet/io/comm/MessageFilter.java
@@ -53,7 +53,7 @@ public final class MessageFilter {
     /** If true, timeouts are relative to the start of waiting, if false, they are relative to
      * the time of calling setTimeout() */
     private boolean _timeoutFromWait;
-    private int _initialTimeout;
+    private long _initialTimeout;
     private MessageFilter _or;
     private Message _message;
     private long _oldBootID;
@@ -106,7 +106,7 @@ public final class MessageFilter {
      * @param timeout The time before this filter expires in ms
      * @return This message filter
      */
-	public MessageFilter setTimeout(int timeout) {
+	public MessageFilter setTimeout(long timeout) {
 		_setTimeout = true;
 		_initialTimeout = timeout;
 		_timeout = System.currentTimeMillis() + timeout;
@@ -286,7 +286,7 @@ public final class MessageFilter {
         notifyAll();
     }
 
-    public int getInitialTimeout() {
+    public long getInitialTimeout() {
         return _initialTimeout;
     }
     

--- a/src/freenet/io/xfer/BlockReceiver.java
+++ b/src/freenet/io/xfer/BlockReceiver.java
@@ -18,6 +18,8 @@
  */
 package freenet.io.xfer;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import freenet.io.comm.AsyncMessageFilterCallback;
 import freenet.io.comm.ByteCounter;
 import freenet.io.comm.DMT;
@@ -115,19 +117,19 @@ public class BlockReceiver implements AsyncMessageFilterCallback {
 	 * hearing from us in 60 seconds. Without contact from the transmitter, we will try sending
 	 * at most MAX_CONSECUTIVE_MISSING_PACKET_REPORTS every RECEIPT_TIMEOUT to recover.
 	 */
-	public final int RECEIPT_TIMEOUT;
-	public static final int RECEIPT_TIMEOUT_REALTIME = 10000;
-	public static final int RECEIPT_TIMEOUT_BULK = 30000;
+	public final long RECEIPT_TIMEOUT;
+	public static final long RECEIPT_TIMEOUT_REALTIME = SECONDS.toMillis(10);
+	public static final long RECEIPT_TIMEOUT_BULK = SECONDS.toMillis(30);
 	// TODO: This should be proportional to the calculated round-trip-time, not a constant
-	public final int MAX_ROUND_TRIP_TIME;
+	public final long MAX_ROUND_TRIP_TIME;
 	public static final int MAX_CONSECUTIVE_MISSING_PACKET_REPORTS = 4;
 	public static final int MAX_SEND_INTERVAL = 500;
-	public static final int CLEANUP_TIMEOUT = 5000;
+	public static final long CLEANUP_TIMEOUT = SECONDS.toMillis(5);
 	// After 15 seconds, the receive is overdue and will cause backoff.
-	public static final int TOO_LONG_TIMEOUT = 15000;
+	public static final long TOO_LONG_TIMEOUT = SECONDS.toMillis(15);
 	/** sendAborted is not sent at the realtime/bulk priority. Most of the two
 	 * stage timeout stuff uses 60 seconds, it's a good number. */
-	public static final int ACK_TRANSFER_FAILED_TIMEOUT = 60*1000;
+	public static final long ACK_TRANSFER_FAILED_TIMEOUT = SECONDS.toMillis(60);
 	PartiallyReceivedBlock _prb;
 	PeerContext _sender;
 	long _uid;
@@ -465,7 +467,7 @@ public class BlockReceiver implements AsyncMessageFilterCallback {
 	private long timeStartedWaiting = -1;
 	
 	private void waitNotification(boolean truncateTimeout) throws DisconnectedException {
-		int timeout;
+		long timeout;
 		long now = System.currentTimeMillis();
 		synchronized(this) {
 			if(truncateTimeout) {
@@ -478,7 +480,7 @@ public class BlockReceiver implements AsyncMessageFilterCallback {
 		_usm.addAsyncFilter(relevantMessages(timeout), notificationWaiter, _ctr);
 	}
 
-	private MessageFilter relevantMessages(int timeout) {
+	private MessageFilter relevantMessages(long timeout) {
 		MessageFilter mfPacketTransmit = MessageFilter.create().setTimeout(timeout).setType(DMT.packetTransmit).setField(DMT.UID, _uid).setSource(_sender);
 		MessageFilter mfAllSent = MessageFilter.create().setTimeout(timeout).setType(DMT.allSent).setField(DMT.UID, _uid).setSource(_sender);
 		MessageFilter mfSendAborted = MessageFilter.create().setTimeout(timeout).setType(DMT.sendAborted).setField(DMT.UID, _uid).setSource(_sender);

--- a/src/freenet/io/xfer/BlockTransmitter.java
+++ b/src/freenet/io/xfer/BlockTransmitter.java
@@ -742,7 +742,7 @@ public class BlockTransmitter {
 				completed = true;
 				if(lastSentPacket > 0) {
 					delta = now - lastSentPacket;
-					int threshold = (realTime ? BlockReceiver.RECEIPT_TIMEOUT_REALTIME : BlockReceiver.RECEIPT_TIMEOUT_BULK);
+					long threshold = (realTime ? BlockReceiver.RECEIPT_TIMEOUT_REALTIME : BlockReceiver.RECEIPT_TIMEOUT_BULK);
 					if(delta > threshold)
 						Logger.warning(this, "Time between packets on "+BlockTransmitter.this+" : "+TimeUtil.formatTime(delta, 2, true)+" ( "+delta+"ms) realtime="+realTime);
 					else if(delta > threshold / 5)

--- a/src/freenet/io/xfer/BulkReceiver.java
+++ b/src/freenet/io/xfer/BulkReceiver.java
@@ -3,6 +3,8 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.io.xfer;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import freenet.io.comm.ByteCounter;
 import freenet.io.comm.DMT;
 import freenet.io.comm.DisconnectedException;
@@ -20,7 +22,7 @@ import freenet.support.ShortBuffer;
  */
 public class BulkReceiver {
 
-	static final int TIMEOUT = 60*1000;
+	static final long TIMEOUT = SECONDS.toMillis(60);
 	/** Tracks the data we have received */
 	final PartiallyReceivedBulk prb;
 	/** Peer we are receiving from */

--- a/src/freenet/io/xfer/BulkTransmitter.java
+++ b/src/freenet/io/xfer/BulkTransmitter.java
@@ -3,6 +3,9 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.io.xfer;
 
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import freenet.io.comm.AsyncMessageCallback;
 import freenet.io.comm.AsyncMessageFilterCallback;
 import freenet.io.comm.ByteCounter;
@@ -35,9 +38,9 @@ public class BulkTransmitter {
 	}
 
 	/** If no packets sent in this period, and no completion acknowledgement / cancellation, assume failure. */
-	static final int TIMEOUT = 5*60*1000;
+	static final long TIMEOUT = MINUTES.toMillis(5);
 	/** Time to hang around listening for the last FNPBulkReceivedAll message */
-	static final int FINAL_ACK_TIMEOUT = 10*1000;
+	static final long FINAL_ACK_TIMEOUT = SECONDS.toMillis(10);
 	final AllSentCallback allSentCallback;
 	/** Available blocks */
 	final PartiallyReceivedBulk prb;
@@ -302,7 +305,7 @@ outer:	while(true) {
 					
 					// Wait for a packet to come in, BulkReceivedAll or BulkReceiveAborted
 					try {
-						wait(60*1000);
+						wait(SECONDS.toMillis(60));
 					} catch (InterruptedException e) {
 						// No problem
 						continue;

--- a/src/freenet/node/Announcer.java
+++ b/src/freenet/node/Announcer.java
@@ -3,6 +3,8 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.node;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import java.io.BufferedInputStream;
 import java.io.BufferedReader;
 import java.io.EOFException;
@@ -51,9 +53,9 @@ public class Announcer {
 	private int sentAnnouncements;
 	private long startTime;
 	private long timeAddedSeeds;
-	private static final long MIN_ADDED_SEEDS_INTERVAL = 60*1000;
+	private static final long MIN_ADDED_SEEDS_INTERVAL = SECONDS.toMillis(60);
 	/** After we have sent 3 announcements, wait for 30 seconds before sending 3 more if we still have no connections. */
-	static final int COOLING_OFF_PERIOD = 30*1000;
+	static final long COOLING_OFF_PERIOD = SECONDS.toMillis(30);
 	/** Pubkey hashes of nodes we have announced to */
 	private final HashSet<ByteArrayWrapper> announcedToIdentities;
 	/** IPs of nodes we have announced to. Maybe this should be first-two-bytes, but I'm not sure how to do that with IPv6. */
@@ -62,7 +64,7 @@ public class Announcer {
 	private static final int CONNECT_AT_ONCE = 15;
 	/** Do not announce if there are more than this many opennet peers connected */
 	private static final int MIN_OPENNET_CONNECTED_PEERS = 10;
-	private static final long NOT_ALL_CONNECTED_DELAY = 60*1000;
+	private static final long NOT_ALL_CONNECTED_DELAY = SECONDS.toMillis(60);
 	public static final String SEEDNODES_FILENAME = "seednodes.fref";
 	/** Total nodes added by announcement so far */
 	private int announcementAddedNodes;
@@ -404,9 +406,9 @@ public class Announcer {
 	}
 
 	/** 1 minute after we have enough peers, remove all seednodes left (presumably disconnected ones) */
-	private static final int FINAL_DELAY = 60*1000;
+	private static final long FINAL_DELAY = SECONDS.toMillis(60);
 	/** But if we don't have enough peers at that point, wait another minute and if the situation has not improved, reannounce. */
-	static final int RETRY_DELAY = 60*1000;
+	static final long RETRY_DELAY = SECONDS.toMillis(60);
 	private boolean started = false;
 
 	private final Runnable checker = new Runnable() {

--- a/src/freenet/node/BaseRequestThrottle.java
+++ b/src/freenet/node/BaseRequestThrottle.java
@@ -3,11 +3,14 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.node;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.MINUTES;
+
 public interface BaseRequestThrottle {
 
-	public static final long DEFAULT_DELAY = 200;
-	static final long MAX_DELAY = 5*60*1000;
-	static final long MIN_DELAY = 20;
+	public static final long DEFAULT_DELAY = MILLISECONDS.toMillis(500);
+	static final long MAX_DELAY = MINUTES.toMillis(5);
+	static final long MIN_DELAY = MILLISECONDS.toMillis(20);
 
 	/**
 	 * Get the current inter-request delay.

--- a/src/freenet/node/BaseSender.java
+++ b/src/freenet/node/BaseSender.java
@@ -1,5 +1,7 @@
 package freenet.node;
 
+import static java.util.concurrent.TimeUnit.MINUTES;
+
 import java.util.HashMap;
 import java.util.HashSet;
 
@@ -45,8 +47,8 @@ public abstract class BaseSender implements ByteCounter {
     final Node node;
     protected final long startTime;
     long uid;
-    static final int SEARCH_TIMEOUT_BULK = 600*1000;
-    static final int SEARCH_TIMEOUT_REALTIME = 60*1000;
+    static final long SEARCH_TIMEOUT_BULK = MINUTES.toMillis(10);
+    static final long SEARCH_TIMEOUT_REALTIME = MINUTES.toMillis(1);
     final int incomingSearchTimeout;
     
     BaseSender(Key key, boolean realTimeFlag, PeerNode source, Node node, short htl, long uid) {
@@ -703,7 +705,7 @@ loadWaiterLoop:
 		return msg.getSpec() == DMT.FNPAccepted;
 	}
 
-	protected abstract int getAcceptedTimeout();
+	protected abstract long getAcceptedTimeout();
 	
 	/** We timed out while waiting for a slot from any node. Fail the request.
 	 * @param load The proportion of requests getting timed out, on average,
@@ -728,13 +730,13 @@ loadWaiterLoop:
 	 * we need to use the old tag.
 	 */
 	protected abstract MessageFilter makeAcceptedRejectedFilter(PeerNode next,
-			int acceptedTimeout, UIDTag tag);
+			long acceptedTimeout, UIDTag tag);
 	
 	protected abstract void forwardRejectedOverload();
 	
 	protected abstract boolean isInsert();
 	
-	protected int ignoreLowBackoff() {
+	protected long ignoreLowBackoff() {
 		return 0;
 	}
 	

--- a/src/freenet/node/CHKInsertHandler.java
+++ b/src/freenet/node/CHKInsertHandler.java
@@ -3,6 +3,8 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.node;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import freenet.io.comm.ByteCounter;
 import freenet.io.comm.DMT;
 import freenet.io.comm.DisconnectedException;
@@ -47,8 +49,8 @@ public class CHKInsertHandler implements PrioRunnable, ByteCounter {
 		});
 	}
 
-    static final int DATA_INSERT_TIMEOUT = 10000;
-    
+    static final long DATA_INSERT_TIMEOUT = SECONDS.toMillis(10);
+
     final Node node;
     final long uid;
     final PeerNode source;
@@ -306,7 +308,7 @@ public class CHKInsertHandler implements PrioRunnable, ByteCounter {
         }
 	}
 
-	private MessageFilter makeDataInsertFilter(int timeout) {
+	private MessageFilter makeDataInsertFilter(long timeout) {
     	MessageFilter mfDataInsert = MessageFilter.create().setType(DMT.FNPDataInsert).setField(DMT.UID, uid).setSource(source).setTimeout(timeout);
     	// DataInsertRejected means the transfer failed upstream so a DataInsert will not be sent.
     	MessageFilter mfDataInsertRejected = MessageFilter.create().setType(DMT.FNPDataInsertRejected).setField(DMT.UID, uid).setSource(source).setTimeout(timeout);
@@ -330,7 +332,7 @@ public class CHKInsertHandler implements PrioRunnable, ByteCounter {
     		// Two stage timeout. Don't go fatal unless no response in 60 seconds.
     		// Yes it's ugly everywhere but since we have a longish connection timeout it's necessary everywhere. :|
     		// FIXME review two stage timeout everywhere with some low level networking guru.
-    		MessageFilter mf = makeDataInsertFilter(60*1000);
+    		MessageFilter mf = makeDataInsertFilter(SECONDS.toMillis(60));
     		node.usm.addAsyncFilter(mf, new SlowAsyncMessageFilterCallback() {
 
     			@Override
@@ -390,13 +392,13 @@ public class CHKInsertHandler implements PrioRunnable, ByteCounter {
      */
     private void finish(int code) {
     	if(logMINOR) Logger.minor(this, "Waiting for receive");
-    	int transferTimeout = realTimeFlag ?
+    	long transferTimeout = realTimeFlag ?
     			CHKInsertSender.TRANSFER_COMPLETION_ACK_TIMEOUT_REALTIME :
     				CHKInsertSender.TRANSFER_COMPLETION_ACK_TIMEOUT_BULK;
 		synchronized(this) {
 			while(receiveStarted && !receiveCompleted) {
 				try {
-					wait(100*1000);
+					wait(SECONDS.toMillis(100));
 				} catch (InterruptedException e) {
 					// Ignore
 				}
@@ -455,7 +457,7 @@ public class CHKInsertHandler implements PrioRunnable, ByteCounter {
         					break;
         				}
         				try {
-        					sender.wait(10*1000);
+        					sender.wait(SECONDS.toMillis(10));
         				} catch (InterruptedException e) {
         					// Loop
         				}

--- a/src/freenet/node/CHKInsertSender.java
+++ b/src/freenet/node/CHKInsertSender.java
@@ -3,6 +3,9 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.node;
 
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -338,11 +341,11 @@ public final class CHKInsertSender extends BaseSender implements PrioRunnable, A
 	}
 	
     // Constants
-    static final int ACCEPTED_TIMEOUT = 10000;
-    static final int TRANSFER_COMPLETION_ACK_TIMEOUT_REALTIME = 60*1000;
-    static final int TRANSFER_COMPLETION_ACK_TIMEOUT_BULK = 300*1000;
+    static final long ACCEPTED_TIMEOUT = SECONDS.toMillis(10);
+    static final long TRANSFER_COMPLETION_ACK_TIMEOUT_REALTIME = MINUTES.toMillis(1);
+    static final long TRANSFER_COMPLETION_ACK_TIMEOUT_BULK = MINUTES.toMillis(5);
 
-    final int transferCompletionTimeout;
+    final long transferCompletionTimeout;
     
     // Basics
     final long origUID;
@@ -630,7 +633,7 @@ public final class CHKInsertSender extends BaseSender implements PrioRunnable, A
 	}
 
 	@Override
-	protected MessageFilter makeAcceptedRejectedFilter(PeerNode next, int acceptedTimeout, UIDTag tag) {
+	protected MessageFilter makeAcceptedRejectedFilter(PeerNode next, long acceptedTimeout, UIDTag tag) {
 		// Use the right UID here, in case we fork on cacheable.
 		final long uid = tag.uid;
         MessageFilter mfAccepted = MessageFilter.create().setSource(next).setField(DMT.UID, uid).setTimeout(acceptedTimeout).setType(DMT.FNPAccepted);
@@ -644,7 +647,7 @@ public final class CHKInsertSender extends BaseSender implements PrioRunnable, A
         return mfAccepted.or(mfRejectedLoop.or(mfRejectedOverload));
 	}
 
-	private static final int TIMEOUT_AFTER_ACCEPTEDREJECTED_TIMEOUT = 60*1000;
+	private static final long TIMEOUT_AFTER_ACCEPTEDREJECTED_TIMEOUT = MINUTES.toMillis(1);
 
 	@Override
 	protected void handleAcceptedRejectedTimeout(final PeerNode next, final UIDTag tag) {
@@ -994,7 +997,7 @@ public final class CHKInsertSender extends BaseSender implements PrioRunnable, A
 					
 					if(logMINOR) Logger.minor(this, "Waiting: transfer completion=" + completedTransfers + " notification="+completedNotifications); 
 					try {
-						backgroundTransfers.wait(100*1000);
+						backgroundTransfers.wait(SECONDS.toMillis(100));
 					} catch (InterruptedException e) {
 						// Ignore
 					}
@@ -1011,7 +1014,7 @@ public final class CHKInsertSender extends BaseSender implements PrioRunnable, A
 	public synchronized void waitForStatus() {
 		while(status == NOT_FINISHED) {
 			try {
-				CHKInsertSender.this.wait(100*1000);
+				CHKInsertSender.this.wait(SECONDS.toMillis(100));
 			} catch (InterruptedException e) {
 				// Ignore
 			}
@@ -1113,7 +1116,7 @@ public final class CHKInsertSender extends BaseSender implements PrioRunnable, A
 	}
 
 	@Override
-	protected int getAcceptedTimeout() {
+	protected long getAcceptedTimeout() {
 		return ACCEPTED_TIMEOUT;
 	}
 
@@ -1387,7 +1390,7 @@ public final class CHKInsertSender extends BaseSender implements PrioRunnable, A
 	}
 	
 	@Override
-	protected int ignoreLowBackoff() {
+	protected long ignoreLowBackoff() {
 		return ignoreLowBackoff ? Node.LOW_BACKOFF : 0;
 	}
 

--- a/src/freenet/node/DarknetPeerNode.java
+++ b/src/freenet/node/DarknetPeerNode.java
@@ -1,5 +1,7 @@
 package freenet.node;
 
+import static java.util.concurrent.TimeUnit.DAYS;
+
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.ByteArrayInputStream;
@@ -1698,7 +1700,7 @@ public class DarknetPeerNode extends PeerNode {
 
 	@Override
 	protected void maybeClearPeerAddedTimeOnRestart(long now) {
-		if((now - peerAddedTime) > (((long) 30) * 24 * 60 * 60 * 1000))  // 30 days
+		if((now - peerAddedTime) > DAYS.toMillis(30))
 			peerAddedTime = 0;
 		if(!neverConnected)
 			peerAddedTime = 0;

--- a/src/freenet/node/FNPPacketMangler.java
+++ b/src/freenet/node/FNPPacketMangler.java
@@ -3,6 +3,10 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.node;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import java.io.File;
 import java.io.UnsupportedEncodingException;
 import java.net.InetAddress;
@@ -108,11 +112,11 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
 	private static final int TRANSIENT_KEY_SIZE = HASH_LENGTH;
 	/** The key used to authenticate the hmac */
 	private final byte[] transientKey = new byte[TRANSIENT_KEY_SIZE];
-	public static final int TRANSIENT_KEY_REKEYING_MIN_INTERVAL = 30*60*1000;
+	public static final long TRANSIENT_KEY_REKEYING_MIN_INTERVAL = MINUTES.toMillis(30);
 	/** The rekeying interval for the session key (keytrackers) */
-	public static final int SESSION_KEY_REKEYING_INTERVAL = 60*60*1000;
+	public static final long SESSION_KEY_REKEYING_INTERVAL = MINUTES.toMillis(60);
 	/** The max amount of time we will accept to use the current tracker when it should have been replaced */
-	public static final int MAX_SESSION_KEY_REKEYING_DELAY = 5*60*1000;
+	public static final long MAX_SESSION_KEY_REKEYING_DELAY = MINUTES.toMillis(5);
 	/** The amount of data sent before we ask for a rekey */
 	public static final int AMOUNT_OF_BYTES_ALLOWED_BEFORE_WE_REKEY = 1024 * 1024 * 1024;
 	/** The Runnable in charge of rekeying on a regular basis */
@@ -799,11 +803,11 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
 	}
 	
 	private long lastLoggedNoContexts = -1;
-	private static int LOG_NO_CONTEXTS_INTERVAL = 60*1000;
-	
+	private static long LOG_NO_CONTEXTS_INTERVAL = MINUTES.toMillis(1);
+
 	private void handleNoContextsException(NoContextsException e,
 			freenet.node.FNPPacketMangler.NoContextsException.CONTEXT context) {
-		if(node.getUptime() < 30*1000) {
+		if(node.getUptime() < SECONDS.toMillis(30)) {
 			Logger.warning(this, "No contexts available, unable to handle or send packet ("+context+") on "+this);
 			return;
 		}
@@ -1459,7 +1463,7 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
 		if(logMINOR) Logger.minor(this, "Got a JFK(4) message, processing it - "+pn.getPeer());
 		if(pn.jfkMyRef == null) {
 			String error = "Got a JFK(4) message but no pn.jfkMyRef for "+pn;
-			if(node.getUptime() < 60*1000) {
+			if(node.getUptime() < SECONDS.toMillis(60)) {
 				Logger.minor(this, error);
 			} else {
 				Logger.error(this, error);
@@ -1825,9 +1829,9 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
 					}
 				}
 			}
-		}, 5*1000);
+		}, SECONDS.toMillis(5));
 		long t2=System.currentTimeMillis();
-		if((t2-t1)>500)
+		if((t2-t1)>MILLISECONDS.toMillis(500))
 			Logger.error(this,"Message3 timeout error:Sending packet for "+pn.getPeer());
 	}
 
@@ -2363,7 +2367,7 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
 	@Override
 	public Status getConnectivityStatus() {
 		long now = System.currentTimeMillis();
-		if (now - lastConnectivityStatusUpdate < 3 * 60 * 1000)
+		if (now - lastConnectivityStatusUpdate < MINUTES.toMillis(3))
 			return lastConnectivityStatus;
 
 		Status value;

--- a/src/freenet/node/FailureTable.java
+++ b/src/freenet/node/FailureTable.java
@@ -3,6 +3,8 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.node;
 
+import static java.util.concurrent.TimeUnit.MINUTES;
+
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -74,21 +76,21 @@ public class FailureTable implements OOMHook {
 	/** Terminate a request if there was a DNF on the same key less than 10 minutes ago.
 	 * Maximum time for any FailureTable i.e. for this period after a DNF, we will avoid the node that 
 	 * DNFed. */
-	static final int REJECT_TIME = 10*60*1000;
+	static final long REJECT_TIME = MINUTES.toMillis(10);
 	/** Maximum time for a RecentlyFailed. I.e. until this period expires, we take a request into account
 	 * when deciding whether we have recently failed to this peer. If we get a DNF, we use this figure.
 	 * If we get a RF, we use what it tells us, which can be less than this. Most other failures use
 	 * shorter periods. */
-	static final int RECENTLY_FAILED_TIME = 30*60*1000;
+	static final long RECENTLY_FAILED_TIME = MINUTES.toMillis(30);
 	/** After 1 hour we forget about an entry completely */
-	static final int MAX_LIFETIME = 60*60*1000;
+	static final long MAX_LIFETIME = MINUTES.toMillis(60);
 	/** Offers expire after 10 minutes */
-	static final int OFFER_EXPIRY_TIME = 10*60*1000;
+	static final long OFFER_EXPIRY_TIME = MINUTES.toMillis(10);
 	/** HMAC key for the offer authenticator */
 	final byte[] offerAuthenticatorKey;
 	/** Clean up old data every 10 minutes to save memory and improve privacy */
-	static final int CLEANUP_PERIOD = 10*60*1000;
-	
+	static final long CLEANUP_PERIOD = MINUTES.toMillis(10);
+
 	FailureTable(Node node) {
 		entriesByKey = LRUMap.createSafeMap();
 		blockOfferListByKey = LRUMap.createSafeMap();
@@ -113,7 +115,7 @@ public class FailureTable implements OOMHook {
 	 * @param htl
 	 * @param timeout
 	 */
-	public void onFailed(Key key, PeerNode routedTo, short htl, int rfTimeout, int ftTimeout) {
+	public void onFailed(Key key, PeerNode routedTo, short htl, long rfTimeout, long ftTimeout) {
 		if(ftTimeout < 0 || ftTimeout > REJECT_TIME) {
 			Logger.error(this, "Bogus timeout "+ftTimeout, new Exception("error"));
 			ftTimeout = Math.max(Math.min(REJECT_TIME, ftTimeout), 0);
@@ -147,7 +149,7 @@ public class FailureTable implements OOMHook {
 	 * avoid problems.
 	 * LOCKING: NEVER synchronize on PeerNode before calling any FailureTable method.
 	 */
-	public void onFinalFailure(Key key, PeerNode routedTo, short htl, short origHTL, int rfTimeout, int ftTimeout, PeerNode requestor) {
+	public void onFinalFailure(Key key, PeerNode routedTo, short htl, short origHTL, long rfTimeout, long ftTimeout, PeerNode requestor) {
 		if(ftTimeout < -1 || ftTimeout > REJECT_TIME) {
 			// -1 is a valid no-op.
 			Logger.error(this, "Bogus timeout "+ftTimeout, new Exception("error"));

--- a/src/freenet/node/FailureTableEntry.java
+++ b/src/freenet/node/FailureTableEntry.java
@@ -1,5 +1,7 @@
 package freenet.node;
 
+import static java.util.concurrent.TimeUnit.HOURS;
+
 import java.lang.ref.WeakReference;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -78,8 +80,8 @@ class FailureTableEntry implements TimedOutNodesList {
 	
 	/** We remember that a node has asked us for a key for up to an hour; after that, we won't offer the key, and
 	 * if we receive an offer from that node, we will reject it */
-	static final int MAX_TIME_BETWEEN_REQUEST_AND_OFFER = 60 * 60 * 1000;
-	
+	static final long MAX_TIME_BETWEEN_REQUEST_AND_OFFER = HOURS.toMillis(1);
+
         public static final long[] EMPTY_LONG_ARRAY = new long[0];
         public static final short[] EMPTY_SHORT_ARRAY = new short[0];
         public static final double[] EMPTY_DOUBLE_ARRAY = new double[0];
@@ -112,7 +114,7 @@ class FailureTableEntry implements TimedOutNodesList {
 	 * @param now The current time.
 	 * @param htl The HTL of the request. Note that timeouts only apply to the same HTL.
 	 */
-	public synchronized void failedTo(PeerNodeUnlocked routedTo, int rfTimeout, int ftTimeout, long now, short htl) {
+	public synchronized void failedTo(PeerNodeUnlocked routedTo, long rfTimeout, long ftTimeout, long now, short htl) {
 		if(logMINOR) {
 			Logger.minor(this, "Failed sending request to "+routedTo.shortToString()+" : timeout "+rfTimeout+" / "+ftTimeout);
 		}

--- a/src/freenet/node/IPDetectorPluginManager.java
+++ b/src/freenet/node/IPDetectorPluginManager.java
@@ -1,5 +1,8 @@
 package freenet.node;
 
+import static java.util.concurrent.TimeUnit.HOURS;
+import static java.util.concurrent.TimeUnit.MINUTES;
+
 import java.net.InetAddress;
 import java.util.Arrays;
 import java.util.ArrayList;
@@ -364,7 +367,7 @@ public class IPDetectorPluginManager implements ForwardPortCallback {
 				freenet.support.Logger.OSThread.logPID(this);
 				tryMaybeRun();
 			}
-		}, 60*1000);
+		}, MINUTES.toMillis(1));
 	}
 
 	/**
@@ -468,7 +471,7 @@ public class IPDetectorPluginManager implements ForwardPortCallback {
 			// If detect attempt failed to produce an IP in the last 5 minutes, don't
 			// try again yet.
 			if(failedRunners.size() == plugins.length) {
-				if(now - lastDetectAttemptEndedTime < 5*60*1000) {
+				if(now - lastDetectAttemptEndedTime < MINUTES.toMillis(5)) {
 					if(logMINOR) Logger.minor(this, "Last detect failed less than 5 minutes ago");
 					return;
 				} else {
@@ -503,7 +506,7 @@ public class IPDetectorPluginManager implements ForwardPortCallback {
 	 * @return True if we should run a detection.
 	 */
 	private boolean shouldDetectNoPeers(long now) {
-		if(now - lastDetectAttemptEndedTime < 6*60*60*1000) {
+		if(now - lastDetectAttemptEndedTime < HOURS.toMillis(6)) {
 			// No peers, only try every 6 hours.
 			if(logMINOR) Logger.minor(this, "No peers but detected less than 6 hours ago");
 			return false;
@@ -555,7 +558,7 @@ public class IPDetectorPluginManager implements ForwardPortCallback {
 				realConnections++;
 			else {
 				realDisconnected++;
-				if(now - p.lastReceivedPacketTime() < 5*60*1000)
+				if(now - p.lastReceivedPacketTime() < MINUTES.toMillis(5))
 					recentlyConnected++;
 			}
 		}
@@ -572,7 +575,7 @@ public class IPDetectorPluginManager implements ForwardPortCallback {
 				// Allow 2 minutes to get incoming connections and therefore detect from them.
 				// In the meantime, *hopefully* our oldIPAddress is valid.
 				// If not, we'll find out in 2 minutes.
-				if(now - firstTimeUrgent > 2*60*1000) {
+				if(now - firstTimeUrgent > MINUTES.toMillis(2)) {
 					detect = true;
 					firstTimeUrgent = now; // Reset now rather than on next round.
 					if(logMINOR) Logger.minor(this, "Detecting now as 2 minutes are up (have oldIPAddress)");
@@ -592,7 +595,7 @@ public class IPDetectorPluginManager implements ForwardPortCallback {
 		// If we have no connections, and have lost several connections recently, we should 
 		// do a detection soon, regardless of the 1 detection per hour throttle.
 		if(realConnections == 0 && realDisconnected > 0 && recentlyConnected > 2) {
-			if(now - lastDetectAttemptEndedTime > 6 * 60 * 1000) {
+			if(now - lastDetectAttemptEndedTime > MINUTES.toMillis(6)) {
 				return true;
 			}
 		}
@@ -603,7 +606,7 @@ public class IPDetectorPluginManager implements ForwardPortCallback {
 			return true;
 		
 		if(detect) {
-			if(now - lastDetectAttemptEndedTime < 60*60*1000) {
+			if(now - lastDetectAttemptEndedTime < HOURS.toMillis(1)) {
 				// Only try every hour
 				if(logMINOR) Logger.minor(this, "Only trying once per hour");
 				return false;
@@ -625,7 +628,7 @@ public class IPDetectorPluginManager implements ForwardPortCallback {
 	private boolean shouldDetectDespiteRealIP(long now, PeerNode[] peers, FreenetInetAddress[] nodeAddrs) {
 		// We might still be firewalled?
 		// First, check only once per day or startup
-		if(now - lastDetectAttemptEndedTime < 12*60*60*1000) {
+		if(now - lastDetectAttemptEndedTime < HOURS.toMillis(12)) {
 			if(logMINOR) Logger.minor(this, "Node has directly detected IP and we have checked less than 12 hours ago");
 			return false;
 		}
@@ -636,7 +639,7 @@ public class IPDetectorPluginManager implements ForwardPortCallback {
 		HashSet<InetAddress> addressesConnected = null;
 		boolean hasOldPeers = false;
 		for(PeerNode p : peers) {
-			if(p.isConnected() || (now - p.lastReceivedPacketTime() < 24*60*60*1000)) {
+			if(p.isConnected() || (now - p.lastReceivedPacketTime() < HOURS.toMillis(24))) {
 				// Has been connected in the last 24 hours.
 				// Unique IP address?
 				Peer peer = p.getPeer();
@@ -667,7 +670,7 @@ public class IPDetectorPluginManager implements ForwardPortCallback {
 					}
 				}
 				long l = p.getPeerAddedTime();
-				if((l <= 0) || (now - l > 30*60*1000)) {
+				if((l <= 0) || (now - l > MINUTES.toMillis(30))) {
 					hasOldPeers = true;
 				}
 			}

--- a/src/freenet/node/LocationManager.java
+++ b/src/freenet/node/LocationManager.java
@@ -3,6 +3,10 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.node;
 
+import static java.util.concurrent.TimeUnit.DAYS;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -66,7 +70,7 @@ public class LocationManager implements ByteCounter {
         }
     }
 
-    static final int TIMEOUT = 60*1000;
+    static final long TIMEOUT = SECONDS.toMillis(60);
     static final int SWAP_MAX_HTL = 10;
     /** Number of swap evaluations, either incoming or outgoing, between resetting our location.
      * There is a 2 in SWAP_RESET chance that a reset will occur on one or other end of a swap request.
@@ -78,15 +82,15 @@ public class LocationManager implements ByteCounter {
      * reduce it to 8000 or 4000. */
     static final int SWAP_RESET = 16000;
 	// FIXME vary automatically
-    static final int SEND_SWAP_INTERVAL = 8000;
+    static final long SEND_SWAP_INTERVAL = SECONDS.toMillis(8);
     /** The average time between sending a swap request, and completion. */
     final BootstrappingDecayingRunningAverage averageSwapTime;
     /** Minimum swap delay */
-    static final int MIN_SWAP_TIME = Node.MIN_INTERVAL_BETWEEN_INCOMING_SWAP_REQUESTS;
+    static final long MIN_SWAP_TIME = Node.MIN_INTERVAL_BETWEEN_INCOMING_SWAP_REQUESTS;
     /** Maximum swap delay */
-    static final int MAX_SWAP_TIME = 60*1000;
+    static final long MAX_SWAP_TIME = MINUTES.toMillis(1);
     /** Don't start swapping until our peers have had a reasonable chance to reconnect. */
-	private static final long STARTUP_DELAY = 60*1000;
+    private static final long STARTUP_DELAY = MINUTES.toMillis(1);
     private static boolean logMINOR;
     final RandomSource r;
     final SwapRequestSender sender;
@@ -153,11 +157,11 @@ public class LocationManager implements ByteCounter {
 					clearOldSwapChains();
 					removeTooOldQueuedItems();
 				} finally {
-					node.ticker.queueTimedJob(this, 10*1000);
+					node.ticker.queueTimedJob(this, SECONDS.toMillis(10));
 				}
 			}
-			
-		}, 10*1000);
+
+		}, SECONDS.toMillis(10));
     }
 
     /**
@@ -175,7 +179,7 @@ public class LocationManager implements ByteCounter {
                     long startTime = System.currentTimeMillis();
                     double nextRandom = r.nextDouble();
                     while(true) {
-                        int sleepTime = getSendSwapInterval();
+                        long sleepTime = getSendSwapInterval();
                         sleepTime *= nextRandom;
                         sleepTime = Math.min(sleepTime, Integer.MAX_VALUE);
                         long endTime = startTime + sleepTime;
@@ -183,7 +187,7 @@ public class LocationManager implements ByteCounter {
                         long diff = endTime - now;
                         try {
                             if(diff > 0)
-                                Thread.sleep(Math.min((int)diff, 10000));
+                                Thread.sleep(Math.min((int)diff, SECONDS.toMillis(10)));
                         } catch (InterruptedException e) {
                             // Ignore
                         }
@@ -195,7 +199,7 @@ public class LocationManager implements ByteCounter {
                     }
                     // Don't send one if we are locked
                     if(lock()) {
-                        if(System.currentTimeMillis() - timeLastSuccessfullySwapped > 30*1000) {
+                        if(System.currentTimeMillis() - timeLastSuccessfullySwapped > SECONDS.toMillis(30)) {
                             try {
                                 boolean myFlag = false;
                                 double myLoc = getLocation();
@@ -208,7 +212,7 @@ public class LocationManager implements ByteCounter {
                                     			// Don't reset location unless we're SURE there is a problem.
                                     			// If the node has had its location equal to ours for at least 2 minutes, and ours has been likewise...
                                     			long now = System.currentTimeMillis();
-                                    			if(now - l.getLocationSetTime() > 120*1000 && now - timeLocSet > 120*1000) {
+                                    			if(now - l.getLocationSetTime() > MINUTES.toMillis(2) && now - timeLocSet > MINUTES.toMillis(2)) {
                                     				myFlag = true;
                                     				// Log an ERROR
                                     				// As this is an ERROR, it results from either a bug or malicious action.
@@ -267,8 +271,8 @@ public class LocationManager implements ByteCounter {
     	return node.isOpennetEnabled();
 	}
 
-	public int getSendSwapInterval() {
-    	int interval = (int) averageSwapTime.currentValue();
+	public long getSendSwapInterval() {
+    	long interval = (long) averageSwapTime.currentValue();
     	if(interval < MIN_SWAP_TIME)
     		interval = MIN_SWAP_TIME;
     	if(interval > MAX_SWAP_TIME)
@@ -866,7 +870,7 @@ public class LocationManager implements ByteCounter {
     static final int MAX_INCOMING_QUEUE_LENGTH = 10;
 
     /** Prevent timeouts and deadlocks due to A waiting for B waiting for A */
-    static final long MAX_TIME_ON_INCOMING_QUEUE = 30*1000;
+    static final long MAX_TIME_ON_INCOMING_QUEUE = SECONDS.toMillis(30);
 
     void removeTooOldQueuedItems() {
     	while(true) {
@@ -1318,7 +1322,7 @@ public class LocationManager implements ByteCounter {
         }
     }
 
-    private static final long MAX_AGE = 7*24*60*60*1000;
+    private static final long MAX_AGE = DAYS.toMillis(7);
 
     private final TimeSortedHashtable<Double> knownLocs = new TimeSortedHashtable<Double>();
 

--- a/src/freenet/node/NewPacketFormat.java
+++ b/src/freenet/node/NewPacketFormat.java
@@ -3,6 +3,8 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.node;
 
+import static java.util.concurrent.TimeUnit.MINUTES;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -36,7 +38,7 @@ public class NewPacketFormat implements PacketFormat {
 	private static final int MSG_WINDOW_SIZE = 65536;
 	private static final int NUM_MESSAGE_IDS = 268435456;
 	static final long NUM_SEQNUMS = 2147483648l;
-	private static final int MAX_MSGID_BLOCK_TIME = 10 * 60 * 1000;
+	private static final long MAX_MSGID_BLOCK_TIME = MINUTES.toMillis(10);
 	private static final int MAX_ACKS = 500;
 	static boolean DO_KEEPALIVES = true;
 

--- a/src/freenet/node/NodeClientCore.java
+++ b/src/freenet/node/NodeClientCore.java
@@ -1,5 +1,7 @@
 package freenet.node;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -171,7 +173,7 @@ public class NodeClientCore implements Persistable, DBJobRunner, OOMHook, Execut
 			System.err.println("Database corrupted (before entering NodeClientCore)!");
 		fecQueue = initFECQueue(node.nodeDBHandle, container, null);
 		this.backgroundBlockEncoder = new BackgroundBlockEncoder();
-		clientDatabaseExecutor = new PrioritizedSerialExecutor(NativeThread.NORM_PRIORITY, NativeThread.MAX_PRIORITY+1, NativeThread.NORM_PRIORITY, true, 30*1000, this, node.nodeStats);
+		clientDatabaseExecutor = new PrioritizedSerialExecutor(NativeThread.NORM_PRIORITY, NativeThread.MAX_PRIORITY+1, NativeThread.NORM_PRIORITY, true, SECONDS.toMillis(30), this, node.nodeStats);
 		storeChecker = new DatastoreChecker(node);
 		byte[] pwdBuf = new byte[16];
 		random.nextBytes(pwdBuf);
@@ -1391,7 +1393,7 @@ public class NodeClientCore implements Persistable, DBJobRunner, OOMHook, Execut
 				synchronized(is) {
 					if(is.getStatus() == CHKInsertSender.NOT_FINISHED)
 						try {
-							is.wait(5 * 1000);
+							is.wait(SECONDS.toMillis(5));
 						} catch(InterruptedException e) {
 							// Ignore
 						}
@@ -1410,7 +1412,7 @@ public class NodeClientCore implements Persistable, DBJobRunner, OOMHook, Execut
 					if(is.completed())
 						break;
 					try {
-						is.wait(10 * 1000);
+						is.wait(SECONDS.toMillis(10));
 					} catch(InterruptedException e) {
 						// Go around again
 					}
@@ -1515,7 +1517,7 @@ public class NodeClientCore implements Persistable, DBJobRunner, OOMHook, Execut
 				synchronized(is) {
 					if(is.getStatus() == SSKInsertSender.NOT_FINISHED)
 						try {
-							is.wait(5 * 1000);
+							is.wait(SECONDS.toMillis(5));
 						} catch(InterruptedException e) {
 							// Ignore
 						}
@@ -1534,7 +1536,7 @@ public class NodeClientCore implements Persistable, DBJobRunner, OOMHook, Execut
 					if(is.getStatus() != SSKInsertSender.NOT_FINISHED)
 						break;
 					try {
-						is.wait(10 * 1000);
+						is.wait(SECONDS.toMillis(10));
 					} catch(InterruptedException e) {
 						// Go around again
 					}
@@ -1849,9 +1851,9 @@ public class NodeClientCore implements Persistable, DBJobRunner, OOMHook, Execut
 
 	private long lastCommitted = System.currentTimeMillis();
 
-	static final int MAX_COMMIT_INTERVAL = 30*1000;
+	static final long MAX_COMMIT_INTERVAL = SECONDS.toMillis(30);
 
-	static final int SOON_COMMIT_INTERVAL = 5*1000;
+	static final long SOON_COMMIT_INTERVAL = SECONDS.toMillis(5);
 
 	class DBJobWrapper implements Runnable {
 

--- a/src/freenet/node/NodeIPDetector.java
+++ b/src/freenet/node/NodeIPDetector.java
@@ -1,5 +1,7 @@
 package freenet.node;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -119,7 +121,7 @@ public class NodeIPDetector {
 	public NodeIPDetector(Node node) {
 		this.node = node;
 		ipDetectorManager = new IPDetectorPluginManager(node, this);
-		ipDetector = new IPAddressDetector(10*1000, this);
+		ipDetector = new IPAddressDetector(SECONDS.toMillis(10), this);
 		invalidAddressOverrideAlert = new InvalidAddressOverrideUserAlert(node);
 		primaryIPUndetectedAlert = new IPUndetectedUserAlert(node);
 		portDetectors = new NodeIPPortDetector[0];
@@ -550,7 +552,7 @@ public class NodeIPDetector {
 				for(NodeIPPortDetector detector: detectors)
 					detector.startARK();
 			}
-		}, 60*1000);
+		}, SECONDS.toMillis(60));
 	}
 
 	public void onConnectedPeer() {

--- a/src/freenet/node/NodePinger.java
+++ b/src/freenet/node/NodePinger.java
@@ -3,6 +3,8 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.node;
 
+import static java.util.concurrent.TimeUnit.DAYS;
+
 import java.util.Arrays;
 
 import freenet.node.NodeStats.PeerLoadStats;
@@ -28,9 +30,9 @@ public class NodePinger implements Runnable {
 
 	private final Node node;
 	private volatile double meanPing = 0;
-	
-	public static final double CRAZY_MAX_PING_TIME = 365.25*24*60*60*1000;
-	
+
+	public static final double CRAZY_MAX_PING_TIME = 365.25 * DAYS.toMillis(1);
+
 	NodePinger(Node n) {
 		this.node = n;
 	}

--- a/src/freenet/node/NodeStarter.java
+++ b/src/freenet/node/NodeStarter.java
@@ -3,6 +3,8 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.node;
 
+import static java.util.concurrent.TimeUnit.MINUTES;
+
 import java.io.File;
 import java.io.IOException;
 
@@ -160,7 +162,7 @@ public class NodeStarter implements WrapperListener {
 				public void run() {
 					while(true) {
 						try {
-							Thread.sleep(60 * 60 * 1000);
+							Thread.sleep(MINUTES.toMillis(60));
 						} catch(InterruptedException e) {
 							// Ignore
 						} catch(Throwable t) {
@@ -304,7 +306,7 @@ public class NodeStarter implements WrapperListener {
 					public void run() {
 						while(true) {
 							try {
-								Thread.sleep(60 * 60 * 1000);
+								Thread.sleep(MINUTES.toMillis(60));
 							} catch(InterruptedException e) {
 								// Ignore
 							} catch(Throwable t) {

--- a/src/freenet/node/OpennetManager.java
+++ b/src/freenet/node/OpennetManager.java
@@ -3,6 +3,10 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.node;
 
+import static java.util.concurrent.TimeUnit.DAYS;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
@@ -98,27 +102,27 @@ public class OpennetManager {
 	/** Chance of resetting path folding (for plausible deniability) is 1 in this number. */
 	public static final int RESET_PATH_FOLDING_PROB = 20;
 	/** Don't re-add a node until it's been up and disconnected for at least this long */
-	public static final int DONT_READD_TIME = 60*1000;
+	public static final long DONT_READD_TIME = MINUTES.toMillis(1);
 	/** Don't drop a node until it's at least this old, if it's connected. */
-	public static final int DROP_MIN_AGE = 300*1000;
+	public static final long DROP_MIN_AGE = MINUTES.toMillis(5);
 	/** Don't drop a node until it's at least this old, if it's not connected (if it has connected once then DROP_DISCONNECT_DELAY applies, but only once an hour as below). Must be less than DROP_MIN_AGE.
 	 * Relatively generous because noderef transfers e.g. for announcement can be slow (Note
 	 * that announcements actually wait for previous transfers!). */
-	public static final int DROP_MIN_AGE_DISCONNECTED = 300*1000;
+	public static final long DROP_MIN_AGE_DISCONNECTED = MINUTES.toMillis(5);
 	/** Don't drop a node until this long after startup */
-	public static final int DROP_STARTUP_DELAY = 120*1000;
+	public static final long DROP_STARTUP_DELAY = MINUTES.toMillis(2);
 	/** Don't drop a node until this long after losing connection to it.
 	 * This should be long enough to cover a typical reboot, but not so long as to result in a lot
 	 * of disconnected nodes in the Strangers list. Also it should probably not be longer than DROP_MIN_AGE! */
-	public static final int DROP_DISCONNECT_DELAY = 5*60*1000;
+	public static final long DROP_DISCONNECT_DELAY = MINUTES.toMillis(5);
 	/** But if it has disconnected more than once in this period, allow it to be dropped anyway */
-	public static final int DROP_DISCONNECT_DELAY_COOLDOWN = 60*60*1000;
+	public static final long DROP_DISCONNECT_DELAY_COOLDOWN = MINUTES.toMillis(60);
 	/** Every DROP_CONNECTED_TIME, we may drop a peer even though it is connected.
 	 * This is per connection type, we should consider whether to reduce it further. */
-	public static final int DROP_CONNECTED_TIME = 5*60*1000;
+	public static final long DROP_CONNECTED_TIME = MINUTES.toMillis(5);
 	/** Minimum time between offers, if we have maximum peers. Less than the above limits,
 	 * since an offer may not be accepted. */
-	public static final int MIN_TIME_BETWEEN_OFFERS = 30*1000;
+	public static final long MIN_TIME_BETWEEN_OFFERS = SECONDS.toMillis(30);
 
 	private static volatile boolean logMINOR;
 
@@ -149,7 +153,7 @@ public class OpennetManager {
 	/** Maximum number of peers for purposes of FOAF attack/sanity check */
 	public static final int PANIC_MAX_PEERS = 110;
 	/** Stop trying to reconnect to an old-opennet-peer after a month. */
-	public static final long MAX_TIME_ON_OLD_OPENNET_PEERS = TimeUnit.DAYS.toMillis(31);
+	public static final long MAX_TIME_ON_OLD_OPENNET_PEERS = DAYS.toMillis(31);
 
 	// This is only relevant while the connection is in the grace period.
 	// Null means none of the above e.g. not in grace period.
@@ -1166,7 +1170,7 @@ public class OpennetManager {
 	}
 
 
-	private static final long MAX_AGE = 7 * 24 * 60 * 60 * 1000;
+	private static final long MAX_AGE = DAYS.toMillis(7);
 	private static final TimeSortedHashtable<String> knownIds = new TimeSortedHashtable<String>();
 
 	private static void registerKnownIdentity(String d) {

--- a/src/freenet/node/OpennetPeerNode.java
+++ b/src/freenet/node/OpennetPeerNode.java
@@ -1,5 +1,8 @@
 package freenet.node;
 
+import static java.util.concurrent.TimeUnit.HOURS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import freenet.io.comm.PeerParseException;
 import freenet.io.comm.ReferenceSignatureVerificationException;
 import freenet.node.OpennetManager.ConnectionType;
@@ -174,21 +177,21 @@ public class OpennetPeerNode extends PeerNode {
 	 * is in progress, but otherwise we should disconnect. */
 	private boolean shouldDisconnectTooOld() {
 		long uptime = System.currentTimeMillis() - timeLastConnectionCompleted();
-		if(uptime < 30*1000)
+		if(uptime < SECONDS.toMillis(30))
 			// Allow 30 seconds to send the UOM request.
 			return false;
 		// FIXME remove, paranoia
-		if(uptime < 60*60*1000)
+		if(uptime < HOURS.toMillis(1))
 			return false;
 		NodeUpdateManager updater = node.nodeUpdater;
 		if(updater == null) return true; // Not going to UOM.
 		UpdateOverMandatoryManager uom = updater.uom;
 		if(uom == null) return true; // Not going to UOM
-		if(uptime > 2*60*60*1000) {
+		if(uptime > HOURS.toMillis(2)) {
 			// UOM transfers can take ages, but there has to be some limit...
 			return true;
 		}
-		if(timeSinceSentUOM() < 60*1000) {
+		if(timeSinceSentUOM() < SECONDS.toMillis(60)) {
 			// Let it finish.
 			// 60 seconds extra to ensure it has time to parse the jar and start fetching dependencies.
 			return false;
@@ -199,7 +202,7 @@ public class OpennetPeerNode extends PeerNode {
 	@Override
 	protected void onConnect() {
 		super.onConnect();
-		opennet.crypto.socket.getAddressTracker().setPresumedGuiltyAt(System.currentTimeMillis()+60*60*1000);
+		opennet.crypto.socket.getAddressTracker().setPresumedGuiltyAt(System.currentTimeMillis() + HOURS.toMillis(1));
 	}
 	
 	private boolean wasDropped;

--- a/src/freenet/node/PeerManager.java
+++ b/src/freenet/node/PeerManager.java
@@ -3,6 +3,9 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.node;
 
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import java.io.BufferedReader;
 import java.io.EOFException;
 import java.io.File;
@@ -92,12 +95,12 @@ public class PeerManager {
 	/** Next time to update routableConnectionStats */
 	private long nextRoutableConnectionStatsUpdateTime = -1;
 	/** routableConnectionStats update interval (milliseconds) */
-	private static final long routableConnectionStatsUpdateInterval = 7 * 1000;  // 7 seconds
-	
+	private static final long routableConnectionStatsUpdateInterval = SECONDS.toMillis(7);
+
 	/** Should update the peer-file ? */
 	private volatile boolean shouldWritePeersDarknet = false;
 	private volatile boolean shouldWritePeersOpennet = false;
-	private static final int MIN_WRITEPEERS_DELAY = 5*60*1000; // 5 minutes. Urgent stuff calls write*PeersUrgent.
+	private static final long MIN_WRITEPEERS_DELAY = MINUTES.toMillis(5); // Urgent stuff calls write*PeersUrgent.
 	private final Runnable writePeersRunnable = new Runnable() {
 
 		@Override
@@ -619,7 +622,7 @@ public class PeerManager {
 	 * disconnect completes.
 	 * @param remove If true, remove the node from the routing table and tell the peer to do so.
 	 */
-	public void disconnect(final PeerNode pn, boolean sendDisconnectMessage, final boolean waitForAck, boolean purge, boolean dumpMessagesNow, final boolean remove, int timeout) {
+	public void disconnect(final PeerNode pn, boolean sendDisconnectMessage, final boolean waitForAck, boolean purge, boolean dumpMessagesNow, final boolean remove, long timeout) {
 		if(logMINOR)
 			Logger.minor(this, "Disconnecting " + pn.shortToString(), new Exception("debug"));
 		synchronized(this) {
@@ -878,7 +881,7 @@ public class PeerManager {
 	}
 
 	public PeerNode closerPeer(PeerNode pn, Set<PeerNode> routedTo, double loc, boolean ignoreSelf, boolean calculateMisrouting,
-	        int minVersion, List<Double> addUnpickedLocsTo, Key key, short outgoingHTL, int ignoreBackoffUnder, boolean isLocal, boolean realTime, boolean excludeMandatoryBackoff) {
+	        int minVersion, List<Double> addUnpickedLocsTo, Key key, short outgoingHTL, long ignoreBackoffUnder, boolean isLocal, boolean realTime, boolean excludeMandatoryBackoff) {
 		return closerPeer(pn, routedTo, loc, ignoreSelf, calculateMisrouting, minVersion, addUnpickedLocsTo, 2.0, key, outgoingHTL, ignoreBackoffUnder, isLocal, realTime, null, false, System.currentTimeMillis(), excludeMandatoryBackoff);
 	}
 
@@ -905,7 +908,7 @@ public class PeerManager {
 	 * wouldn't be a good idea due to introducing a round-trip-to-request-originator; FIXME consider this.
 	 */
 	public PeerNode closerPeer(PeerNode pn, Set<PeerNode> routedTo, double target, boolean ignoreSelf,
-	        boolean calculateMisrouting, int minVersion, List<Double> addUnpickedLocsTo, double maxDistance, Key key, short outgoingHTL, int ignoreBackoffUnder, boolean isLocal, boolean realTime,
+	        boolean calculateMisrouting, int minVersion, List<Double> addUnpickedLocsTo, double maxDistance, Key key, short outgoingHTL, long ignoreBackoffUnder, boolean isLocal, boolean realTime,
 	        RecentlyFailedReturn recentlyFailed, boolean ignoreTimeout, long now, boolean newLoadManagement) {
 		
 		int countWaiting = 0;
@@ -1709,7 +1712,7 @@ public class PeerManager {
 	 */
 	public void maybeLogPeerNodeStatusSummary(long now) {
 		if(now > nextPeerNodeStatusLogTime) {
-			if((now - nextPeerNodeStatusLogTime) > (10 * 1000) && nextPeerNodeStatusLogTime > 0)
+			if((now - nextPeerNodeStatusLogTime) > SECONDS.toMillis(10) && nextPeerNodeStatusLogTime > 0)
 				Logger.error(this, "maybeLogPeerNodeStatusSummary() not called for more than 10 seconds (" + (now - nextPeerNodeStatusLogTime) + ").  PacketSender getting bogged down or something?");
 
 			int numberOfConnected = 0;

--- a/src/freenet/node/PeerMessageQueue.java
+++ b/src/freenet/node/PeerMessageQueue.java
@@ -1,5 +1,7 @@
 package freenet.node;
 
+import static java.util.concurrent.TimeUnit.MINUTES;
+
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -42,13 +44,13 @@ public class PeerMessageQueue {
 	private class PrioQueue {
 		
 		// FIXME refactor into PrioQueue and RoundRobinByUIDPrioQueue
-		PrioQueue(int timeout, boolean timeoutSinceLastSend) {
+		PrioQueue(long timeout, boolean timeoutSinceLastSend) {
 			this.timeout = timeout;
 			this.roundRobinBetweenUIDs = timeoutSinceLastSend;
 		}
 		
 		/** The timeout, period after which messages become urgent. */
-		final int timeout;
+		final long timeout;
 		/** If true, do round-robin between UID's, and count the timeout relative
 		 * to the last send. Block transfers need this - both realtime and bulk. */
 		final boolean roundRobinBetweenUIDs;

--- a/src/freenet/node/PeerNodeStatus.java
+++ b/src/freenet/node/PeerNodeStatus.java
@@ -44,8 +44,8 @@ public class PeerNodeStatus {
 
 	private final int simpleVersion;
 
-	private final int routingBackoffLengthRT;
-	private final int routingBackoffLengthBulk;
+	private final long routingBackoffLengthRT;
+	private final long routingBackoffLengthBulk;
 
 	private final long routingBackedOffUntilRT;
 	private final long routingBackedOffUntilBulk;
@@ -351,7 +351,7 @@ public class PeerNodeStatus {
 	/**
 	 * @return the routingBackoffLength
 	 */
-	public int getRoutingBackoffLength(boolean realTime) {
+	public long getRoutingBackoffLength(boolean realTime) {
 		return realTime ? routingBackoffLengthRT : routingBackoffLengthBulk;
 	}
 

--- a/src/freenet/node/Persister.java
+++ b/src/freenet/node/Persister.java
@@ -1,5 +1,7 @@
 package freenet.node;
 
+import static java.util.concurrent.TimeUnit.MINUTES;
+
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
@@ -17,8 +19,8 @@ class Persister implements Runnable {
         static {
             Logger.registerClass(Persister.class);
         }
-        
-        static final int PERIOD = 900*1000;
+
+        static final long PERIOD = MINUTES.toMillis(15);
 
 	Persister(Persistable t, File persistTemp, File persistTarget, Ticker ps) {
 		this.persistable = t;

--- a/src/freenet/node/RequestScheduler.java
+++ b/src/freenet/node/RequestScheduler.java
@@ -3,6 +3,8 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.node;
 
+import static java.util.concurrent.TimeUnit.MINUTES;
+
 import com.db4o.ObjectContainer;
 
 import freenet.client.FECQueue;
@@ -23,7 +25,7 @@ public interface RequestScheduler {
 
 	/** Once a key has been requested a few times, don't request it again for 30 minutes. 
 	 * To do so would be pointless given ULPRs, and just waste bandwidth. */
-	public static final long COOLDOWN_PERIOD = 30*60*1000;
+	public static final long COOLDOWN_PERIOD = MINUTES.toMillis(30);
 	/** The number of times a key can be requested before triggering the cooldown period. 
 	 * Note: If you don't want your requests to be subject to cooldown (e.g. in fproxy), make 
 	 * your max retry count less than this (and more than -1). */

--- a/src/freenet/node/RequestSender.java
+++ b/src/freenet/node/RequestSender.java
@@ -3,6 +3,9 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.node;
 
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import java.util.ArrayList;
 
 import freenet.crypt.CryptFormatException;
@@ -58,13 +61,13 @@ import freenet.support.math.MedianMeanRunningAverage;
 public final class RequestSender extends BaseSender implements PrioRunnable {
 
     // Constants
-    static final int ACCEPTED_TIMEOUT = 10000;
+    static final long ACCEPTED_TIMEOUT = SECONDS.toMillis(10);
     // After a get offered key fails, wait this long for two stage timeout. Probably we will
     // have disconnected by then.
-    static final int GET_OFFER_LONG_TIMEOUT = 60*1000;
-    final int getOfferedTimeout;
+    static final long GET_OFFER_LONG_TIMEOUT = SECONDS.toMillis(60);
+    final long getOfferedTimeout;
     /** Wait up to this long to get a path folding reply */
-    static final int OPENNET_TIMEOUT = 120000;
+    static final long OPENNET_TIMEOUT = MINUTES.toMillis(2);
     /** One in this many successful requests is randomly reinserted.
      * This is probably a good idea anyway but with the split store it's essential. */
     static final int RANDOM_REINSERT_INTERVAL = 200;
@@ -393,11 +396,11 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
            	return;
         }
 	}
-    
-	private synchronized int timeSinceSentForTimeout() {
+
+	private synchronized long timeSinceSentForTimeout() {
     	int time = timeSinceSent();
     	if(time > FailureTable.REJECT_TIME) {
-    		if(time < searchTimeout + 10*1000) return FailureTable.REJECT_TIME;
+    		if(time < searchTimeout + SECONDS.toMillis(10)) return FailureTable.REJECT_TIME;
     		Logger.error(this, "Very long time since sent: "+time+" ("+TimeUtil.formatTime(time, 2, true)+")");
     		return FailureTable.REJECT_TIME;
     	}
@@ -664,7 +667,7 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
 		}
 	}
 
-	private MessageFilter getOfferedKeyReplyFilter(final PeerNode pn, int timeout) {
+	private MessageFilter getOfferedKeyReplyFilter(final PeerNode pn, long timeout) {
     	MessageFilter mfRO = MessageFilter.create().setSource(pn).setField(DMT.UID, uid).setTimeout(timeout).setType(DMT.FNPRejectedOverload);
     	MessageFilter mfGetInvalid = MessageFilter.create().setSource(pn).setField(DMT.UID, uid).setTimeout(timeout).setType(DMT.FNPGetOfferedKeyInvalid);
     	if(isSSK) {
@@ -923,7 +926,7 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
 
 	@Override
 	protected MessageFilter makeAcceptedRejectedFilter(PeerNode next,
-			int acceptedTimeout, UIDTag tag) {
+			long acceptedTimeout, UIDTag tag) {
 		assert(tag == origTag);
 		/**
 		 * What are we waiting for?
@@ -1235,7 +1238,7 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
 		if (msg.getBoolean(DMT.IS_LOCAL)) {
 			//NB: IS_LOCAL means it's terminal. not(IS_LOCAL) implies that the rejection message was forwarded from a downstream node.
 			//"Local" from our peers perspective, this has nothing to do with local requests (source==null)
-			int t = timeSinceSentForTimeout();
+			long t = timeSinceSentForTimeout();
     		node.failureTable.onFailed(key, next, htl, t, t);
 			next.localRejectedOverload("ForwardRejectedOverload2", realTimeFlag);
 			// Node in trouble suddenly??
@@ -1504,7 +1507,7 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
     	if(mask == WAIT_ALL) throw new IllegalArgumentException("Cannot ignore all!");
     	while(true) {
     	long now = System.currentTimeMillis();
-    	long deadline = now + (realTimeFlag ? 300 * 1000 : 1260 * 1000);
+    	long deadline = now + (realTimeFlag ? MINUTES.toMillis(3) : MINUTES.toMillis(21));
         while(true) {
         	short current = mask; // If any bits are set already, we ignore those states.
         	
@@ -2090,8 +2093,8 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
         }
         cb.schedule();
 	}
-	
-	protected int getAcceptedTimeout() {
+
+	protected long getAcceptedTimeout() {
 		return ACCEPTED_TIMEOUT;
 	}
 
@@ -2125,9 +2128,9 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
 		
 		final short htl = this.htl;
 		origTag.handlingTimeout(next);
-		
-		int timeout = 60*1000;
-		
+
+		long timeout = MINUTES.toMillis(1);
+
 		MessageFilter mf = makeAcceptedRejectedFilter(next, timeout, origTag);
 		try {
 			node.usm.addAsyncFilter(mf, new SlowAsyncMessageFilterCallback() {

--- a/src/freenet/node/RequestStarter.java
+++ b/src/freenet/node/RequestStarter.java
@@ -3,6 +3,9 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.node;
 
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import com.db4o.ObjectContainer;
 
 import freenet.client.async.ChosenBlock;
@@ -120,7 +123,7 @@ public class RequestStarter implements Runnable, RandomGrabArrayItemExclusionLis
 			// Allow 5 minutes before we start killing requests due to not connecting.
 			OpennetManager om;
 			if(core.node.peers.countConnectedPeers() < 3 && (om = core.node.getOpennet()) != null &&
-					System.currentTimeMillis() - om.getCreationTime() < 5*60*1000) {
+					System.currentTimeMillis() - om.getCreationTime() < MINUTES.toMillis(5)) {
 				try {
 					synchronized(this) {
 						wait(1000);
@@ -199,7 +202,7 @@ public class RequestStarter implements Runnable, RandomGrabArrayItemExclusionLis
 					req = sched.grabRequest();
 					if(req == null) {
 						try {
-							wait(1*1000); // this can happen when most but not all stuff is already running but there is still stuff to fetch, so don't wait *too* long.
+							wait(SECONDS.toMillis(1)); // this can happen when most but not all stuff is already running but there is still stuff to fetch, so don't wait *too* long.
 							// FIXME increase when we can be *sure* there is nothing left in the queue (especially for transient requests).
 						} catch (InterruptedException e) {
 							// Ignore

--- a/src/freenet/node/RequestStarterGroup.java
+++ b/src/freenet/node/RequestStarterGroup.java
@@ -3,6 +3,8 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.node;
 
+import static java.util.concurrent.TimeUnit.MINUTES;
+
 import com.db4o.ObjectContainer;
 
 import freenet.client.async.ClientContext;
@@ -194,7 +196,7 @@ public class RequestStarterGroup {
 		private final boolean realTime;
 
 		public MyRequestThrottle(int rtt, String string, SimpleFieldSet fs, int size, boolean realTime) {
-			roundTripTime = new BootstrappingDecayingRunningAverage(rtt, 10, 5*60*1000, 10, fs == null ? null : fs.subset("RoundTripTime"));
+			roundTripTime = new BootstrappingDecayingRunningAverage(rtt, 10, MINUTES.toMillis(5), 10, fs == null ? null : fs.subset("RoundTripTime"));
 			this.size = size;
 			this.realTime = realTime;
 		}

--- a/src/freenet/node/RequestTracker.java
+++ b/src/freenet/node/RequestTracker.java
@@ -1,5 +1,8 @@
 package freenet.node;
 
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -512,7 +515,7 @@ public class RequestTracker {
 
 	// Must include bulk inserts so fairly long.
 	// 21 minutes is enough for a fatal timeout.
-	static final int TIMEOUT = 21 * 60 * 1000;
+	static final long TIMEOUT = MINUTES.toMillis(21);
 
 	void startDeadUIDChecker() {
 		ticker.queueTimedJob(deadUIDChecker, TIMEOUT);
@@ -535,7 +538,7 @@ public class RequestTracker {
 				checkUIDs(runningSSKOfferReplyUIDsBulk);
 				checkUIDs(runningCHKOfferReplyUIDsBulk);
 			} finally {
-				ticker.queueTimedJob(this, 60*1000);
+				ticker.queueTimedJob(this, SECONDS.toMillis(60));
 			}
 		}
 

--- a/src/freenet/node/SSKInsertSender.java
+++ b/src/freenet/node/SSKInsertSender.java
@@ -3,6 +3,8 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.node;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import freenet.crypt.DSAPublicKey;
 import freenet.crypt.SHA256;
 import freenet.io.comm.AsyncMessageCallback;
@@ -32,7 +34,7 @@ import freenet.support.io.NativeThread;
 public class SSKInsertSender extends BaseSender implements PrioRunnable, AnyInsertSender, ByteCounter {
 
     // Constants
-    static final int ACCEPTED_TIMEOUT = 10000;
+    static final long ACCEPTED_TIMEOUT = SECONDS.toMillis(10);
 
     // Basics
     final NodeSSK myKey;
@@ -289,7 +291,7 @@ public class SSKInsertSender extends BaseSender implements PrioRunnable, AnyInse
     	NEXT_PEER
     }
 
-	private static final int TIMEOUT_AFTER_ACCEPTEDREJECTED_TIMEOUT = 60*1000;
+	private static final long TIMEOUT_AFTER_ACCEPTEDREJECTED_TIMEOUT = SECONDS.toMillis(60);
 
 	@Override
 	protected void handleAcceptedRejectedTimeout(final PeerNode next, final UIDTag tag) {
@@ -495,7 +497,7 @@ public class SSKInsertSender extends BaseSender implements PrioRunnable, AnyInse
 
 	@Override
 	protected MessageFilter makeAcceptedRejectedFilter(PeerNode next,
-			int acceptedTimeout, UIDTag tag) {
+			long acceptedTimeout, UIDTag tag) {
 		// Use the right UID here, in case we fork.
 		final long uid = tag.uid;
         /*
@@ -696,7 +698,7 @@ public class SSKInsertSender extends BaseSender implements PrioRunnable, AnyInse
 	}
 
 	@Override
-	protected int getAcceptedTimeout() {
+	protected long getAcceptedTimeout() {
 		return ACCEPTED_TIMEOUT;
 	}
 
@@ -867,7 +869,7 @@ public class SSKInsertSender extends BaseSender implements PrioRunnable, AnyInse
 	}
 
 	@Override
-	protected int ignoreLowBackoff() {
+	protected long ignoreLowBackoff() {
 		return ignoreLowBackoff ? Node.LOW_BACKOFF : 0;
 	}
 

--- a/src/freenet/node/SeedAnnounceTracker.java
+++ b/src/freenet/node/SeedAnnounceTracker.java
@@ -1,5 +1,7 @@
 package freenet.node;
 
+import static java.util.concurrent.TimeUnit.HOURS;
+
 import java.net.InetAddress;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -61,8 +63,8 @@ public class SeedAnnounceTracker {
 	
 	// Reset every 2 hours.
 	// FIXME implement something smoother.
-	static final long RESET_TIME = 2*60*60*1000;
-	
+	static final long RESET_TIME = HOURS.toMillis(2);
+
 	private long lastReset;
 
 	/** If the IP has had at least 5 noderefs, and is out of date, 80% chance of rejection.

--- a/src/freenet/node/SeedClientPeerNode.java
+++ b/src/freenet/node/SeedClientPeerNode.java
@@ -3,6 +3,9 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.node;
 
+import static java.util.concurrent.TimeUnit.HOURS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import freenet.io.comm.PeerParseException;
 import freenet.io.comm.ReferenceSignatureVerificationException;
 import freenet.support.SimpleFieldSet;
@@ -119,12 +122,12 @@ public class SeedClientPeerNode extends PeerNode {
 			// Synchronize to avoid messy races.
 			synchronized(this) {
 				if(timeLastConnectionCompleted() > 0 &&
-						System.currentTimeMillis() - lastReceivedPacketTime() > 60*1000)
+						System.currentTimeMillis() - lastReceivedPacketTime() > SECONDS.toMillis(60))
 				return true;
 			}
 		} else {
 			// Disconnect after an hour in any event.
-			if(System.currentTimeMillis() - timeLastConnectionCompleted() > 60*60*1000)
+			if(System.currentTimeMillis() - timeLastConnectionCompleted() > HOURS.toMillis(1))
 				return true;
 		}
 		return false;

--- a/src/freenet/node/SeedServerPeerNode.java
+++ b/src/freenet/node/SeedServerPeerNode.java
@@ -3,6 +3,9 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.node;
 
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import java.net.InetAddress;
 import java.util.ArrayList;
 
@@ -92,7 +95,7 @@ public class SeedServerPeerNode extends PeerNode {
 						Logger.error(this, "Caught "+t, t);
 					}
 				}
-			}, 5*1000);
+			}, SECONDS.toMillis(5));
 		}
 	}
 
@@ -140,7 +143,7 @@ public class SeedServerPeerNode extends PeerNode {
 		if(!om.announcer.enoughPeers()) return false;
 		// We have enough peers, but we might fluctuate a bit.
 		// Drop the connection once we have consistently had enough opennet peers for 5 minutes.
-		return System.currentTimeMillis() - om.announcer.timeGotEnoughPeers() > 5*60*1000;
+		return System.currentTimeMillis() - om.announcer.timeGotEnoughPeers() > MINUTES.toMillis(5);
 	}
 
 	@Override

--- a/src/freenet/node/SemiOrderedShutdownHook.java
+++ b/src/freenet/node/SemiOrderedShutdownHook.java
@@ -1,10 +1,12 @@
 package freenet.node;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import java.util.ArrayList;
 
 public class SemiOrderedShutdownHook extends Thread {
-	
-	private static final int TIMEOUT = 100*1000;
+
+	private static final long TIMEOUT = SECONDS.toMillis(100);
 	private final ArrayList<Thread> earlyJobs;
 	private final ArrayList<Thread> lateJobs;
 	

--- a/src/freenet/node/TextModeClientInterface.java
+++ b/src/freenet/node/TextModeClientInterface.java
@@ -1,5 +1,7 @@
 package freenet.node;
 
+import static java.util.concurrent.TimeUnit.MINUTES;
+
 import java.io.BufferedInputStream;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
@@ -956,7 +958,7 @@ public class TextModeClientInterface implements Runnable {
         } else if(uline.startsWith("PLUGLIST")) {
         	outsb.append(n.pluginManager.dumpPlugins());
         } else if(uline.startsWith("PLUGKILL:")) {
-        	n.pluginManager.killPlugin(line.substring("PLUGKILL:".length()).trim(), 60*1000, false);
+        	n.pluginManager.killPlugin(line.substring("PLUGKILL:".length()).trim(), MINUTES.toMillis(1), false);
         } else if(uline.startsWith("ANNOUNCE")) {
         	OpennetManager om = n.getOpennet();
         	if(om == null) {

--- a/src/freenet/node/UIDTag.java
+++ b/src/freenet/node/UIDTag.java
@@ -1,5 +1,7 @@
 package freenet.node;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import java.lang.ref.WeakReference;
 import java.util.HashSet;
 
@@ -380,7 +382,7 @@ public abstract class UIDTag {
 	}
 
 	private long loggedStillPresent;
-	private static final int LOGGED_STILL_PRESENT_INTERVAL = 60*1000;
+	private static final long LOGGED_STILL_PRESENT_INTERVAL = SECONDS.toMillis(60);
 
 	public void maybeLogStillPresent(long now, Long uid) {
 		if(now - createdTime > RequestTracker.TIMEOUT) {

--- a/src/freenet/node/UptimeEstimator.java
+++ b/src/freenet/node/UptimeEstimator.java
@@ -3,6 +3,8 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.node;
 
+import static java.util.concurrent.TimeUnit.MINUTES;
+
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.EOFException;
@@ -30,7 +32,7 @@ public class UptimeEstimator implements Runnable {
 	/**
 	 * Five minutes in milliseconds.
 	 */
-	static final int PERIOD = 5*60*1000;
+	static final long PERIOD = MINUTES.toMillis(5);
 
 	Ticker ticker;
 

--- a/src/freenet/node/probe/Probe.java
+++ b/src/freenet/node/probe/Probe.java
@@ -1,5 +1,8 @@
 package freenet.node.probe;
 
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import freenet.config.InvalidConfigValueException;
 import freenet.config.NodeNeedRestartException;
 import freenet.config.SubConfig;
@@ -74,29 +77,24 @@ public class Probe implements ByteCounter {
 	/**
 	 * In ms, per HTL above HTL = 1.
 	 */
-	public static final int TIMEOUT_PER_HTL = 3000;
+	public static final long TIMEOUT_PER_HTL = SECONDS.toMillis(3);
 
 	/**
 	 * In ms, to account for probabilistic decrement at HTL = 1.
 	 */
-	public static final int TIMEOUT_HTL1 = (int)(TIMEOUT_PER_HTL / DECREMENT_PROBABILITY);
-
-	/**
-	 * Minute in milliseconds.
-	 */
-	private static final long MINUTE = 60 * 1000;
+	public static final long TIMEOUT_HTL1 = (long) (TIMEOUT_PER_HTL / DECREMENT_PROBABILITY);
 
 	/**
 	 * To make the timing less obvious when a node responds with a local result instead of forwarding at
 	 * HTL = 1, delay for a number of milliseconds, specifically an exponential distribution with this constant as
 	 * its mean.
 	 */
-	public static final long WAIT_BASE = 1000L;
+	public static final long WAIT_BASE = SECONDS.toMillis(1);
 
 	/**
 	 * Maximum number of milliseconds to wait before sending a response.
 	 */
-	public static final long WAIT_MAX = 2000L;
+	public static final long WAIT_MAX = SECONDS.toMillis(2);
 
 	/**
 	 * Maximum number of probes accepted from a single peer in the past minute.
@@ -438,7 +436,7 @@ public class Probe implements ByteCounter {
 			return;
 		}
 		//One-minute window on acceptance; free up this probe slot in 60 seconds.
-		timer.schedule(task, MINUTE);
+		timer.schedule(task, MINUTES.toMillis(1));
 
 		/*
 		 * Route to a peer, using Metropolis-Hastings correction and ignoring backoff to get a more uniform
@@ -552,7 +550,7 @@ public class Probe implements ByteCounter {
 	 * @return filter for the requested result type, probe error, and probe refusal.
 	 */
 	private static MessageFilter createResponseFilter(final Type type, final PeerNode candidate, final long uid, final byte htl) {
-		final int timeout = (htl - 1) * TIMEOUT_PER_HTL + TIMEOUT_HTL1;
+		final long timeout = (htl - 1) * TIMEOUT_PER_HTL + TIMEOUT_HTL1;
 		final MessageFilter filter = createFilter(candidate, uid, timeout);
 
 		switch (type) {
@@ -576,7 +574,7 @@ public class Probe implements ByteCounter {
 		return filter;
 	}
 
-	private static MessageFilter createFilter(final PeerNode source, final long uid, final int timeout) {
+	private static MessageFilter createFilter(final PeerNode source, final long uid, final long timeout) {
 		return MessageFilter.create().setSource(source).setField(DMT.UID, uid).setTimeout(timeout);
 	}
 

--- a/src/freenet/node/simulator/LongTermMHKTest.java
+++ b/src/freenet/node/simulator/LongTermMHKTest.java
@@ -1,5 +1,7 @@
 package freenet.node.simulator;
 
+import static java.util.concurrent.TimeUnit.HOURS;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -280,7 +282,7 @@ public class LongTermMHKTest extends LongTermTest {
 					linesNoURL++;
 					continue;
 				}
-				if(Math.abs(target.getTimeInMillis() - calendar.getTimeInMillis()) < 12*60*60*1000) {
+				if(Math.abs(target.getTimeInMillis() - calendar.getTimeInMillis()) < HOURS.toMillis(12)) {
 					System.out.println("Found row for target date "+dateFormat.format(target.getTime())+" : "+dateFormat.format(calendar.getTime()));
 					System.out.println("Version: "+split[1]);
 					match = true;

--- a/src/freenet/node/simulator/LongTermManySingleBlocksTest.java
+++ b/src/freenet/node/simulator/LongTermManySingleBlocksTest.java
@@ -1,5 +1,7 @@
 package freenet.node.simulator;
 
+import static java.util.concurrent.TimeUnit.HOURS;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -349,7 +351,7 @@ loopOverLines:
 					System.out.println("Key insert "+i+" : "+insertedURIs[i]+" in "+insertTimes[i]);
 				}
 				for(int i=0;i<targets.length;i++) {
-					if(Math.abs(targets[i].getTimeInMillis() - calendar.getTimeInMillis()) < 12*60*60*1000) {
+					if(Math.abs(targets[i].getTimeInMillis() - calendar.getTimeInMillis()) < HOURS.toMillis(12)) {
 						System.out.println("Found row for target date "+((1<<i)-1)+" days ago.");
 						System.out.println("Version: "+split[1]);
 						csvLine.add(Integer.toString(i));

--- a/src/freenet/node/simulator/LongTermPushPullTest.java
+++ b/src/freenet/node/simulator/LongTermPushPullTest.java
@@ -1,5 +1,8 @@
 package freenet.node.simulator;
 
+import static java.util.concurrent.TimeUnit.DAYS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -255,7 +258,7 @@ public class LongTermPushPullTest extends LongTermTest {
 			if(prevDate != null) {
 				long now = calendar.getTimeInMillis();
 				long prev = prevDate.getTimeInMillis();
-				long dist = (now - prev) / (24 * 60 * 60 * 1000);
+				long dist = DAYS.convert(now - prev, MILLISECONDS);
 				if(dist != 1) System.out.println(""+dist+" days since last report");
 			}
 			prevDate = calendar;

--- a/src/freenet/node/simulator/RealNodeBusyNetworkTest.java
+++ b/src/freenet/node/simulator/RealNodeBusyNetworkTest.java
@@ -3,6 +3,8 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.node.simulator;
 
+import static java.util.concurrent.TimeUnit.DAYS;
+
 import java.io.File;
 import java.io.UnsupportedEncodingException;
 
@@ -149,7 +151,7 @@ public class RealNodeBusyNetworkTest extends RealNodeRoutingTest {
         	ClientCHK key = keys[i];
         	System.err.println("Queueing requests for "+i+" of "+INSERT_KEYS);
         	for(int j=0;j<nodes.length;j++) {
-        		clients[j].prefetch(key.getURI(), 24*60*60*1000, 32768, null);
+        		clients[j].prefetch(key.getURI(), DAYS.toMillis(1), 32768, null);
         	}
         	long totalRunningRequests = 0;
         	for(int j=0;j<nodes.length;j++) {

--- a/src/freenet/node/simulator/SeednodePingTest.java
+++ b/src/freenet/node/simulator/SeednodePingTest.java
@@ -3,6 +3,10 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.node.simulator;
 
+import static java.util.concurrent.TimeUnit.DAYS;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -42,7 +46,7 @@ import freenet.support.LoggerHook.InvalidThresholdException;
 public class SeednodePingTest extends RealNodeTest {
 
 	static File STATUS_DIR = new File("/var/www/freenet/tests/seednodes/status/");
-	static final long COUNT_SUCCESSES_PERIOD = 7*24*60*60*1000; // 1 week
+	static final long COUNT_SUCCESSES_PERIOD = DAYS.toMillis(7);
 
 	static final int DARKNET_PORT = RealNodeULPRTest.DARKNET_PORT_END;
 	static final int OPENNET_PORT = DARKNET_PORT+1;
@@ -74,14 +78,14 @@ public class SeednodePingTest extends RealNodeTest {
         node.start(true);
 	//Logger.setupStdoutLogging(LogLevel.MINOR, "freenet:NORMAL,freenet.node.NodeDispatcher:MINOR,freenet.node.FNPPacketMangler:MINOR");
 	Logger.getChain().setThreshold(LogLevel.ERROR); // kill logging
-	Thread.sleep(2000);
+	Thread.sleep(SECONDS.toMillis(2));
 	if(seedNodes.size() != numberOfNodesInTheFile)
 		    System.out.println("ERROR ADDING SOME OF THE SEEDNODES!!");
 	System.out.println("Let some time for the "+ seedNodes.size() +" nodes to connect...");
-	Thread.sleep(8000);
+	Thread.sleep(SECONDS.toMillis(8));
 
 	int pingID = 0;
-	long deadline = System.currentTimeMillis() + 2*60*1000;
+	long deadline = System.currentTimeMillis() + MINUTES.toMillis(2);
 	while(System.currentTimeMillis() < deadline) {
 		int countConnectedSeednodes = 0;
 		for(SeedServerPeerNode seednode : node.peers.getConnectedSeedServerPeersVector(null)) {
@@ -122,7 +126,7 @@ public class SeednodePingTest extends RealNodeTest {
 			System.out.println(fate + " : "+totals.get(fate));
 		}
 		System.out.println("################## ("+node.peers.countConnectedPeers()+") "+countConnectedSeednodes+'/'+node.peers.countSeednodes());
-		Thread.sleep(5000);
+		Thread.sleep(SECONDS.toMillis(5));
 	}
 	Map<FATE, Integer> totals = new EnumMap<FATE, Integer>(SeedServerTestPeerNode.FATE.class);
 	for(SeedServerTestPeerNode seednode : seedNodes) {

--- a/src/freenet/node/updater/NodeUpdateManager.java
+++ b/src/freenet/node/updater/NodeUpdateManager.java
@@ -1,5 +1,10 @@
 package freenet.node.updater;
 
+import static java.util.concurrent.TimeUnit.DAYS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -427,9 +432,7 @@ public class NodeUpdateManager {
 										+ filename
 										+ " after fetching it from Freenet.");
 						try {
-							Thread.sleep(1000 + node.fastWeakRandom
-									.nextInt(((int) (1000 * Math.min(
-											Math.pow(2, i), 15 * 60 * 1000)))));
+							Thread.sleep(SECONDS.toMillis(1) + node.fastWeakRandom.nextInt((int) SECONDS.toMillis((long) Math.min(Math.pow(2, i), MINUTES.toSeconds(15)))));
 						} catch (InterruptedException e) {
 							// Ignore
 						}
@@ -912,8 +915,8 @@ public class NodeUpdateManager {
 		deployOffThread(0, false);
 	}
 
-	private static final int WAIT_FOR_SECOND_FETCH_TO_COMPLETE = 240 * 1000;
-	private static final int RECENT_REVOCATION_INTERVAL = 120 * 1000;
+	private static final long WAIT_FOR_SECOND_FETCH_TO_COMPLETE = MINUTES.toMillis(4);
+	private static final long RECENT_REVOCATION_INTERVAL = MINUTES.toMillis(2);
 	/**
 	 * After 5 minutes, deploy the update even if we haven't got 3 DNFs on the
 	 * revocation key yet. Reason: we want to be able to deploy UOM updates on
@@ -921,7 +924,7 @@ public class NodeUpdateManager {
 	 * Note that with UOM, revocation certs are automatically propagated node to
 	 * node, so this should be *relatively* safe. Any better ideas, tell us.
 	 */
-	private static final int REVOCATION_FETCH_TIMEOUT = 5 * 60 * 1000;
+	private static final long REVOCATION_FETCH_TIMEOUT = MINUTES.toMillis(5);
 
 	/**
 	 * Does the updater have an update ready to deploy? May be called
@@ -997,7 +1000,7 @@ public class NodeUpdateManager {
 				Logger.minor(this, "Returning true because of ignoreRevocation");
 			return true;
 		}
-		int waitTime = Math.max(REVOCATION_FETCH_TIMEOUT, waitForNextJar);
+		long waitTime = Math.max(REVOCATION_FETCH_TIMEOUT, waitForNextJar);
 		if(logMINOR) Logger.minor(this, "Will deploy in "+waitTime+"ms");
 		deployOffThread(waitTime, false);
 		return false;
@@ -1309,7 +1312,7 @@ public class NodeUpdateManager {
 			Logger.minor(this, "Restarting...");
 		node.getNodeStarter().restart();
 		try {
-			Thread.sleep(5 * 60 * 1000);
+			Thread.sleep(MINUTES.toMillis(5));
 		} catch (InterruptedException e) {
 			// Break
 		} // in case it's still restarting
@@ -1476,7 +1479,7 @@ public class NodeUpdateManager {
 			public void run() {
 				revocationChecker.start(false);
 			}
-		}, node.random.nextInt(24 * 60 * 60 * 1000));
+		}, node.random.nextInt((int) DAYS.toMillis(1)));
 	}
 
 	private void deployPluginUpdates() {
@@ -1820,7 +1823,7 @@ public class NodeUpdateManager {
 			// We are a seednode.
 			// Normally this means we won't send UOM.
 			// However, if something breaks severely, we need an escape route.
-			if (node.getUptime() > 5 * 60 * 1000
+			if (node.getUptime() > MINUTES.toMillis(5)
 					&& node.peers.countCompatibleRealPeers() == 0)
 				return false;
 			return true;

--- a/src/freenet/node/updater/NodeUpdater.java
+++ b/src/freenet/node/updater/NodeUpdater.java
@@ -1,5 +1,8 @@
 package freenet.node.updater;
 
+import static java.util.concurrent.TimeUnit.HOURS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
@@ -159,7 +162,7 @@ public abstract class NodeUpdater implements ClientGetCallback, USKCallback, Req
 			public void run() {
 				maybeUpdate();
 			}
-		}, 60 * 1000); // leave some time in case we get later editions
+		}, SECONDS.toMillis(60)); // leave some time in case we get later editions
 		// LOCKING: Always take the NodeUpdater lock *BEFORE* the NodeUpdateManager lock
 		if(found <= currentVersion) {
 			System.err.println("Cancelling fetch for "+found+": not newer than current version "+currentVersion);
@@ -453,7 +456,7 @@ public abstract class NodeUpdater implements ClientGetCallback, USKCallback, Req
 					public void run() {
 						maybeUpdate();
 					}
-				}, 60 * 60 * 1000);
+				}, HOURS.toMillis(1));
 		}
 	}
 

--- a/src/freenet/node/updater/RevocationChecker.java
+++ b/src/freenet/node/updater/RevocationChecker.java
@@ -1,5 +1,7 @@
 package freenet.node.updater;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -319,8 +321,8 @@ public class RevocationChecker implements ClientGetCallback, RequestClient {
 					public void run() {
 						start(wasAggressive, false);
 					}
-					
-				}, 1*1000);
+
+				}, SECONDS.toMillis(1));
 			} else {
 				start(wasAggressive, false);
 			}

--- a/src/freenet/node/updater/UpdateOverMandatoryManager.java
+++ b/src/freenet/node/updater/UpdateOverMandatoryManager.java
@@ -3,6 +3,9 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.node.updater;
 
+import static java.util.concurrent.TimeUnit.HOURS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import java.io.BufferedInputStream;
 import java.io.DataInputStream;
 import java.io.EOFException;
@@ -107,9 +110,9 @@ public class UpdateOverMandatoryManager implements RequestClient {
 	// 2 for reliability, no more as gets very slow/wasteful
 	static final int MAX_NODES_SENDING_JAR = 2;
 	/** Maximum time between asking for the main jar and it starting to transfer */
-	static final int REQUEST_MAIN_JAR_TIMEOUT = 60 * 1000;
+	static final long REQUEST_MAIN_JAR_TIMEOUT = SECONDS.toMillis(60);
 	//** Grace time before we use UoM to update */
-	public static final int GRACE_TIME = 3 * 60 * 60 * 1000; // 3h
+	public static final long GRACE_TIME = HOURS.toMillis(3);
 	private UserAlert alert;
 	private static final Pattern mainBuildNumberPattern = Pattern.compile("^main(?:-jar)?-(\\d+)\\.fblob$");
 	private static final Pattern mainTempBuildNumberPattern = Pattern.compile("^main(?:-jar)?-(\\d+-)?(\\d+)\\.fblob\\.tmp*$");
@@ -304,8 +307,8 @@ public class UpdateOverMandatoryManager implements RequestClient {
 				System.err.println("Peer "+source+" (build #" + source.getSimpleVersion() + ") said that the auto-update key had been blown, but did not transfer the revocation certificate. The most likely explanation is that the key has not been blown (the node is buggy or malicious), so we are ignoring this.");
 				maybeNotRevoked();
 			}
-			
-		}, 60*1000);
+
+		}, SECONDS.toMillis(60));
 
 	// The reply message will start the transfer. It includes the revocation URI
 	// so we can tell if anything wierd is happening.

--- a/src/freenet/node/useralerts/IPUndetectedUserAlert.java
+++ b/src/freenet/node/useralerts/IPUndetectedUserAlert.java
@@ -3,6 +3,8 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.node.useralerts;
 
+import static java.util.concurrent.TimeUnit.MINUTES;
+
 import freenet.config.Option;
 import freenet.config.SubConfig;
 import freenet.l10n.NodeL10n;
@@ -49,7 +51,7 @@ public class IPUndetectedUserAlert extends AbstractUserAlert {
 	public boolean isValid() {
 		if(node.isOpennetEnabled())
 			return false;
-		if(node.peers.countConnectiblePeers() >= 5 && (node.getUptime() < 60*1000 || node.ipDetector.isDetecting()))
+		if(node.peers.countConnectiblePeers() >= 5 && (node.getUptime() < MINUTES.toMillis(1) || node.ipDetector.isDetecting()))
 			return false;
 		return true;
 	}

--- a/src/freenet/node/useralerts/PeerManagerUserAlert.java
+++ b/src/freenet/node/useralerts/PeerManagerUserAlert.java
@@ -3,6 +3,8 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.node.useralerts;
 
+import static java.util.concurrent.TimeUnit.DAYS;
+
 import freenet.l10n.NodeL10n;
 import freenet.node.NodeStats;
 import freenet.node.PeerManager;
@@ -55,8 +57,8 @@ public class PeerManagerUserAlert extends AbstractUserAlert {
 	public static final int MIN_CONN_ERROR_ALERT_THRESHOLD = 5;
 	
 	/** How high can oldestNeverConnectedPeerAge be before we alert (in milliseconds)*/
-	public static final long MAX_OLDEST_NEVER_CONNECTED_PEER_AGE_ALERT_THRESHOLD = ((long) 2)*7*24*60*60*1000;  // 2 weeks
-	
+	public static final long MAX_OLDEST_NEVER_CONNECTED_PEER_AGE_ALERT_THRESHOLD = DAYS.toMillis(14); // 2 weeks
+
 	public PeerManagerUserAlert(NodeStats n, NodeUpdateManager nodeUpdater) {
 		super(false, null, null, null, null, (short) 0, true, NodeL10n.getBase().getString("UserAlert.hide"), false, null);
 		this.n = n;

--- a/src/freenet/pluginmanager/PluginInfoWrapper.java
+++ b/src/freenet/pluginmanager/PluginInfoWrapper.java
@@ -142,10 +142,8 @@ public class PluginInfoWrapper implements Comparable<PluginInfoWrapper> {
 			stopping = true;
 		}
 	}
-	
-	
-	
-	public boolean finishShutdownPlugin(PluginManager manager, int maxWaitTime, boolean reloading) {
+
+	public boolean finishShutdownPlugin(PluginManager manager, long maxWaitTime, boolean reloading) {
 		boolean success = true;
 		if(thread != null) {
 			thread.interrupt();
@@ -182,7 +180,7 @@ public class PluginInfoWrapper implements Comparable<PluginInfoWrapper> {
 	 * terminate. Set to -1 if you don't want to wait at all, 0 to wait forever
 	 * or else a value in milliseconds.
 	 **/
-	public void stopPlugin(PluginManager manager, int maxWaitTime, boolean reloading) {
+	public void stopPlugin(PluginManager manager, long maxWaitTime, boolean reloading) {
 		startShutdownPlugin(manager, reloading);
 		finishShutdownPlugin(manager, maxWaitTime, reloading);
 		// always remove plugin

--- a/src/freenet/pluginmanager/PluginManager.java
+++ b/src/freenet/pluginmanager/PluginManager.java
@@ -3,6 +3,8 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.pluginmanager;
 
+import static java.util.concurrent.TimeUnit.MINUTES;
+
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileFilter;
@@ -242,7 +244,7 @@ public class PluginManager {
 		}
 	}
 
-	public void stop(int maxWaitTime) {
+	public void stop(long maxWaitTime) {
 		// Stop loading plugins.
 		ArrayList<PluginProgress> matches = new ArrayList<PluginProgress>();
 		synchronized(this) {
@@ -965,7 +967,7 @@ public class PluginManager {
 		throw new NotFoundPluginHTTPException("Plugin '"+plugin+"' not found!", "/plugins");
 	}
 
-	public void killPlugin(String name, int maxWaitTime, boolean reloading) {
+	public void killPlugin(String name, long maxWaitTime, boolean reloading) {
 		PluginInfoWrapper pi = null;
 		boolean found = false;
 		synchronized(pluginWrappers) {
@@ -981,7 +983,7 @@ public class PluginManager {
 			pi.stopPlugin(this, maxWaitTime, reloading);
 	}
 
-	public void killPluginByFilename(String name, int maxWaitTime, boolean reloading) {
+	public void killPluginByFilename(String name, long maxWaitTime, boolean reloading) {
 		PluginInfoWrapper pi = null;
 		boolean found = false;
 		synchronized(pluginWrappers) {
@@ -997,7 +999,7 @@ public class PluginManager {
 			pi.stopPlugin(this, maxWaitTime, reloading);
 	}
 
-	public void killPluginByClass(String name, int maxWaitTime) {
+	public void killPluginByClass(String name, long maxWaitTime) {
 		PluginInfoWrapper pi = null;
 		boolean found = false;
 		synchronized(pluginWrappers) {
@@ -1013,7 +1015,7 @@ public class PluginManager {
 			pi.stopPlugin(this, maxWaitTime, false);
 	}
 
-	public void killPlugin(FredPlugin plugin, int maxWaitTime) {
+	public void killPlugin(FredPlugin plugin, long maxWaitTime) {
 		PluginInfoWrapper pi = null;
 		boolean found = false;
 		synchronized(pluginWrappers) {
@@ -1260,7 +1262,7 @@ public class PluginManager {
 				try {
 					downloaded = true;
 					System.err.println("Downloading plugin "+name);
-					WrapperManager.signalStarting(5*60*1000);
+					WrapperManager.signalStarting((int) MINUTES.toMillis(5));
 					File tempPluginFile = null;
 					OutputStream pluginOutputStream = null;
 					InputStream pluginInputStream = null;

--- a/src/freenet/store/saltedhash/SaltedHashFreenetStore.java
+++ b/src/freenet/store/saltedhash/SaltedHashFreenetStore.java
@@ -3,6 +3,9 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.store.saltedhash;
 
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import java.io.EOFException;
 import java.io.File;
 import java.io.IOException;
@@ -1102,7 +1105,7 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
 						random.nextBytes(seed);
 						mt = new MersenneTwister(seed);
 						if (starting) {
-							WrapperManager.signalStarting(5*60*1000);
+							WrapperManager.signalStarting((int) MINUTES.toMillis(5));
 							if ( x++ % 32 == 0 )
 								System.err.println("Preallocating space for " + name + ": " + currentHdLen + "/" + newHdLen);
 						}
@@ -1424,7 +1427,7 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
 						configLock.writeLock().unlock();
 					}
 
-					WrapperManager.signalStarting(RESIZE_MEMORY_ENTRIES * 30 * 1000 + 1000);
+					WrapperManager.signalStarting((int) (RESIZE_MEMORY_ENTRIES * SECONDS.toMillis(30) + SECONDS.toMillis(1)));
 				}
 
 				@Override
@@ -1466,7 +1469,7 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
 				int i = 0;
 				@Override
 				public boolean batch(long entriesLeft) {
-					WrapperManager.signalStarting(RESIZE_MEMORY_ENTRIES * 30 * 1000 + 1000);
+					WrapperManager.signalStarting((int) (RESIZE_MEMORY_ENTRIES * SECONDS.toMillis(30) + SECONDS.toMillis(1)));
 
 					if (i++ % 16 == 0)
 						writeConfigFile();
@@ -1536,8 +1539,8 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
 					} finally {
 						configLock.writeLock().unlock();
 					}
-					
-					WrapperManager.signalStarting(RESIZE_MEMORY_ENTRIES * 5 * 1000 + 1000);
+
+					WrapperManager.signalStarting((int) (RESIZE_MEMORY_ENTRIES * SECONDS.toMillis(5) + SECONDS.toMillis(1)));
 				}
 				
 				@Override
@@ -1564,7 +1567,7 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
 				int i = 0;
 				@Override
 				public boolean batch(long entriesLeft) {
-					WrapperManager.signalStarting(RESIZE_MEMORY_ENTRIES * 5 * 1000 + 1000);
+					WrapperManager.signalStarting((int) (RESIZE_MEMORY_ENTRIES * SECONDS.toMillis(5) + SECONDS.toMillis(1)));
 
 					if (i++ % 16 == 0)
 						writeConfigFile();

--- a/src/freenet/support/FileLoggerHook.java
+++ b/src/freenet/support/FileLoggerHook.java
@@ -1,5 +1,7 @@
 package freenet.support;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import java.io.BufferedOutputStream;
 import java.io.Closeable;
 import java.io.DataInputStream;
@@ -1082,7 +1084,7 @@ public class FileLoggerHook extends LoggerHook implements Closeable {
 		public void run() {
 			synchronized(list) {
 				closed = true;
-				long deadline = System.currentTimeMillis() + 10*1000;
+				long deadline = System.currentTimeMillis() + SECONDS.toMillis(10);
 				while(!closedFinished) {
 					int wait = (int) (deadline - System.currentTimeMillis());
 					if(wait <= 0) return;

--- a/src/freenet/support/PooledExecutor.java
+++ b/src/freenet/support/PooledExecutor.java
@@ -3,6 +3,8 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.support;
 
+import static java.util.concurrent.TimeUnit.MINUTES;
+
 import java.util.ArrayList;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -43,7 +45,7 @@ public class PooledExecutor implements Executor {
 		waitingThreadsCount = 0;
 	}
 	/** Maximum time a thread will wait for a job */
-	static final int TIMEOUT = 1 * 60 * 1000;
+	static final long TIMEOUT = MINUTES.toMillis(1);
 
 	public void start() {
 		logMINOR = Logger.shouldLog(LogLevel.MINOR, this);

--- a/src/freenet/support/PrioritizedSerialExecutor.java
+++ b/src/freenet/support/PrioritizedSerialExecutor.java
@@ -1,5 +1,7 @@
 package freenet.support;
 
+import static java.util.concurrent.TimeUnit.MINUTES;
+
 import java.util.ArrayDeque;
 
 import freenet.node.NodeStats;
@@ -30,8 +32,8 @@ public class PrioritizedSerialExecutor implements Executor {
 	private boolean running;
 	private final ExecutorIdleCallback callback;
 
-	private static final int DEFAULT_JOB_TIMEOUT = 5*60*1000;
-	private final int jobTimeout;
+	private static final long DEFAULT_JOB_TIMEOUT = MINUTES.toMillis(5);
+	private final long jobTimeout;
 
 	private final Runner runner = new Runner();
 	
@@ -148,7 +150,7 @@ public class PrioritizedSerialExecutor implements Executor {
 	 * @param defaultPriority
 	 * @param invertOrder Set if the priorities are thread priorities. Unset if they are request priorities. D'oh!
 	 */
-	public PrioritizedSerialExecutor(int priority, int internalPriorityCount, int defaultPriority, boolean invertOrder, int jobTimeout, ExecutorIdleCallback callback, NodeStats statistics) {
+	public PrioritizedSerialExecutor(int priority, int internalPriorityCount, int defaultPriority, boolean invertOrder, long jobTimeout, ExecutorIdleCallback callback, NodeStats statistics) {
 		@SuppressWarnings("unchecked") ArrayDeque<Runnable>[] jobs = new ArrayDeque[internalPriorityCount];
 		for (int i=0;i<jobs.length;i++) {
 			jobs[i] = new ArrayDeque<Runnable>();

--- a/src/freenet/support/RandomGrabArray.java
+++ b/src/freenet/support/RandomGrabArray.java
@@ -1,5 +1,7 @@
 package freenet.support;
 
+import static java.util.concurrent.TimeUnit.MINUTES;
+
 import java.util.Arrays;
 
 import org.tanukisoftware.wrapper.WrapperManager;
@@ -693,7 +695,7 @@ public class RandomGrabArray implements RemoveRandom, HasCooldownCacheItem {
 	// At present it is only called on startup so this is okay.
 	public void moveElementsTo(RandomGrabArray existingGrabber,
 			ObjectContainer container, boolean canCommit) {
-		WrapperManager.signalStarting(5*60*1000);
+		WrapperManager.signalStarting((int) MINUTES.toMillis(5));
 		for(Block block: blocks) {
 			if(persistent) container.activate(block, 1);
 			for(int j=0;j<block.reqs.length;j++) {

--- a/src/freenet/support/SerialExecutor.java
+++ b/src/freenet/support/SerialExecutor.java
@@ -1,5 +1,7 @@
 package freenet.support;
 
+import static java.util.concurrent.TimeUnit.MINUTES;
+
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
@@ -30,8 +32,8 @@ public class SerialExecutor implements Executor {
 	private String name;
 	private Executor realExecutor;
 
-	private static final int NEWJOB_TIMEOUT = 5*60*1000;
-	
+	private static final long NEWJOB_TIMEOUT = MINUTES.toMillis(5);
+
 	private Thread runningThread;
 
 	private final Runnable runner = new PrioRunnable() {

--- a/src/freenet/support/TimeUtil.java
+++ b/src/freenet/support/TimeUtil.java
@@ -18,6 +18,12 @@
 
 package freenet.support;
 
+import static java.util.concurrent.TimeUnit.DAYS;
+import static java.util.concurrent.TimeUnit.HOURS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import java.text.DecimalFormat;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
@@ -65,41 +71,41 @@ public class TimeUtil {
             return sb.toString();
         }
         //
-        long weeks = (l / (7L*24*60*60*1000));
-        if (weeks > 0) {
+		long weeks = DAYS.convert(l, MILLISECONDS) / 7;
+		if (weeks > 0) {
             sb.append(weeks).append('w');
             termCount++;
-            l = l - (weeks * (7L*24*60*60*1000));
+            l = l - DAYS.toMillis(7 * weeks);
         }
         if(termCount >= maxTerms) {
             return sb.toString();
         }
         //
-        long days = (l / (24L*60*60*1000));
+        long days = DAYS.convert(l, MILLISECONDS);
         if (days > 0) {
             sb.append(days).append('d');
             termCount++;
-            l = l - (days * (24L*60*60*1000));
+            l = l - DAYS.toMillis(days);
         }
         if(termCount >= maxTerms) {
           return sb.toString();
         }
         //
-        long hours = (l / (60L*60*1000));
+        long hours = HOURS.convert(l, MILLISECONDS);
         if (hours > 0) {
             sb.append(hours).append('h');
             termCount++;
-            l = l - (hours * (60L*60*1000));
+            l = l - HOURS.toMillis(hours);
         }
         if(termCount >= maxTerms) {
             return sb.toString();
         }
         //
-        long minutes = (l / (60L*1000));
+        long minutes = MINUTES.convert(l, MILLISECONDS);
         if (minutes > 0) {
             sb.append(minutes).append('m');
             termCount++;
-            l = l - (minutes * (60L*1000));
+            l = l - MINUTES.toMillis(minutes);
         }
         if(termCount >= maxTerms) {
             return sb.toString();
@@ -113,7 +119,7 @@ public class TimeUtil {
                 //l = l - ((long)fractionalSeconds * (long)1000);
             }
         } else {
-            long seconds = (l / 1000L);
+            long seconds = SECONDS.convert(l, MILLISECONDS);
             if (seconds > 0) {
                 sb.append(seconds).append('s');
                 termCount++;

--- a/src/freenet/support/TokenBucket.java
+++ b/src/freenet/support/TokenBucket.java
@@ -1,5 +1,8 @@
 package freenet.support;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
 import freenet.support.Logger.LogLevel;
 
 /**
@@ -31,7 +34,7 @@ public class TokenBucket {
 		}
 		this.nanosPerTick = nanosPerTick;
 		long now = System.currentTimeMillis();
-		this.timeLastTick = now * (1000 * 1000);
+		this.timeLastTick = NANOSECONDS.convert(now, MILLISECONDS);
 		if(nanosPerTick <= 0) throw new IllegalArgumentException();
 		if(max <= 0) throw new IllegalArgumentException();
 	}
@@ -139,7 +142,7 @@ public class TokenBucket {
 		}
 		
 		long minDelayNS = nanosPerTick * (-current);
-		long minDelayMS = (minDelayNS + 1000*1000 - 1) / (1000*1000);
+		long minDelayMS = MILLISECONDS.convert(minDelayNS + MILLISECONDS.toNanos(1) - 1, NANOSECONDS);
 		long now = System.currentTimeMillis();
 		long wakeAt = now + minDelayMS;
 		
@@ -216,11 +219,11 @@ public class TokenBucket {
 	}
 	
 	synchronized long tokensToAdd() {
-		long nowNS = System.currentTimeMillis() * (1000 * 1000);
+		long nowNS = NANOSECONDS.convert(System.currentTimeMillis(), MILLISECONDS);
 		if(timeLastTick > nowNS) {
-			System.err.println("CLOCK SKEW DETECTED! CLOCK WENT BACKWARDS BY AT LEAST "+TimeUtil.formatTime((timeLastTick - nowNS)/(1000*1000), 2, true));
+			System.err.println("CLOCK SKEW DETECTED! CLOCK WENT BACKWARDS BY AT LEAST "+TimeUtil.formatTime(MILLISECONDS.convert(timeLastTick - nowNS, NANOSECONDS), 2, true));
 			System.err.println("FREENET WILL BREAK SEVERELY IF THIS KEEPS HAPPENING!");
-			Logger.error(this, "CLOCK SKEW DETECTED! CLOCK WENT BACKWARDS BY AT LEAST "+TimeUtil.formatTime((timeLastTick - nowNS)/(1000*1000), 2, true));
+			Logger.error(this, "CLOCK SKEW DETECTED! CLOCK WENT BACKWARDS BY AT LEAST "+TimeUtil.formatTime(MILLISECONDS.convert(timeLastTick - nowNS, NANOSECONDS), 2, true));
 			timeLastTick = nowNS;
 			return 0;
 		}

--- a/src/freenet/support/TransferThread.java
+++ b/src/freenet/support/TransferThread.java
@@ -3,6 +3,10 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.support;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import java.util.Collection;
 
 import com.db4o.ObjectContainer;
@@ -67,7 +71,7 @@ public abstract class TransferThread implements PrioRunnable, ClientGetCallback,
 
 	@Override
 	public void run() {
-		long sleepTime = 1 * 1000;
+		long sleepTime = SECONDS.toMillis(1);
 		try {
 			Logger.debug(this, "Loop running...");
 			iterate();
@@ -77,7 +81,7 @@ public abstract class TransferThread implements PrioRunnable, ClientGetCallback,
 			Logger.error(this, "Error in iterate() or getSleepTime() probably", e);
 		}
 		finally {
-			Logger.debug(this, "Loop finished. Sleeping for " + (sleepTime/(1000*60)) + " minutes.");
+			Logger.debug(this, "Loop finished. Sleeping for " + MINUTES.convert(sleepTime, MILLISECONDS) + " minutes.");
 			mTicker.queueTimedJob(this, mName, sleepTime, false, true);
 		}
 	}

--- a/src/freenet/support/compress/DecompressorThreadManager.java
+++ b/src/freenet/support/compress/DecompressorThreadManager.java
@@ -3,6 +3,8 @@
 * http://www.gnu.org/ for further details of the GPL. */
 package freenet.support.compress;
 
+import static java.util.concurrent.TimeUnit.MINUTES;
+
 import freenet.support.LogThresholdCallback;
 import freenet.support.TimeUtil;
 
@@ -123,9 +125,9 @@ public class DecompressorThreadManager {
 				// FIXME remove the timeout here.
 				// Something wierd is happening...
 				//wait(0)
-				wait(20*60*1000);
+				wait(MINUTES.toMillis(20));
 				long time = System.currentTimeMillis()-start;
-				if(time > 20*60*1000)
+				if(time > MINUTES.toMillis(20))
 					Logger.error(this, "Still waiting for decompressor chain after "+TimeUtil.formatTime(time));
 			} catch(InterruptedException e) {
 				//Do nothing

--- a/src/freenet/support/io/FilenameGenerator.java
+++ b/src/freenet/support/io/FilenameGenerator.java
@@ -1,5 +1,7 @@
 package freenet.support.io;
 
+import static java.util.concurrent.TimeUnit.MINUTES;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.Random;
@@ -57,7 +59,7 @@ public class FilenameGenerator {
 			File[] filenames = tmpDir.listFiles();
 			if(filenames != null) {
 				for(int i=0;i<filenames.length;i++) {
-					WrapperManager.signalStarting(5*60*1000);
+					WrapperManager.signalStarting((int) MINUTES.toMillis(5));
 					if(i % 1024 == 0 && i > 0)
 						// User may want some feedback during startup
 						System.err.println("Deleted "+wipedFiles+" temp files ("+(i - wipeableFiles)+" non-temp files in temp dir)");

--- a/src/freenet/support/io/PersistentBlobTempBucketFactory.java
+++ b/src/freenet/support/io/PersistentBlobTempBucketFactory.java
@@ -1,5 +1,8 @@
 package freenet.support.io;
 
+import static java.util.concurrent.TimeUnit.HOURS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import java.io.EOFException;
 import java.io.File;
 import java.io.IOException;
@@ -147,7 +150,7 @@ public class PersistentBlobTempBucketFactory {
 		}
 		size -= size % blockSize;
 		long blocks = size / blockSize;
-		WrapperManager.signalStarting((int) Math.max(blocks * 100, 24*60*60*1000));
+		WrapperManager.signalStarting((int) Math.max(blocks * 100, HOURS.toMillis(24)));
 		if(blocks > Integer.MAX_VALUE) {
 			Logger.error(this, "Unable to create free blocks cache!");
 			throw new IOException("Blob file already too big!");
@@ -690,7 +693,7 @@ outer:		while(true) {
 		synchronized(this) {
 		
 			int blocksMoved = 0;
-			if(now - lastCheckedEnd > 60*1000 || DISABLE_SANITY_CHECKS_DEFRAG) {
+			if(now - lastCheckedEnd > SECONDS.toMillis(60) || DISABLE_SANITY_CHECKS_DEFRAG) {
 				if(logMINOR) Logger.minor(this, "maybeShrink() inner");
 				// Check whether there is a big white space at the end of the file.
 				long blocks = getSize();
@@ -1011,8 +1014,8 @@ outer:				while(true) {
 					// Not much we can do
 				}
 			}
-			
-		}, 61*1000);
+
+		}, SECONDS.toMillis(61));
 	}
 
 	public void store(PersistentBlobTempBucket bucket, ObjectContainer container) {

--- a/src/freenet/support/io/TempBucketFactory.java
+++ b/src/freenet/support/io/TempBucketFactory.java
@@ -3,6 +3,8 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.support.io;
 
+import static java.util.concurrent.TimeUnit.MINUTES;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -61,7 +63,7 @@ public class TempBucketFactory implements BucketFactory {
 	private long maxRamUsed;
 
 	/** How old is a long-lived RAMBucket? */
-	private final static int RAMBUCKET_MAX_AGE = 5*60*1000; // 5mins
+	private final static long RAMBUCKET_MAX_AGE = MINUTES.toMillis(5);
 	/** How many times the maxRAMBucketSize can a RAMBucket be before it gets migrated? */
 	final static int RAMBUCKET_CONVERSION_FACTOR = 4;
 	

--- a/src/freenet/support/transport/ip/IPAddressDetector.java
+++ b/src/freenet/support/transport/ip/IPAddressDetector.java
@@ -31,14 +31,14 @@ public class IPAddressDetector implements Runnable {
 	}
 	
 	//private String preferedAddressString = null;
-	private final int interval;
+	private final long interval;
 	private final NodeIPDetector detector;
         /**
          * 
          * @param interval
          * @param detector
          */
-        public IPAddressDetector(int interval, NodeIPDetector detector) {
+        public IPAddressDetector(long interval, NodeIPDetector detector) {
 		this.interval = interval;
 		this.detector = detector;
 	}


### PR DESCRIPTION
This replaces many occurences of “60 \* 1000” (and all kinds of other durations) by “MINUTES.toMillis(1)” (and the matching other constants). In most places this changes an implicit `int` (60 \* 1000 is an `int`) to `long`s (because that is what `TimeUnit.toMillis(…)` returns). Often this change is uncritical because the value is only used in private member variables, or on-the-fly in comparisons. However, a couple of interface methods had to be changed to accept a `long` as a value for e.g. a timeout (`BaseSender` immediately comes to mind). I also have no idea whether I accidentally touched one of the classes that are stored in db4o.

The changes have only been tested by the compiler and the unit tests, I did not yet try to run this.
