### PR TITLE
WrapperConfig: always set reload_configuration=TRUE

### DIFF
--- a/src/freenet/config/WrapperConfig.java
+++ b/src/freenet/config/WrapperConfig.java
@@ -97,6 +97,7 @@ public class WrapperConfig {
 					bw.write(name+'='+value+'\n');
 					written = true;
 				} else if(line.equalsIgnoreCase("wrapper.restart.reload_configuration=TRUE")) {
+					bw.write(line+'\n');
 					writtenReload = true;
 				} else {
 					bw.write(line+'\n');


### PR DESCRIPTION
WrapperConfig unintentionaly failed to write
`wrapper.restart.reload_configuration=TRUE` to wrapper.conf on property
write (but only when it was set), causing the configuration to not be
reloaded on automated restart of the wrapper.

This caused stale values to be used and may have resulted in loading
the wrong (previous) version on auto-update, in turn causing an
infinite update loop.

This should solve bugs [3208](https://bugs.freenetproject.org/view.php?id=3208) and [6284](https://bugs.freenetproject.org/view.php?id=6284).
