### PR TITLE
Separate display and SFS/FCP Option representation

### DIFF
--- a/src/freenet/clients/http/ConfigToadlet.java
+++ b/src/freenet/clients/http/ConfigToadlet.java
@@ -316,7 +316,7 @@ public class ConfigToadlet extends Toadlet implements LinkEnabledCallback {
 							+ configName, MAX_PARAM_VALUE_SIZE);
 				}
 
-				if (!(o.getValueString().equals(value))) {
+				if (!(o.getValueDisplayString().equals(value))) {
 
 					if (logMINOR) {
 						Logger.minor(this, "Changing " + prefix + '.'
@@ -517,7 +517,7 @@ public class ConfigToadlet extends Toadlet implements LinkEnabledCallback {
 				displayedConfigElements++;
 				String configName = o.getName();
 				String fullName = subConfig.getPrefix() + '.' + configName;
-				String value = o.getValueString();
+				String value = o.getValueDisplayString();
 
 				if (value == null) {
 					Logger.error(this, fullName

--- a/src/freenet/clients/http/wizardsteps/WELCOME.java
+++ b/src/freenet/clients/http/wizardsteps/WELCOME.java
@@ -48,7 +48,7 @@ public class WELCOME implements Step {
 		//Add option dropdown for languages
 		Option<?> language = config.get("node").getOption("l10n");
 		EnumerableOptionCallback l10nCallback = (EnumerableOptionCallback)language.getCallback();
-		HTMLNode dropDown = ConfigToadlet.addComboBox(language.getValueString(), l10nCallback, language.getName(), false);
+		HTMLNode dropDown = ConfigToadlet.addComboBox(language.getValueDisplayString(), l10nCallback, language.getName(), false);
 		//Submit automatically upon selection if Javascript.
 		dropDown.addAttribute("onchange", "this.form.submit()");
 		languageForm.addChild(dropDown);

--- a/src/freenet/config/IntOption.java
+++ b/src/freenet/config/IntOption.java
@@ -41,7 +41,12 @@ public class IntOption extends Option<Integer> {
 	}
 
 	@Override
-	protected String toString(Integer val) {
+	protected String toDisplayString(Integer val) {
 		return Fields.intToString(val, isSize);
+	}
+
+	@Override
+	protected String toString(Integer val) {
+		return Fields.intToString(val, false);
 	}
 }

--- a/src/freenet/config/LongOption.java
+++ b/src/freenet/config/LongOption.java
@@ -39,9 +39,14 @@ public class LongOption extends Option<Long> {
 	private String l10n(String key, String pattern, String value) {
 		return NodeL10n.getBase().getString("LongOption." + key, pattern, value);
 	}
-	
+
+	@Override
+	protected String toDisplayString(Long val) {
+		return Fields.longToString(val, isSize);
+	}
+
 	@Override
 	protected String toString(Long val) {
-		return Fields.longToString(val, isSize);
+		return Fields.longToString(val, false);
 	}
 }

--- a/src/freenet/config/Option.java
+++ b/src/freenet/config/Option.java
@@ -64,6 +64,9 @@ public abstract class Option<T> {
 
 	protected abstract T parseString(String val) throws InvalidConfigValueException; 
 	protected abstract String toString(T val);
+	protected String toDisplayString(T val) {
+		return toString(val);
+	}
 
 	protected final void set(T val) throws InvalidConfigValueException, NodeNeedRestartException {
 		try {
@@ -80,6 +83,13 @@ public abstract class Option<T> {
 	 */
 	public final String getValueString() {
 		return toString(currentValue);
+	}
+
+	/**
+	 * Get the current value of the option as a string suited to end-user display.
+	 */
+	public final String getValueDisplayString() {
+		return toDisplayString(currentValue);
 	}
 
 	/** Set to a value from the config file; this is not passed on to the callback, as we

--- a/src/freenet/config/ShortOption.java
+++ b/src/freenet/config/ShortOption.java
@@ -31,7 +31,12 @@ public class ShortOption extends Option<Short> {
 	}
 
 	@Override
-	protected String toString(Short val) {
+	protected String toDisplayString(Short val) {
 		return Fields.shortToString(val, isSize);
-	}	
+	}
+
+	@Override
+	protected String toString(Short val) {
+		return Fields.shortToString(val, false);
+	}
 }

--- a/src/freenet/node/useralerts/IPUndetectedUserAlert.java
+++ b/src/freenet/node/useralerts/IPUndetectedUserAlert.java
@@ -87,7 +87,7 @@ public class IPUndetectedUserAlert extends AbstractUserAlert {
 		formNode.addChild("input", new String[] { "type", "name", "value" }, new String[] { "hidden", "subconfig", sc.getPrefix() });
 		HTMLNode listNode = formNode.addChild("ul", "class", "config");
 		HTMLNode itemNode = listNode.addChild("li");
-		itemNode.addChild("span", "class", "configshortdesc", o.getLocalisedShortDesc()).addChild("input", new String[] { "type", "name", "value" }, new String[] { "text", sc.getPrefix() + ".tempIPAddressHint", o.getValueString() });
+		itemNode.addChild("span", "class", "configshortdesc", o.getLocalisedShortDesc()).addChild("input", new String[] { "type", "name", "value" }, new String[] { "text", sc.getPrefix() + ".tempIPAddressHint", o.getValueDisplayString() });
 		itemNode.addChild("span", "class", "configlongdesc", o.getLocalisedLongDesc());
 		formNode.addChild("input", new String[] { "type", "value" }, new String[] { "submit", NodeL10n.getBase().getString("UserAlert.apply") });
 		formNode.addChild("input", new String[] { "type", "value" }, new String[] { "reset", NodeL10n.getBase().getString("UserAlert.reset") });

--- a/src/freenet/node/useralerts/InvalidAddressOverrideUserAlert.java
+++ b/src/freenet/node/useralerts/InvalidAddressOverrideUserAlert.java
@@ -46,7 +46,7 @@ public class InvalidAddressOverrideUserAlert extends AbstractUserAlert {
 		formNode.addChild("input", new String[] { "type", "name", "value" }, new String[] { "hidden", "subconfig", sc.getPrefix() });
 		HTMLNode listNode = formNode.addChild("ul", "class", "config");
 		HTMLNode itemNode = listNode.addChild("li");
-		itemNode.addChild("span", "class", "configshortdesc", o.getLocalisedShortDesc()).addChild("input", new String[] { "type", "name", "value" }, new String[] { "text", sc.getPrefix() + ".ipAddressOverride", o.getValueString() });
+		itemNode.addChild("span", "class", "configshortdesc", o.getLocalisedShortDesc()).addChild("input", new String[] { "type", "name", "value" }, new String[] { "text", sc.getPrefix() + ".ipAddressOverride", o.getValueDisplayString() });
 		itemNode.addChild("span", "class", "configlongdesc", o.getLocalisedLongDesc());
 		formNode.addChild("input", new String[] { "type", "value" }, new String[] { "submit", NodeL10n.getBase().getString("UserAlert.apply") });
 		formNode.addChild("input", new String[] { "type", "value" }, new String[] { "reset", NodeL10n.getBase().getString("UserAlert.reset") });

--- a/src/freenet/node/useralerts/MeaningfulNodeNameUserAlert.java
+++ b/src/freenet/node/useralerts/MeaningfulNodeNameUserAlert.java
@@ -52,7 +52,7 @@ public class MeaningfulNodeNameUserAlert extends AbstractUserAlert {
 		itemNode.addChild("span", new String[]{ "class", "title", "style" },
 				new String[]{ "configshortdesc", NodeL10n.getBase().getString("ConfigToadlet.defaultIs", new String[] { "default" }, new String[] { o.getDefault() }), 
 				"cursor: help;" }).addChild(o.getShortDescNode());
-		itemNode.addChild("input", new String[] { "type", "class", "alt", "name", "value" }, new String[] { "text", "config", o.getShortDesc(), "node.name", o.getValueString() });
+		itemNode.addChild("input", new String[] { "type", "class", "alt", "name", "value" }, new String[] { "text", "config", o.getShortDesc(), "node.name", o.getValueDisplayString() });
 		itemNode.addChild("span", "class", "configlongdesc").addChild(o.getLongDescNode());
 		formNode.addChild("input", new String[] { "type", "value" }, new String[] { "submit", NodeL10n.getBase().getString("UserAlert.apply") });
 		formNode.addChild("input", new String[] { "type", "value" }, new String[] { "reset", NodeL10n.getBase().getString("UserAlert.reset") });


### PR DESCRIPTION
Specifically sizes should only be formatted with size units when
displayed to the end user. Conflating display and data transfer/storage
representation, if nothing else, makes FCP more difficult to use. A
bandwidth limit or store size must be parsed for units instead of used
as a number of bytes.
