### PR TITLE
Don’t throw an exception if already closed.

### DIFF
--- a/src/freenet/support/io/TempBucketFactory.java
+++ b/src/freenet/support/io/TempBucketFactory.java
@@ -210,7 +210,9 @@ public class TempBucketFactory implements BucketFactory {
 			}
 			
 			private void _maybeMigrateRamBucket(long futureSize) throws IOException {
-				if(closed) throw new IOException("Already closed");
+				if (closed) {
+					return;
+				}
 				if(isRAMBucket()) {
 					boolean shouldMigrate = false;
 					boolean isOversized = false;


### PR DESCRIPTION
I am currently chasing a problem in Sone that prevents me from inserting new editions. I created a fresh node for that. The problem surfaces when the TarArchiveOutputStream is closed in SimpleManifestPutter:1118: it closes its internal TarBuffer which in turn already closes the underlying output stream. Afterwards, the TAOS itself closes the output stream again. This output stream, however, is a TempBucketFactory$TempBucket$TempBucketOutputStream which throws an exception in TempBucketFactory:213 if it is already closed. This is in clear violation of Closeable.close() with says “If the stream is already closed then invoking this method has no effect.”
