### PR TITLE
Fix out of memory error on ?latestlog

### DIFF
--- a/src/freenet/clients/http/WelcomeToadlet.java
+++ b/src/freenet/clients/http/WelcomeToadlet.java
@@ -575,7 +575,7 @@ public class WelcomeToadlet extends Toadlet {
         LineReadingInputStream stream = null;
         try {
             stream = getLogTailReader(logfile, byteLimit);
-            return FileUtil.readUTF(stream);
+            return FileUtil.readUTF(stream).toString();
         } finally {
             Closer.close(stream);
         }

--- a/src/freenet/node/fcp/TestDDACompleteMessage.java
+++ b/src/freenet/node/fcp/TestDDACompleteMessage.java
@@ -58,7 +58,8 @@ public class TestDDACompleteMessage extends FCPMessage {
 			File maybeWrittenFile = checkJob.writeFilename;
 			if (maybeWrittenFile.exists() && maybeWrittenFile.isFile() && maybeWrittenFile.canRead()) {
 				try {
-					isWriteAllowed = checkJob.writeContent.equals(FileUtil.readUTF(maybeWrittenFile).trim());
+				    String existingContent = FileUtil.readUTF(maybeWrittenFile).toString().trim();
+					isWriteAllowed = checkJob.writeContent.equals(existingContent);
 				} catch (IOException e) {
 					Logger.error(this, "Caught an IOE trying to read the file (" + maybeWrittenFile + ")! " + e.getMessage());
 				}

--- a/src/freenet/support/io/FileUtil.java
+++ b/src/freenet/support/io/FileUtil.java
@@ -210,7 +210,7 @@ final public class FileUtil {
      * @throws FileNotFoundException if <code>file</code> cannot be opened
      * @throws IOException if an I/O error occurs
      */
-    public static String readUTF(File file) throws FileNotFoundException, IOException {
+    public static StringBuilder readUTF(File file) throws FileNotFoundException, IOException {
         return readUTF(file, 0);
     }
 
@@ -222,7 +222,7 @@ final public class FileUtil {
      * @throws FileNotFoundException if <code>file</code> cannot be opened
      * @throws IOException if an I/O error occurs
      */
-	public static String readUTF(File file, long offset) throws FileNotFoundException, IOException {
+	public static StringBuilder readUTF(File file, long offset) throws FileNotFoundException, IOException {
 		StringBuilder result = new StringBuilder();
 		FileInputStream fis = null;
 		BufferedInputStream bis = null;
@@ -246,7 +246,7 @@ final public class FileUtil {
 			Closer.close(bis);
 			Closer.close(fis);
 		}
-		return result.toString();
+		return result;
 	}
 	
 	/**
@@ -255,7 +255,7 @@ final public class FileUtil {
 	 * @return The content of <code>stream</code>
 	 * @throws IOException if an I/O error occurs
 	 */
-	public static String readUTF(InputStream stream) throws IOException {
+	public static StringBuilder readUTF(InputStream stream) throws IOException {
 	    return readUTF(stream, 0);
 	}
 	
@@ -266,7 +266,7 @@ final public class FileUtil {
 	 * @return The content of <code>stream</code>, starting at <code>offset</code>
 	 * @throws IOException if an I/O error occurs
 	 */
-	public static String readUTF(InputStream stream, long offset) throws IOException {
+	public static StringBuilder readUTF(InputStream stream, long offset) throws IOException {
 	    StringBuilder result = new StringBuilder();
 	    skipFully(stream, offset);
 	    InputStreamReader reader = null;
@@ -280,7 +280,7 @@ final public class FileUtil {
 	    } finally {
 	        Closer.close(reader);
 	    }
-	    return result.toString();
+	    return result;
 	}
 
 	/**


### PR DESCRIPTION
Put a limit on the amount of the log file that's displayed.
