### PR TITLE
Fix JFXX header corruption in JPEG filter

### DIFF
--- a/src/freenet/clients/http/filter/JPEGFilter.java
+++ b/src/freenet/clients/http/filter/JPEGFilter.java
@@ -230,6 +230,7 @@ public class JPEGFilter implements ContentDataFilter {
 						int extensionCode = dis.readUnsignedByte();
 						if(extensionCode == 0x10 || extensionCode == 0x11 || extensionCode == 0x13) {
 							// Alternate thumbnail, perfectly valid
+							dos.writeUnsignedByte(extensionCode);
 							skipRest(blockLength, countAtStart, cis, dis, dos, "thumbnail frame");
 							Logger.minor(this, "Thumbnail frame");
 						} else


### PR DESCRIPTION
Filter was failing to copy the extensionCode byte to the output.
