### PR TITLE
Reduce startup page refresh period to 1 second

### DIFF
--- a/src/freenet/clients/http/StartupToadlet.java
+++ b/src/freenet/clients/http/StartupToadlet.java
@@ -33,7 +33,7 @@ public class StartupToadlet extends Toadlet {
 			PageNode page = ctx.getPageMaker().getPageNode(desc, ctx, new RenderParameters().renderStatus(false).renderNavigationLinks(false).renderModeSwitch(false));
 			HTMLNode pageNode = page.outer;
 			HTMLNode headNode = page.headNode;
-			headNode.addChild("meta", new String[]{"http-equiv", "content"}, new String[]{"refresh", "20; url="});
+			headNode.addChild("meta", new String[]{"http-equiv", "content"}, new String[]{"refresh", "1; url="});
 			HTMLNode contentNode = page.content;
 
 			if(!isPRNGReady) {


### PR DESCRIPTION
Node startup can be much faster than 20 seconds, so to retain
responsiveness, especially when waiting on the first run setup, a faster
response rate is preferable.