### PR TITLE
Fix clobbering old logs

### DIFF
--- a/src/freenet/support/FileLoggerHook.java
+++ b/src/freenet/support/FileLoggerHook.java
@@ -279,7 +279,7 @@ public class FileLoggerHook extends LoggerHook implements Closeable {
 					int x = gc.get(INTERVAL);
 					gc.set(INTERVAL, (x / INTERVAL_MULTIPLIER) * INTERVAL_MULTIPLIER);
 				}
-				findOldLogFiles(gc);
+				findOldLogFiles((GregorianCalendar)gc.clone());
 				currentFilename = new File(getHourLogName(gc, -1, true));
 				synchronized(logFiles) {
 					if((!logFiles.isEmpty()) && logFiles.getLast().filename.equals(currentFilename)) {


### PR DESCRIPTION
This was reported on FMS, and I've seen it here. It's not actually a purge-db4o regression, but a long standing bug.
