### PR TITLE
Revert "Replace catch block with something a lot less stupid."

### DIFF
--- a/src/freenet/client/async/ClientRequestSchedulerBase.java
+++ b/src/freenet/client/async/ClientRequestSchedulerBase.java
@@ -3,8 +3,6 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.client.async;
 
-import static java.lang.String.format;
-
 import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -387,7 +385,11 @@ abstract class ClientRequestSchedulerBase {
 					if(listener.handleBlock(key, saltedKey, block, container, context))
 						ret = true;
 				} catch (Throwable t) {
-					Logger.error(this, format("Error in handleBlock callback for %s", listener), t);
+					try {
+						Logger.error(this, "Caught "+t+" in handleBlock callback for "+listener, new Exception("error"));
+					} catch (Throwable t1) {
+						Logger.error(this, "Caught "+t+" in handleBlock callback", new Exception("error"));
+					}
 				}
 				if(listener.isEmpty()) {
 					synchronized(this) {


### PR DESCRIPTION
There are various places in fred where defensive programming is actually absolutely necessary. Listener could be null (I'm not sure whether format() would do something evil in this case), it could be deactivated or corrupt, toString() could throw ... we do not necessarily want all the other listeners to fail just because this one has an error which is bad enough that toString() throws.

This reverts commit ce651ed41ddf5b391104b51ed9a40bcf3cf193cb.
