### PR TITLE
Eleriseth packetsender caching

### DIFF
--- a/src/freenet/node/NewPacketFormatKeyContext.java
+++ b/src/freenet/node/NewPacketFormatKeyContext.java
@@ -32,7 +32,11 @@ public class NewPacketFormatKeyContext {
 	// WARNING: timeCheckForAcksCached must invalidated or adjusted if acks is altered
 	private final TreeMap<Integer, Long> acks = new TreeMap<Integer, Long>();
 	private long timeCheckForAcksCached = Long.MAX_VALUE; // cached timeCheckForAcks; Long.MIN_VALUE if invalid; Long.MAX_VALUE for empty acks (initial state);  uses "synchronized(acks)" lock
+
+	// WARNING: minSentTimeCached must be invalidated or adjusted if any sentPackets added/removed/changed
 	private final HashMap<Integer, SentPacket> sentPackets = new HashMap<Integer, SentPacket>();
+	private long minSentTimeCached = Long.MAX_VALUE; // cached minimum time for sentPackets; Long.MIN_VALUE if invalid; Long.MAX_VALUE for empty sentPackets (initial state);  uses "synchronized(sentPackets)" lock
+
 	/** Keep this many sent times for lost packets, so we can compute an accurate round trip time if
 	 * they are acked after we had decided they were lost. */
 	private static final int MAX_LOST_SENT_TIMES = 128;
@@ -116,6 +120,8 @@ public class NewPacketFormatKeyContext {
 		synchronized(sentPackets) {
 			sent = sentPackets.remove(ack);
 			maxSize = (maxSeenInFlight * 2) + 10;
+			/* invalidate cache */
+			minSentTimeCached = Long.MIN_VALUE;
 		}
 		if(sent != null) {
 			rtt = sent.acked(key);
@@ -162,7 +168,11 @@ public class NewPacketFormatKeyContext {
 	public void sent(int sequenceNumber, int length) {
 		synchronized(sentPackets) {
 			SentPacket sentPacket = sentPackets.get(sequenceNumber);
-			if(sentPacket != null) sentPacket.sent(length);
+			if(sentPacket != null) {
+				sentPacket.sent(length);
+				/* sent timestamp was changed, invalidate cache */
+				minSentTimeCached = Long.MIN_VALUE;
+			}
 		}
 	}
 
@@ -234,6 +244,8 @@ public class NewPacketFormatKeyContext {
 	    sentPacket.sent(length);
 		synchronized(sentPackets) {
 			sentPackets.put(seqNum, sentPacket);
+			/* invalidate cache */
+			minSentTimeCached = Long.MIN_VALUE;
 			int inFlight = sentPackets.size();
 			if(inFlight > maxSeenInFlight) {
 				maxSeenInFlight = inFlight;
@@ -252,12 +264,20 @@ public class NewPacketFormatKeyContext {
 		double avgRtt = Math.max(MIN_RTT_FOR_RETRANSMIT, averageRTT);
 		long maxDelay = (long)(avgRtt + MAX_ACK_DELAY * 1.1);
 		synchronized(sentPackets) {
+			if (minSentTimeCached > Long.MIN_VALUE) {
+				timeCheck = minSentTimeCached;
+			} else {
 			for (SentPacket s : sentPackets.values()) {
-				long t = s.getSentTime() + maxDelay;
+				long t = s.getSentTime();
 				if (t < timeCheck) {
 				    timeCheck = t;
 			    }
 			}
+			minSentTimeCached = timeCheck;
+			}
+		}
+		if (timeCheck != Long.MAX_VALUE) {
+			timeCheck += maxDelay;
 		}
 		return timeCheck;
 	}
@@ -276,21 +296,28 @@ public class NewPacketFormatKeyContext {
 		final boolean logMINOR = NewPacketFormatKeyContext.logMINOR;
 		
 		synchronized(sentPackets) {
+			if (minSentTimeCached >= threshold) { // && minSentTimeCached != Long.MIN_VALUE [implied by previous condition]
+				// when minimum of sentPackets[].getSentTime() >= threshold, "s.getSentTime() < threshold" condition is always false, and no sentPackets needs to be removed
+				return;
+			}
 			bigLostCount = sentPackets.size();
 			Iterator<Map.Entry<Integer, SentPacket>> it = sentPackets.entrySet().iterator();
+			// sentPackets will be changed, invalidate cached value
+			minSentTimeCached = Long.MIN_VALUE;
 			while(it.hasNext()) {
 				Map.Entry<Integer, SentPacket> e = it.next();
 				SentPacket s = e.getValue();
-				if (s.getSentTime() < threshold) {
+				long t = s.getSentTime();
+				if (t < threshold) {
 					if (logMINOR) {
 						Logger.minor(this, "Assuming packet " + e.getKey() + " has been lost. "
-						                + "Delay " + (curTime - s.getSentTime()) + "ms, "
+						                + "Delay " + (curTime - t) + "ms, "
 						                + "threshold " + threshold + "ms");
 					}
 					// Store the packet sentTime in our lost sent times cache, so we can calculate
 					// RTT if an ack may surface later on.
 					if(!s.messages.isEmpty()) {
-				        lostSentTimes.report(e.getKey(), s.getSentTime());
+				        lostSentTimes.report(e.getKey(), t);
 			        }
 			        // Mark the packet as lost and remove it from our active packets.
 			        s.lost();
@@ -332,6 +359,8 @@ public class NewPacketFormatKeyContext {
 				s.lost();
 			}
 			sentPackets.clear();
+			// reset cache to initial state
+			minSentTimeCached = Long.MAX_VALUE;
 		}
 	}
 }

--- a/src/freenet/node/NewPacketFormatKeyContext.java
+++ b/src/freenet/node/NewPacketFormatKeyContext.java
@@ -272,6 +272,8 @@ public class NewPacketFormatKeyContext {
 		double avgRtt = Math.max(MIN_RTT_FOR_RETRANSMIT, averageRTT);
 		long maxDelay = (long)(avgRtt + MAX_ACK_DELAY * 1.1);
 		long threshold = curTime - maxDelay;
+
+		final boolean logMINOR = NewPacketFormatKeyContext.logMINOR;
 		
 		synchronized(sentPackets) {
 			bigLostCount = sentPackets.size();

--- a/src/freenet/node/NewPacketFormatKeyContext.java
+++ b/src/freenet/node/NewPacketFormatKeyContext.java
@@ -272,13 +272,13 @@ public class NewPacketFormatKeyContext {
 			if (minSentTimeCached > Long.MIN_VALUE) {
 				timeCheck = minSentTimeCached;
 			} else {
-			for (SentPacket s : sentPackets.values()) {
-				long t = s.getSentTime();
-				if (t < timeCheck) {
-				    timeCheck = t;
-			    }
-			}
-			minSentTimeCached = timeCheck;
+				for (SentPacket s : sentPackets.values()) {
+					long t = s.getSentTime();
+					if (t < timeCheck) {
+						timeCheck = t;
+					}
+				}
+				minSentTimeCached = timeCheck;
 			}
 		}
 		if (timeCheck != Long.MAX_VALUE) {

--- a/src/freenet/node/NewPacketFormatKeyContext.java
+++ b/src/freenet/node/NewPacketFormatKeyContext.java
@@ -264,8 +264,8 @@ public class NewPacketFormatKeyContext {
 
 	public void checkForLostPackets(double averageRTT, long curTime, BasePeerNode pn) {
 		//Mark packets as lost
-		int bigLostCount = 0;
-		int count = 0;
+		int bigLostCount;
+		int count;
 		
 		// Because MIN_RTT_FOR_RETRANSMIT > MAX_ACK_DELAY, and because averageRTT() includes the
 		// actual ack delay, we don't need to add it on here.
@@ -274,6 +274,7 @@ public class NewPacketFormatKeyContext {
 		long threshold = curTime - maxDelay;
 		
 		synchronized(sentPackets) {
+			bigLostCount = sentPackets.size();
 			Iterator<Map.Entry<Integer, SentPacket>> it = sentPackets.entrySet().iterator();
 			while(it.hasNext()) {
 				Map.Entry<Integer, SentPacket> e = it.next();
@@ -292,11 +293,10 @@ public class NewPacketFormatKeyContext {
 			        // Mark the packet as lost and remove it from our active packets.
 			        s.lost();
 					it.remove();
-					bigLostCount++;
-				} else {
-					count++;
 				}
 			}
+			count = sentPackets.size();
+			bigLostCount -= count;
 		}
 		if(count > 0 && logMINOR)
 			Logger.minor(this, "" + count + " packets in flight with threshold " + maxDelay + "ms");

--- a/src/freenet/node/NewPacketFormatKeyContext.java
+++ b/src/freenet/node/NewPacketFormatKeyContext.java
@@ -150,9 +150,10 @@ public class NewPacketFormatKeyContext {
 	public int queueAck(int seqno) {
 		synchronized(acks) {
 			if(!acks.containsKey(seqno)) {
-				acks.put(seqno, System.currentTimeMillis());
-				// invalidate cache
-				timeCheckForAcksCached = Long.MIN_VALUE;
+				long now = System.currentTimeMillis();
+				acks.put(seqno, now);
+				// one ack added, adjust cached value (won't change if was invalid before)
+				timeCheckForAcksCached = Math.min(timeCheckForAcksCached, now + MAX_ACK_DELAY);
 				return acks.size();
 			} else return -1;
 		}

--- a/src/freenet/node/PeerMessageQueue.java
+++ b/src/freenet/node/PeerMessageQueue.java
@@ -742,20 +742,9 @@ public class PeerMessageQueue {
 		enqueuePrioritizedMessageItem(item);
 		int x = 0;
 		for(PrioQueue pq : queuesByPriority) {
-			if(pq.itemsNonUrgent != null) {
-				for(MessageItem it : pq.itemsNonUrgent) {
-					x += it.getLength() + MESSAGE_OVERHEAD;
-					if(x > maxSize)
-						break;
-				}
-			}
-			if(pq.nonEmptyItemsWithID != null) {
-				for(PrioQueue.Items q : pq.nonEmptyItemsWithID)
-					for(MessageItem it : q.items) {
-						x += it.getLength() + MESSAGE_OVERHEAD;
-						if(x > maxSize)
-							break;
-					}
+			x = pq.addSize(x, maxSize);
+			if (x > maxSize) {
+				return x;
 			}
 		}
 		return x;

--- a/src/freenet/node/PeerMessageQueue.java
+++ b/src/freenet/node/PeerMessageQueue.java
@@ -760,13 +760,22 @@ public class PeerMessageQueue {
 	}
 
 	public synchronized long getMessageQueueLengthBytes() {
+		if (cachedQueueSize>=0 && cachedQueueSizeIsComplete) {
+			return cachedQueueSize;
+		}
 		long x = 0;
 		for(PrioQueue pq : queuesByPriority) {
+			if(pq.itemsNonUrgent != null) {
+				for(MessageItem item : pq.itemsNonUrgent)
+					x += item.getLength() + MESSAGE_OVERHEAD;
+			}
 			if(pq.nonEmptyItemsWithID != null)
 				for(PrioQueue.Items q : pq.nonEmptyItemsWithID)
 					for(MessageItem it : q.items)
 						x += it.getLength() + MESSAGE_OVERHEAD;
 		}
+		cachedQueueSize = x > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int)x;
+		cachedQueueSizeIsComplete = !(x > Integer.MAX_VALUE);
 		return x;
 	}
 

--- a/src/freenet/node/PeerMessageQueue.java
+++ b/src/freenet/node/PeerMessageQueue.java
@@ -819,7 +819,7 @@ public class PeerMessageQueue {
 	 */
 	public synchronized long getNextUrgentTime(long t, long returnIfBefore) {
 		for(PrioQueue queue: queuesByPriority) {
-			t = Math.min(t, queue.getNextUrgentTime(t, returnIfBefore));
+			t = queue.getNextUrgentTime(t, returnIfBefore);
 			if(t <= returnIfBefore) return t; // How much in the past doesn't matter, as long as it's in the past.
 		}
 		return t;

--- a/src/freenet/node/PeerMessageQueue.java
+++ b/src/freenet/node/PeerMessageQueue.java
@@ -810,19 +810,23 @@ public class PeerMessageQueue {
 	 * Get the time at which the next message must be sent. If any message is
 	 * overdue, we will return a value less than now, which may not be completely
 	 * accurate.
-	 * @param t The current next urgent time. The return value will be no greater
-	 * than this.
 	 * @param returnIfBefore The current time. If the next urgent time is less than 
 	 * this we return immediately rather than computing an accurate past value. 
 	 * Set to Long.MAX_VALUE if you want an accurate value.
 	 * @return The next urgent time, but can be too high if it is less than now.
 	 */
-	public synchronized long getNextUrgentTime(long t, long returnIfBefore) {
+	public synchronized long getNextUrgentTime(long returnIfBefore) {
+		long t = Long.MAX_VALUE;
 		for(PrioQueue queue: queuesByPriority) {
 			t = queue.getNextUrgentTime(t, returnIfBefore);
 			if(t <= returnIfBefore) return t; // How much in the past doesn't matter, as long as it's in the past.
 		}
 		return t;
+	}
+
+	@Deprecated
+	public long getNextUrgentTime(long t, long stopIfBeforeTime) {
+		return Math.min(t, getNextUrgentTime(stopIfBeforeTime));
 	}
 
 	/**
@@ -833,7 +837,7 @@ public class PeerMessageQueue {
 	 * <code>now</code>
 	 */
 	public boolean mustSendNow(long now) {
-		return getNextUrgentTime(Long.MAX_VALUE, now) <= now;
+		return getNextUrgentTime(now) <= now;
 	}
 
 	/**

--- a/src/freenet/node/PeerMessageQueue.java
+++ b/src/freenet/node/PeerMessageQueue.java
@@ -866,8 +866,7 @@ public class PeerMessageQueue {
 		addPeerLoadStatsRT.value = true;
 		addPeerLoadStatsBulk.value = true;
 		
-		for(int i=0;i<DMT.PRIORITY_REALTIME_DATA;i++) {
-			if(i < minPriority) continue;
+		for(int i=minPriority;i<DMT.PRIORITY_REALTIME_DATA;i++) {
 			if(logMINOR) Logger.minor(this, "Adding from priority "+i);
 			MessageItem ret = queuesByPriority[i].addPriorityMessages(now, addPeerLoadStatsRT, addPeerLoadStatsBulk);
 			if(ret != null) return ret;

--- a/src/freenet/node/PeerMessageQueue.java
+++ b/src/freenet/node/PeerMessageQueue.java
@@ -884,10 +884,13 @@ public class PeerMessageQueue {
 			tryRealtimeFirst = false;
 		} else if(queuesByPriority[DMT.PRIORITY_BULK_DATA].isEmpty()) {
 			tryRealtimeFirst = true;
-		} else if(queuesByPriority[DMT.PRIORITY_BULK_DATA].getNextUrgentTime(Long.MAX_VALUE, 0) >= queuesByPriority[DMT.PRIORITY_REALTIME_DATA].getNextUrgentTime(Long.MAX_VALUE, 0)) {
-			tryRealtimeFirst = true;
 		} else {
-			tryRealtimeFirst = false;
+			long rtNextUrgentTime = queuesByPriority[DMT.PRIORITY_REALTIME_DATA].getNextUrgentTime(Long.MAX_VALUE, 0);
+			if(queuesByPriority[DMT.PRIORITY_BULK_DATA].getNextUrgentTime(Long.MAX_VALUE, rtNextUrgentTime) >= rtNextUrgentTime) {
+				tryRealtimeFirst = true;
+			} else {
+				tryRealtimeFirst = false;
+			}
 		}
 		
 		// FIXME token bucket?

--- a/src/freenet/node/PeerMessageQueue.java
+++ b/src/freenet/node/PeerMessageQueue.java
@@ -740,13 +740,22 @@ public class PeerMessageQueue {
 	 */
 	public synchronized int queueAndEstimateSize(MessageItem item, int maxSize) {
 		enqueuePrioritizedMessageItem(item);
+		if (cachedQueueSize >= 0) {
+			if (cachedQueueSizeIsComplete || cachedQueueSize > maxSize) {
+				return cachedQueueSize;
+			}
+		}
 		int x = 0;
 		for(PrioQueue pq : queuesByPriority) {
 			x = pq.addSize(x, maxSize);
 			if (x > maxSize) {
+				cachedQueueSize = Math.max(cachedQueueSize, x);
+				cachedQueueSizeIsComplete = false;
 				return x;
 			}
 		}
+		cachedQueueSize = cachedQueueSize;
+		cachedQueueSizeIsComplete = true;
 		return x;
 	}
 

--- a/src/freenet/node/PeerNode.java
+++ b/src/freenet/node/PeerNode.java
@@ -1427,7 +1427,7 @@ public abstract class PeerNode implements USKRetrieverCallback, BasePeerNode, Pe
 		if(pf != null) {
 			boolean canSend = cur != null && pf.canSend(cur);
 			if(canSend) { // New messages are only sent on cur.
-				long l = messageQueue.getNextUrgentTime(t, 0); // Need an accurate value even if in the past.
+				long l = messageQueue.getNextUrgentTime(0); // Need an accurate value even if in the past.
 				if(t >= now && l < now && logMINOR)
 					Logger.minor(this, "Next urgent time from message queue less than now");
 				else if(logDEBUG)

--- a/test/freenet/node/PeerMessageQueueTest.java
+++ b/test/freenet/node/PeerMessageQueueTest.java
@@ -8,7 +8,7 @@ import junit.framework.TestCase;
 public class PeerMessageQueueTest extends TestCase {
 	public void testUrgentTimeEmpty() {
 		PeerMessageQueue pmq = new PeerMessageQueue();
-		assertEquals(Long.MAX_VALUE, pmq.getNextUrgentTime(Long.MAX_VALUE, System.currentTimeMillis()));
+		assertEquals(Long.MAX_VALUE, pmq.getNextUrgentTime(System.currentTimeMillis()));
 	}
 
 	public void testUrgentTime() {
@@ -22,7 +22,7 @@ public class PeerMessageQueueTest extends TestCase {
 		pmq.queueAndEstimateSize(item, 1024);
 
 		//The timeout for item should be within (start + 100) and (end + 100)
-		long urgentTime = pmq.getNextUrgentTime(Long.MAX_VALUE, System.currentTimeMillis());
+		long urgentTime = pmq.getNextUrgentTime(System.currentTimeMillis());
 		if(!((urgentTime >= (start + 100)) && (urgentTime <= (end + 100)))) {
 			fail("Timeout not in expected range. Expected: " + (start + 100) + "->" + (end + 100) + ", actual: " + urgentTime);
 		}
@@ -54,7 +54,7 @@ public class PeerMessageQueueTest extends TestCase {
 
 		//getNextUrgentTime() should return the timeout of itemUrgent, which is within (start + 100)
 		//and (end + 100)
-		long urgentTime = pmq.getNextUrgentTime(Long.MAX_VALUE, System.currentTimeMillis());
+		long urgentTime = pmq.getNextUrgentTime(System.currentTimeMillis());
 		if(!((urgentTime >= (start + 100)) && (urgentTime <= (end + 100)))) {
 			fail("Timeout not in expected range. Expected: " + (start + 100) + "->" + (end + 100) + ", actual: " + urgentTime);
 		}


### PR DESCRIPTION
Eleriseth has a patch set to address [bug 6376](https://bugs.freenetproject.org/view.php?id=6376). Quoting from FMS:

> Avoiding repeated calls at higher levels and related refactoring was too complex
> to me, so I went by easier path and just added caching for nextUrgentTime and
> mustSendSize (in PeerMessageQueue), timeSendAcks and [time]CheckForLostPackets
> (in NewPacketFormatKeyContext).
> Last patch adds logging of cache effectiveness and *should not be included in
> any released build* (put it on separate branch or something; logging is noisy,
> System.nanoTime() can be expensive on some platforms, and locking code is quite
> clumsy and probably unsafe; it is only intended to demonstrate that caching code
> works [and effective], and completely unneeded to end users).
> Patches 08 and 11 can be a bit problematic and should be reviewed by someone
> with better understanding of code (too lazy to watch for irclog, will toad be
> available anytime soon?).
> 
> Everything is run-tested against build01467, appears to work, no ill effects
> noticed so far (but I could've overlooked something, please review carefully).
> Should be applicable to next, but not even compile-tested.
> 
> On my (rather low-bandwidth and low-peer) node results of few hours run with
> logging patch was:
> 
> timeCheckForAcks:
> cached/calls=99.4%, 7500 calls/s, uncached=2.1 µs/call
> getNextUrgentTime:
> cached/calls=97.2%, 4000 calls/s, uncached=7.5 µs/call
> mustSendSize:
> cached/calls=97.4% complete/calls=88%, 2100 calls/s, uncached=4.1 µs/call
> checkForLostPackets:
> cached/calls=98,6%, 5500 calls/s, uncached=3.5 µs/call
> (That is, all above reduced cpu load by 6%, about quarter of current node use)
> queueAndEstimateSize:
> cached/calls=96.6%, 76 calls/s, uncached=6.7 µs/call
> (That is, while cache was effective here too, optimizing this one was nearly
> useless)
> 
> Results from higher-loaded nodes would be interesting.

Although I'm not a huge fan of increasing memory usage by adding caching instead of fixing the root of the problem, this might be an acceptable stopgap until we get to doing the complex refactoring? What do people make of this set? There is also an instrumentation patch for development logging: 4c39e930d5b7c13e88a90c420ec47a5fc02b726e Maybe this would be suitable for a DEBUG or TRACE level?