### PR TITLE
JavaDoc BaseL10n.addL10nSubstitution():

### DIFF
--- a/src/freenet/l10n/BaseL10n.java
+++ b/src/freenet/l10n/BaseL10n.java
@@ -558,39 +558,39 @@ public class BaseL10n {
 		node.addChild("%", result);
 	}
 
-    /**
-     * Loads an L10n string, replaces variables such as ${link} or ${bold} in it with {@link HTMLNode}s
-     * and adds the result to the given HTMLNode.
-     * 
-     * This is *much* safer than the deprecated {@link #addL10nSubstitution(HTMLNode, String, String[], String[])}. 
-     * Callers won't accidentally pass in unencoded strings and cause vulnerabilities.
-     * Callers should try to reuse parameters if possible.
-     * We automatically close each tag: When a pattern ${name} is matched, we search for
-     * ${/name}. If we find it, we make the tag enclose everything between the two; if we
-     * can't find it, we just add it with no children. It is not possible to create an
-     * HTMLNode representing a tag closure, so callers will need to change their code to
-     * not pass in /link or similar, and in some cases will need to change the l10n 
-     * strings themselves to always close the tag properly, rather than using a generic
-     * /link for multiple links as we use in some places.
-     * 
-     * <p><b>Examples</b>:
-     * <p>TranslationLookup.string=This is a ${link}link${/link} about ${text}.</p>
-     * <p>
-     * <code>addL10nSubstitution(html, "TranslationLookup.string", new String[] { "link", "text" },
-     *   new HTMLNode[] { HTMLNode.link("/KSK@gpl.txt"), HTMLNode.text("blah") });</code>
-     * </p>
-     * <br>
-     * <p>TranslationLookup.string=${bold}This${/bold} is a bold text.</p>
-     * <p>
-     * <code>addL10nSubstitution(html, "TranslationLookup.string", new String[] { "bold" },
-     *   new HTMLNode[] { HTMLNode.STRONG });</code>
-     * </p>
-     * 
-     * @param node The {@link HTMLNode} to which the L10n should be added after substitution was done.
-     * @param key The key of the L10n string which shall be used. 
-     * @param patterns Specifies things such as ${link} which shall be replaced in the L10n string with {@link HTMLNode}s.
-     * @param values For each entry in the previous array parameter, this array specifies the {@link HTMLNode} with which it shall be replaced. 
-     */
+	/**
+	 * Loads an L10n string, replaces variables such as ${link} or ${bold} in it with {@link HTMLNode}s
+	 * and adds the result to the given HTMLNode.
+	 * 
+	 * This is *much* safer than the deprecated {@link #addL10nSubstitution(HTMLNode, String, String[], String[])}. 
+	 * Callers won't accidentally pass in unencoded strings and cause vulnerabilities.
+	 * Callers should try to reuse parameters if possible.
+	 * We automatically close each tag: When a pattern ${name} is matched, we search for
+	 * ${/name}. If we find it, we make the tag enclose everything between the two; if we
+	 * can't find it, we just add it with no children. It is not possible to create an
+	 * HTMLNode representing a tag closure, so callers will need to change their code to
+	 * not pass in /link or similar, and in some cases will need to change the l10n 
+	 * strings themselves to always close the tag properly, rather than using a generic
+	 * /link for multiple links as we use in some places.
+	 * 
+	 * <p><b>Examples</b>:
+	 * <p>TranslationLookup.string=This is a ${link}link${/link} about ${text}.</p>
+	 * <p>
+	 * <code>addL10nSubstitution(html, "TranslationLookup.string", new String[] { "link", "text" },
+	 *   new HTMLNode[] { HTMLNode.link("/KSK@gpl.txt"), HTMLNode.text("blah") });</code>
+	 * </p>
+	 * <br>
+	 * <p>TranslationLookup.string=${bold}This${/bold} is a bold text.</p>
+	 * <p>
+	 * <code>addL10nSubstitution(html, "TranslationLookup.string", new String[] { "bold" },
+	 *   new HTMLNode[] { HTMLNode.STRONG });</code>
+	 * </p>
+	 * 
+	 * @param node The {@link HTMLNode} to which the L10n should be added after substitution was done.
+	 * @param key The key of the L10n string which shall be used. 
+	 * @param patterns Specifies things such as ${link} which shall be replaced in the L10n string with {@link HTMLNode}s.
+	 * @param values For each entry in the previous array parameter, this array specifies the {@link HTMLNode} with which it shall be replaced. 
+	 */
 	public void addL10nSubstitution(HTMLNode node, String key, String[] patterns, HTMLNode[] values) {
 		String value = getString(key);
 		addL10nSubstitutionInner(node, key, value, patterns, values);


### PR DESCRIPTION
The reason for me working on fred with this one is that I've observed myself to have searched for example of how to do a bold substitution for numerous times in the JavaDoc there, so it was time to fix the JavaDoc. Did some more improvements while I was at it, see commit message.

NOTICE: My fred-commits will be GnuPG-signed from now on. Use "git log --show-signature" to verify the signature. WOT and FT commits won't be signed: I maintain the repositories myself so I have direct push access anyway. Instead once I want the fred-maintainer to publish a WOT/FT build, I will push a signed tag as usual.
