### PR TITLE
Remove Freetalk from plugins page.

### DIFF
--- a/src/freenet/pluginmanager/PluginManager.java
+++ b/src/freenet/pluginmanager/PluginManager.java
@@ -1112,7 +1112,6 @@ public class PluginManager {
 		addOfficialPlugin("Freereader", "index", false, 4, true, new FreenetURI("CHK@4PuSjXk4Z0Hdu04JLhdPHLyOVLljj8qVbjRn3rHVzvg,bDGYnuYj67Q4uzroPBEWAYWRk26bPzf-iQ4~Uo3S7mg,AAIC--8/Freereader.jar"));
 		addOfficialPlugin("Library", "index", false, 34, true, new FreenetURI("CHK@q1NEAHGaa~kl2x-BhgaZMrExgEnFsxDfk588gjRNCI0,aeGkaVZlnaFfZMRNUlE10o0jlzFI6idfh~JMY3On0zU,AAMC--8/Library.jar"));
 		addOfficialPlugin("Spider", "index", false, 51, false, new FreenetURI("CHK@CcJfB~uOTgbzdpVr8htrhLXs0uNsVW6KFRpEvHGjXDU,BPr2fm9Cq9gj7BQeJdLbkCmcmXRx-e-b6aerDzSK4zk,AAMC--8/Spider.jar"), false, false, true);
-		addOfficialPlugin("Freetalk", "communication", false, 13, true, new FreenetURI("CHK@zZDy-KwoZHYy4ZRpK9ZNNQb1vyespIIi9b-RPIyRM0k,EDHJbQpLtGSW4WHA23UHt6MpcoAp--dR7zmX-SGzzis,AAMC--8/Freetalk.jar"), false, false, true);
 		addOfficialPlugin("WebOfTrust", "communication", false, 12, true, new FreenetURI("CHK@Z6jitqIR4tJc9gOXih5cbTJxwnThweDvE5e-pTzetGM,vJfK3hmt06b-dF0yIbovPZlCUqTdgZ5-xsRzcslq1KU,AAIC--8/WebOfTrust.jar"), false, false, false); // from 35617f66afba287d98320843a521a9b395a5fbb3 (WoT build fix for headless)
 		addOfficialPlugin("FlogHelper", "communication", false, 29, true, new FreenetURI("CHK@deSqrIbHCOtLe6n1HdvhCprm-mAm9Fo7dxN9fGcGHmU,mqT5nMqNftPnoYd0JEuftSP3yInvZxYeF2PQMIJeerU,AAMC--8/FlogHelper.jar"), false, false, false);
 		} catch (MalformedURLException e) {


### PR DESCRIPTION
Even with a warning and only showing the plugin in advanced mode, people
are still installing Freetalk and having problems. Because we do not
want anyone but developers who are working on fixing Freetalk installing
Freetalk, remove the plugin for now.

Once the problems are fixed, the plugin will be added again. Even if
Freetalk were not removed, it would still need a new build of Fred to
distribute the fix.
