### PR TITLE
Manifest putter fix mime type guessing

### DIFF
--- a/src/freenet/client/async/BaseManifestPutter.java
+++ b/src/freenet/client/async/BaseManifestPutter.java
@@ -1469,7 +1469,7 @@ public abstract class BaseManifestPutter extends ManifestPutter {
 
 		public ContainerBuilder makeSubContainer(String name) {
 			ContainerBuilder subCon = new ContainerBuilder(selfHandle, name);
-			currentDir.put(name , subCon.selfHandle);
+			currentDir.put(name, subCon.selfHandle);
 			putHandlersTransformMap.put(subCon.selfHandle, currentDir);
 			perContainerPutHandlersWaitingForMetadata.get(selfHandle).add(subCon.selfHandle);
 			return subCon;
@@ -1556,7 +1556,7 @@ public abstract class BaseManifestPutter extends ManifestPutter {
                 manifestEntries.put(name, o);
             } else if(o instanceof Bucket) {
                 RandomAccessBucket data = (RandomAccessBucket) o;
-                manifestEntries.put(name, new ManifestElement(name, data, null,data.size()));
+                manifestEntries.put(name, new ManifestElement(name, data, null, data.size()));
             } else if(o instanceof HashMap) {
                 manifestEntries.put(name, bucketsByNameToManifestEntries(Metadata.forceMap(o)));
             } else

--- a/src/freenet/client/async/ContainerInserter.java
+++ b/src/freenet/client/async/ContainerInserter.java
@@ -340,7 +340,7 @@ public class ContainerInserter implements ClientPutState, Serializable {
 				smc.addItem(name, (Metadata)o);
 			} else {
 				ManifestElement element = (ManifestElement) o;
-				String mimeType = element.mimeOverride;
+				String mimeType = element.getMimeType();
 				ClientMetadata cm;
 				if(mimeType == null || mimeType.equals(DefaultMIMETypes.DEFAULT_MIME_TYPE))
 					cm = null;

--- a/src/freenet/support/api/ManifestElement.java
+++ b/src/freenet/support/api/ManifestElement.java
@@ -6,6 +6,7 @@ package freenet.support.api;
 import java.io.Serializable;
 
 import freenet.client.async.ClientContext;
+import freenet.client.DefaultMIMETypes;
 import freenet.keys.FreenetURI;
 import freenet.support.io.ResumeFailedException;
 
@@ -123,6 +124,15 @@ public class ManifestElement implements Serializable {
 
 	public String getMimeTypeOverride() {
 		return mimeOverride;
+	}
+	/**
+	 * A MIME type to feed into ClientMetadata.
+	 */
+	public String getMimeType() {
+		String mimeType = mimeOverride;
+		if((mimeOverride == null) && (name != null))
+			mimeType = DefaultMIMETypes.guessMIMEType(name, true);
+		return mimeType;
 	}
 
 	public RandomAccessBucket getData() {


### PR DESCRIPTION
Sharewiki and Freereader work again.

→ old: http://127.0.0.1:8888/KeyUtils/Site/?mftype=TARmanifest&key=SSK@pFAHc9wpvLztZ4hYor2qYH54lYTYF6j6Pbg6Mqy5-bM,SPN7S~kYzaggMCCavc46mBxsrI5gTrtcc5JP4aXCTtg,AQACAAE/Test-1&hexwidth=32&deep=checked
→ new: http://127.0.0.1:8888/KeyUtils/Site/?mftype=TARmanifest&key=SSK@pFAHc9wpvLztZ4hYor2qYH54lYTYF6j6Pbg6Mqy5-bM,SPN7S~kYzaggMCCavc46mBxsrI5gTrtcc5JP4aXCTtg,AQACAAE/Test-3&hexwidth=32&deep=checked

This still needs someone who managed to setup junit4 to check whether all tests run.

Fixes bug 0006385 and bug 0006446:
- https://bugs.freenetproject.org/view.php?id=6385
- https://bugs.freenetproject.org/view.php?id=6446