### PR TITLE
Unified store

### DIFF
--- a/src/freenet/node/Node.java
+++ b/src/freenet/node/Node.java
@@ -4221,10 +4221,18 @@ public class Node implements TimeSkewDetectorCallback {
 	}
         
         private boolean shouldStore(double loc) {
-            if (this.chkDatastore.keyCount() < this.chkDatastore.getMaxKeys()) return true;
-            final double WIDTH = 0.05;
+            if (this.chkDatastore.keyCount() < this.chkDatastore.getMaxKeys()){
+                System.out.println("store not full");
+                return true;
+            }
+            
             final double p = Math.random() * Math.random();
-            return (2 * Location.distance(loc, this.lm.getLocation())) < Math.random();
+            final double twoDist = 2 * Location.distance(loc, this.lm.getLocation());
+            final boolean result = twoDist < p;
+            
+            System.out.println("2d=" + twoDist + ", p=" + p + " r=" + result);
+            
+            return result;
         }
         
 	private void store(CHKBlock block, boolean canWriteClientCache, boolean canWriteDatastore, boolean forULPR) {

--- a/src/freenet/node/Node.java
+++ b/src/freenet/node/Node.java
@@ -4222,6 +4222,8 @@ public class Node implements TimeSkewDetectorCallback {
         
         private boolean shouldStore(double loc) {
             if (this.chkDatastore.keyCount() < this.chkDatastore.getMaxKeys()) return true;
+            final double WIDTH = 0.05;
+            final double p = Math.random() * Math.random();
             return (2 * Location.distance(loc, this.lm.getLocation())) < Math.random();
         }
         

--- a/src/freenet/node/NodeStats.java
+++ b/src/freenet/node/NodeStats.java
@@ -2197,35 +2197,25 @@ public class NodeStats implements Persistable, BlockTimeCallback {
 		fs.put("swapsRejectedRateLimit", swapsRejectedRateLimit);
 		fs.put("swapsRejectedRecognizedID", swapsRejectedRecognizedID);
 		long fix32kb = 32 * 1024;
-		long cachedKeys = node.getChkDatacache().keyCount();
-		long cachedSize = cachedKeys * fix32kb;
 		long storeKeys = node.getChkDatastore().keyCount();
 		long storeSize = storeKeys * fix32kb;
-		long overallKeys = cachedKeys + storeKeys;
-		long overallSize = cachedSize + storeSize;
+		long overallKeys = storeKeys;
+		long overallSize = storeSize;
 
 		long maxOverallKeys = node.getMaxTotalKeys();
 		long maxOverallSize = maxOverallKeys * fix32kb;
 
 		double percentOverallKeysOfMax = (double)(overallKeys*100)/(double)maxOverallKeys;
 
-		long cachedStoreHits = node.getChkDatacache().hits();
-		long cachedStoreMisses = node.getChkDatacache().misses();
-		long cachedStoreWrites = node.getChkDatacache().writes();
-		long cacheAccesses = cachedStoreHits + cachedStoreMisses;
-		long cachedStoreFalsePositives = node.getChkDatacache().getBloomFalsePositive();
-		double percentCachedStoreHitsOfAccesses = (double)(cachedStoreHits*100) / (double)cacheAccesses;
 		long storeHits = node.getChkDatastore().hits();
 		long storeMisses = node.getChkDatastore().misses();
 		long storeWrites = node.getChkDatastore().writes();
 		long storeFalsePositives = node.getChkDatastore().getBloomFalsePositive();
 		long storeAccesses = storeHits + storeMisses;
 		double percentStoreHitsOfAccesses = (double)(storeHits*100) / (double)storeAccesses;
-		long overallAccesses = storeAccesses + cacheAccesses;
+		long overallAccesses = storeAccesses;
 		double avgStoreAccessRate = (double)overallAccesses/(double)nodeUptimeSeconds;
 
-		fs.put("cachedKeys", cachedKeys);
-		fs.put("cachedSize", cachedSize);
 		fs.put("storeKeys", storeKeys);
 		fs.put("storeSize", storeSize);
 		fs.put("overallKeys", overallKeys);
@@ -2233,12 +2223,6 @@ public class NodeStats implements Persistable, BlockTimeCallback {
 		fs.put("maxOverallKeys", maxOverallKeys);
 		fs.put("maxOverallSize", maxOverallSize);
 		fs.put("percentOverallKeysOfMax", percentOverallKeysOfMax);
-		fs.put("cachedStoreHits", cachedStoreHits);
-		fs.put("cachedStoreMisses", cachedStoreMisses);
-		fs.put("cachedStoreWrites", cachedStoreWrites);
-		fs.put("cacheAccesses", cacheAccesses);
-		fs.put("cachedStoreFalsePositives", cachedStoreFalsePositives);
-		fs.put("percentCachedStoreHitsOfAccesses", percentCachedStoreHitsOfAccesses);
 		fs.put("storeHits", storeHits);
 		fs.put("storeMisses", storeMisses);
 		fs.put("storeAccesses", storeAccesses);
@@ -3286,40 +3270,6 @@ public class NodeStats implements Persistable, BlockTimeCallback {
 			@Override
 			public double distanceStats() throws StatsNotAvailableException {
 				return cappedDistance(avgStoreCHKLocation, node.getChkDatastore());
-			}
-		};
-	}
-
-	/**
-	 * View of stats for CHK Cache
-	 *
-	 * @return CHK cache stats
-	 */
-	public StoreLocationStats chkCacheStats() {
-		return new StoreLocationStats() {
-			@Override
-			public double avgLocation() {
-				return avgCacheCHKLocation.currentValue();
-			}
-
-			@Override
-			public double avgSuccess() {
-				return avgCacheCHKSuccess.currentValue();
-			}
-
-			@Override
-			public double furthestSuccess() throws StatsNotAvailableException {
-				return furthestCacheCHKSuccess;
-			}
-
-			@Override
-			public double avgDist() throws StatsNotAvailableException {
-				return Location.distance(nodeLoc, avgLocation());
-			}
-
-			@Override
-			public double distanceStats() throws StatsNotAvailableException {
-				return cappedDistance(avgCacheCHKLocation, node.getChkDatacache());
 			}
 		};
 	}


### PR DESCRIPTION
Because issue #210 already proposes using a new store layout for new nodes, I'd like to go one step further with the stores. The basic idea I'm following here goes like this:

  *  we want to maximize the success rate of our store
  * because the store size is bounded, the best thing we can do is to make the key distribution in the store match the incoming request distribution

So I propose having a only a single store, which

  * when not full, simply stores every block coming across the node
  * when full, stores some block `B` with probability `P_store(B)`

So what should `P_store` look like? What I'm currently experimenting with is a normal distribution around the node's location, like this:

~~~java
final double p = Math.random() * Math.random();
final double twoDist = 2 * Location.distance(block.location(), node.location());
return twoDist < p;
~~~

This superimposes a distribution which prefers nearby keys atop the incoming request distribution. I'm not sure if this is really needed, as the routing already prefers giving us requests which are close to our location. But it might help in some degenerate situations.

An even simpler scheme, closer to the original idea would be to just store blocks with an fixed probability `P`. This would be a tuneable which determines how much the store prefers keeping old data over storing new data.

This unified store would serve the purposes of the current store and cache, because:

  * there is a good chance that it contains data close to our node (because (a) data close to our location is more likely to be handled by our node and possibly (b) preferring locations close to out location by other means, like in the code above)
  * there is a good chance that it contains data requested often (because the more often some data is requested, the more often it get's a chance to make it into the store)

I currently have two nodes running in a "shootout" for a little over a week:

  * the "classic" node has a success rate of __1,1949%__
    * 0,4978% for the CHK store
    * 0,6971% for the CHK cache
  * the "unified store" node has a success rate of __1,9228%__

That's an improvement of 60%, which seems promising.

PS: I'm fully aware that this pull request cannot be merged in it's current form, but I'd like to get some input on this, and maybe someone wants to play with it, too.