### PR TITLE
Fix favicon.ico on the /feed/ screen.

### DIFF
--- a/src/freenet/clients/http/FProxyToadlet.java
+++ b/src/freenet/clients/http/FProxyToadlet.java
@@ -530,7 +530,7 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
 			}
 		}else if(ks.equals("/favicon.ico")){
 		    try {
-                throw new RedirectException(StaticToadlet.ROOT_PATH+"favicon.ico");
+                throw new RedirectException(StaticToadlet.ROOT_URL+"favicon.ico");
             } catch (URISyntaxException e) {
                 throw new Error(e);
             }


### PR DESCRIPTION
ROOT_URL must be used to get static resources as a URL.
