### PR TITLE
PluginReplySender: Add getConnectionIdentifier()

### DIFF
--- a/src/freenet/node/fcp/FCPConnectionHandler.java
+++ b/src/freenet/node/fcp/FCPConnectionHandler.java
@@ -73,7 +73,7 @@ public class FCPConnectionHandler implements Closeable {
 	private FCPClient foreverClient;
 	final BucketFactory bf;
 	final HashMap<String, ClientRequest> requestsByIdentifier;
-	protected final String connectionIdentifier;
+	public final String connectionIdentifier;
 	private static volatile boolean logMINOR;
 	private boolean killedDupe;
 

--- a/src/freenet/pluginmanager/PluginReplySender.java
+++ b/src/freenet/pluginmanager/PluginReplySender.java
@@ -3,6 +3,8 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.pluginmanager;
 
+import freenet.node.fcp.FCPConnectionInputHandler;
+import freenet.node.fcp.FCPPluginMessage;
 import freenet.support.SimpleFieldSet;
 import freenet.support.api.Bucket;
 import freenet.support.io.ArrayBucket;
@@ -10,19 +12,40 @@ import freenet.support.io.ArrayBucket;
 public abstract class PluginReplySender {
 	
 	final String pluginname;
-	final String identifier;	
+    
+    /**
+     * Identifier of the connection to the client. Randomly chosen for each connection.
+     */
+    final String clientIdentifier;
 	
-	public PluginReplySender(String pluginname2, String identifier2) {
+	/**
+     * Specified by the client through FCP via the "Identifier" field.
+     * As the client can specify this freely, it is not sufficient as an ID. Thats why there also is another {@link #clientIdentifier}.
+	 */
+	final String clientSideIdentifier;
+    
+	
+    /**
+     * @param clientIdentifier Identifier of the particular network connection to the client. Should be a random UUID chosen for each network connection.
+     * @param clientSideIdentifier Specified by the client through FCP via the "Identifier" field. As the client can specify this freely, it is not sufficient
+     *                             as an ID. Thats why there also is another parameter clientIdentifier.
+     */
+	public PluginReplySender(String pluginname2, String clientIdentifier, String clientSideIdentifier) {
 		pluginname = pluginname2;
-		identifier = identifier2;
+		this.clientIdentifier = clientIdentifier;
+		this.clientSideIdentifier = clientSideIdentifier;
 	}
 	
 	public String getPluginName() {
 		return pluginname;
 	}
 	
+	/**
+     * @return An identifier of the connection specified by the client through FCP via the "Identifier" field.
+     *         As the client can specify this freely, it is not sufficient as an ID. Thats why there also is {@link #getConnectionIdentifier()}.
+	 */
 	public String getIdentifier() {
-		return identifier;
+		return clientSideIdentifier;
 	}
 
 	public void send(SimpleFieldSet params) throws PluginNotFoundException {
@@ -38,4 +61,23 @@ public abstract class PluginReplySender {
 	
 	public abstract void send(SimpleFieldSet params, Bucket bucket) throws PluginNotFoundException;
 
+    /**
+     * <p>Gets an unique identifier of the connection to the client.</p>
+     * <p><b>Notice:</b> The client can cause one network connection to appear with different connection IDs by setting a different <i>Identifier</i> field in
+     * the contents of multiple FCP messages: The <i>Identifier</i> set by the client is part of the returned connection ID. See {@link #getIdentifier()}.</p>
+     * 
+     * <p>This allows you to identify whether two PluginReplySender objects which you received through multiple callbacks of
+     * {@link FredPluginFCP#handle(PluginReplySender, SimpleFieldSet, Bucket, int)} belong to the same client connection:<br/>
+     * If the connection is the same, and the FCP field <i>Identifier</i> by the client is the same, the return value of this function is
+     * {@link String#equals(Object)}.<br/>
+     * If the return value is not equals(), then the PlugplinReplySenders belong to a different client, to a different connection of the same client, or
+     * to a different <i>Identifier</i> specified by the client.<br/></p>
+     * 
+     * <p>This mechanism is necessary because the {@link FCPConnectionInputHandler} will create a fresh PluginReplySender for each message it receives from
+     * the same client. <br/>Therefore, object identity of the PluginReplySender is not sufficient for identifying connections.<br/>
+     * (Actually it creates a fresh {@link FCPPluginMessage} for every processes message, which in turn creates a fresh PluginReplySender).</p>
+     */
+    public final String getConnectionIdentifier() {
+        return clientIdentifier + ":" + clientSideIdentifier;
+    }
 }

--- a/src/freenet/pluginmanager/PluginReplySenderDirect.java
+++ b/src/freenet/pluginmanager/PluginReplySenderDirect.java
@@ -10,15 +10,18 @@ import freenet.support.api.Bucket;
 
 /**
  * @author saces
- *
+ * @author xor (xor@freenetproject.org)
  */
 public class PluginReplySenderDirect extends PluginReplySender {
 	
 	private final Node node;
 	private final FredPluginTalker target;
 
-	public PluginReplySenderDirect(Node node2, FredPluginTalker target2, String pluginname2, String identifier2) {
-		super(pluginname2, identifier2);
+	/**
+	 * @see PluginReplySender#PluginReplySender(String, String, String)
+	 */
+	public PluginReplySenderDirect(Node node2, FredPluginTalker target2, String pluginname2, String clientIdentifier, String clientSideIdentifier) {
+		super(pluginname2, clientIdentifier, clientSideIdentifier);
 		node = node2;
 		target = target2;
 	}
@@ -32,7 +35,7 @@ public class PluginReplySenderDirect extends PluginReplySender {
 			public void run() {
 
 				try {
-					target.onReply(pluginname, identifier, params, bucket);
+					target.onReply(pluginname, clientSideIdentifier, params, bucket);
 				} catch (Throwable t) {
 					Logger.error(this, "Cought error while handling plugin reply: " + t.getMessage(), t);
 				}

--- a/src/freenet/pluginmanager/PluginReplySenderFCP.java
+++ b/src/freenet/pluginmanager/PluginReplySenderFCP.java
@@ -10,14 +10,18 @@ import freenet.support.api.Bucket;
 
 /**
  * @author saces
- *
+ * @author xor (xor@freenetproject.org)
  */
 public class PluginReplySenderFCP extends PluginReplySender {
 	
 	final FCPConnectionHandler handler; 
 
-	public PluginReplySenderFCP(FCPConnectionHandler handler2, String pluginname2, String identifier2) {
-		super(pluginname2, identifier2);
+	/**
+	 * @see PluginReplySender#PluginReplySender(String, String, String)
+	 */
+	public PluginReplySenderFCP(FCPConnectionHandler handler2, String pluginname2, String clientIdentifier, String clientSideIdentifier) {
+		super(pluginname2, clientIdentifier, clientSideIdentifier);
+		
 		handler = handler2;
 	}
 
@@ -26,7 +30,8 @@ public class PluginReplySenderFCP extends PluginReplySender {
 		// like in linux everthing is a file, in Plugintalker everything is a plugin. So it throws PluginNotFoundException
 		// instead fcp connection errors 
 		if (handler.isClosed()) throw new PluginNotFoundException("FCP connection closed");
-		FCPPluginReply reply = new FCPPluginReply(pluginname, identifier, params, bucket);
+		FCPPluginReply reply = new FCPPluginReply(pluginname, clientSideIdentifier, params, bucket);
 		handler.outputHandler.queue(reply);
 	}
+
 }


### PR DESCRIPTION
- This allow identifying to which client connection a PluginReplySender belongs.
- It is need for WOT SubscriptionManager (= event-notifications) so it can determine whether a certain client is already subscribed to certain events. Also, it will have to store the connection ID in the database so when events happen in the future it can obtain the PluginReplySender with the matching ID to send the events back to.
- For pure FCP network connections, the data needed for this was already stored: A random per-network-connection identifier at FCPConnectionHandler.connectionIdentifier. It was only a matter of exposing it through a getter.
- For intra-node connections between plugins, a new random ID is stored for each PluginTalker
- The result of getConnectionIdentifier() is not only the connection ID but also contains the client-specified "Identifier" from FCP which was already existing in the code. This is to not break clients which try to maintain multiple connections by using a different "Identifier" field.
