### PR TITLE
DisconnectedException: Don't synchronize function which modifies nothing; JavaDoc

### DIFF
--- a/src/freenet/io/comm/DisconnectedException.java
+++ b/src/freenet/io/comm/DisconnectedException.java
@@ -7,12 +7,14 @@ package freenet.io.comm;
  * Thrown when the node is disconnected in the middle of (or
  * at the beginning of) a waitFor(). Not the same as 
  * NotConnectedException.
+ * 
+ * Notice: For performance reasons, this does not provide a stack trace.
  */
 public class DisconnectedException extends Exception {
 	private static final long serialVersionUID = -1;
 
     @Override
-    public final synchronized Throwable fillInStackTrace() {
+    public final Throwable fillInStackTrace() {
         return null;
     }
 }


### PR DESCRIPTION
- The synchronized likely resulted from copy-pasting the parent function which does modify stuff as skeleton.
- Add JavaDoc which explains the typical reason for not producing a stack trace.
