### PR TITLE
Fix Eclipse not finding bcprov.jar

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -5,7 +5,7 @@
 	<classpathentry kind="lib" path="/usr/share/java/junit.jar"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="lib" path="lib/freenet/freenet-ext.jar" sourcepath="/Contrib/db4o/src/db4oj"/>
-	<classpathentry kind="lib" path="lib/bcprov.jar"/>
+	<classpathentry kind="lib" path="lib/bcprov-jdk15on-151.jar"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
 	<classpathentry kind="output" path="build/main/"/>
 </classpath>


### PR DESCRIPTION
Commit 08da52a45633704c1486a6a92d536713c80e4bce changed
the Ant builder to consume "lib/bcprov-jdk15on-151.jar"
instead of "lib/bcprov.jar". Unfortunately, it did not update the
Eclipse project configuration to reflect that change.

This commit fixes that.