### PR TITLE
Deprecate PluginManager.getPluginInfo: It doesn't do what its JavaDoc says

### DIFF
--- a/src/freenet/pluginmanager/PluginManager.java
+++ b/src/freenet/pluginmanager/PluginManager.java
@@ -863,13 +863,44 @@ public class PluginManager {
 	 * look for PluginInfo for a Plugin with given classname
 	 * @param plugname
 	 * @return the PluginInfo or null if not found
+	 * @deprecated As opposed to its JavaDoc, this function will also return plugins with a matching filename, no only class name.
+	 *             To fix this ambiguity, instead use either {@link #getPluginInfoByClassName(String)} or {@link #getPluginInfoByFileName(String)}.
 	 */
+	@Deprecated
 	public PluginInfoWrapper getPluginInfo(String plugname) {
 		synchronized(pluginWrappers) {
 			for(int i = 0; i < pluginWrappers.size(); i++) {
 				PluginInfoWrapper pi = pluginWrappers.get(i);
 				if(pi.getPluginClassName().equals(plugname) || pi.getFilename().equals(plugname))
 					return pi;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * @param pluginClassName The name of the main class of the plugin - that is the class which implements {@link FredPlugin}.
+	 * @return The plugin with the given class, or null if no matching plugin was found.
+	 */
+	public PluginInfoWrapper getPluginInfoByClassName(String pluginClassName) {
+		synchronized(pluginWrappers) {
+			for(PluginInfoWrapper piw : pluginWrappers) {
+				if(piw.getPluginClassName().equals(pluginClassName))
+					return piw;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * @param pluginFileName The filename of the JAR from which the plugin was loaded.
+	 * @return Null if no matching plugin was found.
+	 */
+	public PluginInfoWrapper getPluginInfoByFileName(String pluginFileName) {
+		synchronized(pluginWrappers) {
+			for(PluginInfoWrapper piw : pluginWrappers) {
+				if(piw.getFilename().equals(pluginFileName))
+					return piw;
 			}
 		}
 		return null;


### PR DESCRIPTION
- It will not only return plugins with a matching class name but also with a matching filename
- I should have reviewed the callers for whether they need the filename matching and removed the functionality completely if they don't. But the tight WOT release schedule forbids me from spending too much time on this. So insteadd this commit just deprecates the function.
- Add replacement functions for querying by class name and by filename. Do not add one for querying by both - I doubt that this is needed. If someone needs it, it will be easy to add.
