### PR TITLE
Start the plugins off-thread. Don't let them block the rest of startup. ...

### DIFF
--- a/src/freenet/pluginmanager/PluginManager.java
+++ b/src/freenet/pluginmanager/PluginManager.java
@@ -234,8 +234,16 @@ public class PluginManager {
 
 	public void start(Config config) {
 		if(toStart != null)
-			for(String name : toStart)
-				startPluginAuto(name, false);
+			for(final String name : toStart) {
+			    core.getExecutor().execute(new Runnable() {
+
+                    @Override
+                    public void run() {
+                        startPluginAuto(name, false);
+                    }
+			        
+			    });
+			}
 		synchronized(pluginWrappers) {
 			started = true;
 			toStart = null;


### PR DESCRIPTION
This fixes some rare startup breakage. AFAICS the IP detection plugins work fine even if they are started after the IP detector code.
