### PR TITLE
freenet.support.TransferThread: Deprecate

### DIFF
--- a/src/freenet/support/TransferThread.java
+++ b/src/freenet/support/TransferThread.java
@@ -29,8 +29,15 @@ import freenet.support.io.TempBucketFactory;
  * When calling <code>start()</code>, the thread will iterate the first time after <code>getStartupDelay()</code> milliseconds.
  * After each iteration, it will sleep for <code>getSleepTime()</code> milliseconds.
  * 
+ * @deprecated
+ *     This class uses {@link TrivialTicker} in a bogus way.
+ *     See <a href="https://bugs.freenetproject.org/view.php?id=6423">issue 6423</a>.<br>
+ *     The Web Of Trust plugin contains a bugfixed version, please use that one instead.<br>
+ *     (The fixed version was not moved to fred because TransferThread is only used by WOT and
+ *     Freetalk, not by fred itself. Thus it should probably be moved to a common library.)
  * @author xor
  */
+@Deprecated
 public abstract class TransferThread implements PrioRunnable, ClientGetCallback, ClientPutCallback {
 	
 	private final String mName;

--- a/src/freenet/support/TransferThread.java
+++ b/src/freenet/support/TransferThread.java
@@ -32,9 +32,12 @@ import freenet.support.io.TempBucketFactory;
  * @deprecated
  *     This class uses {@link TrivialTicker} in a bogus way.
  *     See <a href="https://bugs.freenetproject.org/view.php?id=6423">issue 6423</a>.<br>
- *     The Web Of Trust plugin contains a bugfixed version, please use that one instead.<br>
- *     (The fixed version was not moved to fred because TransferThread is only used by WOT and
- *     Freetalk, not by fred itself. Thus it should probably be moved to a common library.)
+ *     Also, it was not used by fred itself but only by Web Of Trust and Freetalk, while not being
+ *     part of the fred official plugin API. Thus it should not be contained in fred.<br>
+ *     If you do continue to need this class for a plugin, please move it to a shared library for
+ *     plugins.<br>
+ *     In that case, please use the version of Web Of Trust as it contains fixes for the existing
+ *     bugs of this version here.
  * @author xor
  */
 @Deprecated


### PR DESCRIPTION
Reasons are explained in the added JavaDoc.

(For completeness, it shall be noted that the fixed version in WOT which the JavaDoc talks about is not committed yet. However there is a bugtracker entry at WOT which documents that it needs to be done, and it is the immediate next entry on my TODO list, so IMHO we can deprecate this already to make sure that people don't run into the bugs)