### PR TITLE
Fix NodeStats::nodeLoc is fixed to zero, yet still used in calculations

### DIFF
--- a/src/freenet/node/NodeStats.java
+++ b/src/freenet/node/NodeStats.java
@@ -96,7 +96,6 @@ public class NodeStats implements Persistable, BlockTimeCallback {
 	private int outgoingRequestsAccounted = 0;
 	private volatile long subMaxPingTime;
 	private volatile long maxPingTime;
-    private final double nodeLoc=0.0;
 
 	final Node node;
 	private MemoryChecker myMemoryChecker;
@@ -3279,7 +3278,7 @@ public class NodeStats implements Persistable, BlockTimeCallback {
 
 			@Override
 			public double avgDist() throws StatsNotAvailableException {
-				return Location.distance(nodeLoc, avgLocation());
+				return Location.distance(node.lm.getLocation(), avgLocation());
 			}
 
 			@Override
@@ -3313,7 +3312,7 @@ public class NodeStats implements Persistable, BlockTimeCallback {
 
 			@Override
 			public double avgDist() throws StatsNotAvailableException {
-				return Location.distance(nodeLoc, avgLocation());
+				return Location.distance(node.lm.getLocation(), avgLocation());
 			}
 
 			@Override
@@ -3347,7 +3346,7 @@ public class NodeStats implements Persistable, BlockTimeCallback {
 
 			@Override
 			public double avgDist() throws StatsNotAvailableException {
-				return Location.distance(nodeLoc, avgLocation());
+				return Location.distance(node.lm.getLocation(), avgLocation());
 			}
 
 			@Override
@@ -3381,7 +3380,7 @@ public class NodeStats implements Persistable, BlockTimeCallback {
 
 			@Override
 			public double avgDist() throws StatsNotAvailableException {
-				return Location.distance(nodeLoc, avgLocation());
+				return Location.distance(node.lm.getLocation(), avgLocation());
 			}
 
 			@Override
@@ -3415,7 +3414,7 @@ public class NodeStats implements Persistable, BlockTimeCallback {
 
 			@Override
 			public double avgDist() throws StatsNotAvailableException {
-				return Location.distance(nodeLoc, avgLocation());
+				return Location.distance(node.lm.getLocation(), avgLocation());
 			}
 
 			@Override
@@ -3449,7 +3448,7 @@ public class NodeStats implements Persistable, BlockTimeCallback {
 
 			@Override
 			public double avgDist() throws StatsNotAvailableException {
-				return Location.distance(nodeLoc, avgLocation());
+				return Location.distance(node.lm.getLocation(), avgLocation());
 			}
 
 			@Override
@@ -3483,7 +3482,7 @@ public class NodeStats implements Persistable, BlockTimeCallback {
 
 			@Override
 			public double avgDist() throws StatsNotAvailableException {
-				return Location.distance(nodeLoc, avgLocation());
+				return Location.distance(node.lm.getLocation(), avgLocation());
 			}
 
 			@Override
@@ -3517,7 +3516,7 @@ public class NodeStats implements Persistable, BlockTimeCallback {
 
 			@Override
 			public double avgDist() throws StatsNotAvailableException {
-				return Location.distance(nodeLoc, avgLocation());
+				return Location.distance(node.lm.getLocation(), avgLocation());
 			}
 
 			@Override


### PR DESCRIPTION
nodeLoc, as defined in /src/freenet/node/NodeStats.java#L99, has final value 0.0, which does of course not accurately represent the Node's location. To work around this, in the NodeStats constructor on L596 a new (local) nodeLoc is defined for the subsequent calculations.

Still, the global (final) nodeLoc is used in the calculation of the StoreLocationStats (for instance, L3297), particulary in the avgDist function. Due to this the average datastore distance statistic is always equal to the average datastore location.

I am not fully aware of the implications (there may be none, except for the Statistics page), but my guess is that this is wrong (since it introduces undocumented redundancy). ~~This should be an easy fix.~~ Fix attached.
