### PR TITLE
Remove access to constructor, always use factory method.

### DIFF
--- a/src/freenet/client/async/USKDateHint.java
+++ b/src/freenet/client/async/USKDateHint.java
@@ -36,8 +36,8 @@ public class USKDateHint {
 	}
 	
 	private GregorianCalendar cal;
-	
-	USKDateHint() {
+
+	private USKDateHint() {
 		cal = new GregorianCalendar(TimeZone.getTimeZone("GMT"), Locale.US);
 	}
 	

--- a/src/freenet/client/async/USKFetcher.java
+++ b/src/freenet/client/async/USKFetcher.java
@@ -1035,7 +1035,7 @@ public class USKFetcher implements ClientGetState, USKCallback, HasKeyListener, 
 	
 	/** Call synchronized, then call startDBRs() */
 	private DBRAttempt[] addDBRs(ClientContext context) {
-		USKDateHint date = new USKDateHint();
+		USKDateHint date = USKDateHint.now();
 		ClientSSK[] ssks = date.getRequestURIs(this.origUSK);
 		DBRAttempt[] atts = new DBRAttempt[ssks.length];
 		int x = 0;


### PR DESCRIPTION
Just a tiny cleanup to make the creation of USK date hints consistent.
