### PR TITLE
SentTimeCache: fix new Coverity defects

### DIFF
--- a/src/freenet/support/SentTimeCache.java
+++ b/src/freenet/support/SentTimeCache.java
@@ -17,7 +17,7 @@ public class SentTimeCache {
     /**
      * LinkedHashMap with int keys, long values, that has bounded capacity.
      */
-    private class BoundedSentTimeMap extends LinkedHashMap<Integer, Long> {
+    private static class BoundedSentTimeMap extends LinkedHashMap<Integer, Long> {
         private static final long serialVersionUID = 0;
         private final int maxSize;
         
@@ -95,10 +95,10 @@ public class SentTimeCache {
     }
 
     /**
-     * Queries the number of items currently held by this cache. This method is not thread-safe.
+     * Queries the number of items currently held by this cache.
      * @return The number of items in this cache.
      */
-    int size() {
+    synchronized int size() {
         return cache.size();
     }
 }


### PR DESCRIPTION
This should fix defects 74787, 74788 and 74789 detected by the Coverity
scan on build 1466 on 2014-11-09. None of these defects are of any
importance, but fixing them seems to be the right thing to do.
