### PR TITLE
Trim name after removing excess cruft.

### DIFF
--- a/src/freenet/support/io/NativeThread.java
+++ b/src/freenet/support/io/NativeThread.java
@@ -188,7 +188,7 @@ public class NativeThread extends Thread {
 		if (name.indexOf('(') != -1)
 			name = name.substring(0, name.indexOf('('));
 		
-		return name;
+		return name.trim();
 	}
 	
 	public String getNormalizedName() {


### PR DESCRIPTION
When excess strings are removed from a thread’s name, sometimes there’s whitespace left after it. This messes up the thread names on the statistics page.
