### PR TITLE
Fix plugin configuration loss

### DIFF
--- a/src/freenet/pluginmanager/PluginManager.java
+++ b/src/freenet/pluginmanager/PluginManager.java
@@ -248,7 +248,7 @@ public class PluginManager {
                         startPluginAuto(name, false);
                         startingPlugins.release();
                     }
-	
+			        
 			    });
 			}
 


### PR DESCRIPTION
This fixes [bug 6411](https://bugs.freenetproject.org/view.php?id=6411).

```
PluginManager: fix plugin configuration corruption

This fixes a regression introduced by
869f62559a06b2f72c9224a2179001dd551ea442 which corrupts plugin
configuration by prompting getConfigLoadString() to access plugin
startup information before startup is complete.
```

There's also a small cleanup. It's a mess in there.
