### PR TITLE
ClientRequester: add default getSchedulerGroup() implementation

### DIFF
--- a/src/freenet/client/async/BaseManifestPutter.java
+++ b/src/freenet/client/async/BaseManifestPutter.java
@@ -56,7 +56,7 @@ import freenet.support.io.ResumeFailedException;
  * WARNING: Changing non-transient members on classes that are Serializable can result in 
  * restarting downloads or losing uploads.
  */
-public abstract class BaseManifestPutter extends ManifestPutter implements ClientRequestSchedulerGroup {
+public abstract class BaseManifestPutter extends ManifestPutter {
 
     private static final long serialVersionUID = 1L;
     private static volatile boolean logMINOR;
@@ -1612,10 +1612,5 @@ public abstract class BaseManifestPutter extends ManifestPutter implements Clien
         }
         if(rootMetaPutHandler != null)
             rootMetaPutHandler.onResume(context);
-    }
-    
-    @Override
-    public ClientRequestSchedulerGroup getSchedulerGroup() {
-        return this;
     }
 }

--- a/src/freenet/client/async/ClientGetter.java
+++ b/src/freenet/client/async/ClientGetter.java
@@ -62,7 +62,7 @@ import freenet.support.io.StorageFormatException;
  * example fetches a key, parses the metadata, and if necessary creates other states to e.g. fetch splitfiles.
  */
 public class ClientGetter extends BaseClientGetter 
-implements WantsCooldownCallback, FileGetCompletionCallback, Serializable, ClientRequestSchedulerGroup {
+implements WantsCooldownCallback, FileGetCompletionCallback, Serializable {
 
     private static final long serialVersionUID = 1L;
     private static volatile boolean logMINOR;
@@ -1066,10 +1066,4 @@ implements WantsCooldownCallback, FileGetCompletionCallback, Serializable, Clien
         // Just a plain FileBucket. Not a temporary, not delayed free, etc.
         return ((FileBucket)returnBucket).getFile();
     }
-
-    @Override
-    public ClientRequestSchedulerGroup getSchedulerGroup() {
-        return this;
-    }
-
 }

--- a/src/freenet/client/async/ClientPutter.java
+++ b/src/freenet/client/async/ClientPutter.java
@@ -26,7 +26,7 @@ import freenet.support.api.RandomAccessBucket;
 import freenet.support.io.ResumeFailedException;
 
 /** A high level insert. */
-public class ClientPutter extends BaseClientPutter implements PutCompletionCallback, ClientRequestSchedulerGroup {
+public class ClientPutter extends BaseClientPutter implements PutCompletionCallback {
 
     private static final long serialVersionUID = 1L;
     /** Callback for when the insert completes. */
@@ -570,10 +570,4 @@ public class ClientPutter extends BaseClientPutter implements PutCompletionCallb
         if(state != null)
             state.onShutdown(context);
     }
-
-    @Override
-    public ClientRequestSchedulerGroup getSchedulerGroup() {
-        return this;
-    }
-
 }

--- a/src/freenet/client/async/ClientRequester.java
+++ b/src/freenet/client/async/ClientRequester.java
@@ -28,7 +28,7 @@ import freenet.support.io.ResumeFailedException;
  * WARNING: Changing non-transient members on classes that are Serializable can result in 
  * restarting downloads or losing uploads.
  */
-public abstract class ClientRequester implements Serializable {
+public abstract class ClientRequester implements Serializable, ClientRequestSchedulerGroup {
     private static final long serialVersionUID = 1L;
     private static volatile boolean logMINOR;
 	
@@ -393,7 +393,12 @@ public abstract class ClientRequester implements Serializable {
         return false;
     }
 
-    /** Get the ClientRequestSchedulerGroup. Usually but not always this will just be "return this". */
-    public abstract ClientRequestSchedulerGroup getSchedulerGroup();
+    /**
+     * Get the group the request belongs to. For single requests this is the request itself; for
+     * those in a group, such as a site insert, it is a common value between them.
+     */
+    public ClientRequestSchedulerGroup getSchedulerGroup() {
+      return this;
+    }
 
 }

--- a/src/freenet/client/async/SimpleHealingQueue.java
+++ b/src/freenet/client/async/SimpleHealingQueue.java
@@ -18,7 +18,7 @@ import freenet.support.Logger;
 import freenet.support.Logger.LogLevel;
 import freenet.support.api.Bucket;
 
-public class SimpleHealingQueue extends BaseClientPutter implements HealingQueue, PutCompletionCallback, ClientRequestSchedulerGroup {
+public class SimpleHealingQueue extends BaseClientPutter implements HealingQueue, PutCompletionCallback {
 
 	final int maxRunning;
 	int counter;
@@ -202,10 +202,4 @@ public class SimpleHealingQueue extends BaseClientPutter implements HealingQueue
     protected ClientBaseCallback getCallback() {
         return null;
     }
-
-    @Override
-    public ClientRequestSchedulerGroup getSchedulerGroup() {
-        return this;
-    }
-
 }

--- a/src/freenet/client/async/USKFetcherWrapper.java
+++ b/src/freenet/client/async/USKFetcherWrapper.java
@@ -18,7 +18,7 @@ import freenet.support.io.ResumeFailedException;
 /**
  * Wrapper for a backgrounded USKFetcher.
  */
-public class USKFetcherWrapper extends BaseClientGetter implements ClientRequestSchedulerGroup {
+public class USKFetcherWrapper extends BaseClientGetter {
 
 	final USK usk;
 	
@@ -128,10 +128,4 @@ public class USKFetcherWrapper extends BaseClientGetter implements ClientRequest
     protected ClientBaseCallback getCallback() {
         return null;
     }
-
-    @Override
-    public ClientRequestSchedulerGroup getSchedulerGroup() {
-        return this;
-    }
-
 }

--- a/src/freenet/client/async/USKRetriever.java
+++ b/src/freenet/client/async/USKRetriever.java
@@ -36,7 +36,7 @@ import freenet.support.io.NativeThread;
 /**
  * Poll a USK, and when a new slot is found, fetch it. 
  */
-public class USKRetriever extends BaseClientGetter implements USKCallback, ClientRequestSchedulerGroup {
+public class USKRetriever extends BaseClientGetter implements USKCallback {
 
 	/** Context for fetching data */
 	final FetchContext ctx;
@@ -341,10 +341,4 @@ public class USKRetriever extends BaseClientGetter implements USKCallback, Clien
         // Not persistent.
         return null;
     }
-
-    @Override
-    public ClientRequestSchedulerGroup getSchedulerGroup() {
-        return this;
-    }
-	
 }


### PR DESCRIPTION
This can implement the common behavior as well as extend the interface
instead of pushing that down to all its subclasses.
