### PR TITLE
Fix the ant build script (for Windows)

### DIFF
--- a/build-clean.xml
+++ b/build-clean.xml
@@ -311,7 +311,7 @@ maintainers may prefer to use this instead of build.xml.
 	<target name="unit-build" depends="build" unless="${test.skip}">
 		<antcall target="libdep-junit"/>
 		<antcall target="libdep-hamcrest"/>
-		<javac srcdir="${test.src}" destdir="${test.make}" debug="on" source="1.6" target="1.6" encoding="UTF-8">
+		<javac srcdir="${test.src}" destdir="${test.make}" debug="on" source="1.6" target="1.6" includeAntRuntime="false" encoding="UTF-8">
 			<compilerarg line="${javac.args}"/>
 			<classpath refid="libtest.path"/>
 			<include name="**/*.java"/>


### PR DESCRIPTION
Ant will fail by default if a directory listed in a FileSet is not
 present... which is the case of /usr/share/java/ on Windows
