### PR TITLE
Checkbox: select all friends

### DIFF
--- a/src/freenet/clients/http/BookmarkEditorToadlet.java
+++ b/src/freenet/clients/http/BookmarkEditorToadlet.java
@@ -272,8 +272,27 @@ public class BookmarkEditorToadlet extends Toadlet {
 						if(core.node.getDarknetConnections().length > 0 && ("addItem".equals(action) || "share".equals(action))) {
 							form.addChild("br");
 							form.addChild("br");
+							if (core.node.isFProxyJavascriptEnabled()) {
+								StringBuilder jsBuf = new StringBuilder();
+								// copypaste javascript from http://stackoverflow.com/a/7251104/7666
+								jsBuf.append( "  function checkAll(bx) {\n" );
+								jsBuf.append( "    var cbs = document.getElementsByClassName(\"darknet_connections\")[0].getElementsByTagName(\"input\");\n" );
+								jsBuf.append( "	   for(var i=0; i < cbs.length; i++) {\n" );
+								jsBuf.append( "	     if(cbs[i].type == \"checkbox\") {\n" );
+								jsBuf.append( "	       cbs[i].checked = bx.checked;\n" );
+								jsBuf.append( "	     }\n" );
+								jsBuf.append( "    }\n" );
+								jsBuf.append( "  }\n" );
+								form.addChild("script", "type", "text/javascript").addChild("%", jsBuf.toString());
+							}
 							HTMLNode peerTable = form.addChild("table", "class", "darknet_connections");
-							peerTable.addChild("th", "colspan", "2", NodeL10n.getBase().getString("QueueToadlet.recommendToFriends"));
+							if (core.node.isFProxyJavascriptEnabled()) {
+								HTMLNode headerRow = peerTable.addChild("tr");
+								headerRow.addChild("th").addChild("input", new String[] { "type", "onclick" }, new String[] { "checkbox", "checkAll(this)" });
+								headerRow.addChild("th", NodeL10n.getBase().getString("QueueToadlet.recommendToFriends"));
+							} else {
+								peerTable.addChild("tr").addChild("th", "colspan", "2", NodeL10n.getBase().getString("QueueToadlet.recommendToFriends"));
+							}
 							for(DarknetPeerNode peer : core.node.getDarknetConnections()) {
 								HTMLNode peerRow = peerTable.addChild("tr", "class", "darknet_connections_normal");
 								peerRow.addChild("td", "class", "peer-marker").addChild("input", new String[] { "type", "name" }, new String[] { "checkbox", "node_" + peer.hashCode() });

--- a/src/freenet/clients/http/BookmarkEditorToadlet.java
+++ b/src/freenet/clients/http/BookmarkEditorToadlet.java
@@ -273,22 +273,12 @@ public class BookmarkEditorToadlet extends Toadlet {
 							form.addChild("br");
 							form.addChild("br");
 							if (core.node.isFProxyJavascriptEnabled()) {
-								StringBuilder jsBuf = new StringBuilder();
-								// copypaste javascript from http://stackoverflow.com/a/7251104/7666
-								jsBuf.append( "  function checkAll(bx) {\n" );
-								jsBuf.append( "    var cbs = document.getElementsByClassName(\"darknet_connections\")[0].getElementsByTagName(\"input\");\n" );
-								jsBuf.append( "	   for(var i=0; i < cbs.length; i++) {\n" );
-								jsBuf.append( "	     if(cbs[i].type == \"checkbox\") {\n" );
-								jsBuf.append( "	       cbs[i].checked = bx.checked;\n" );
-								jsBuf.append( "	     }\n" );
-								jsBuf.append( "    }\n" );
-								jsBuf.append( "  }\n" );
-								form.addChild("script", "type", "text/javascript").addChild("%", jsBuf.toString());
+								form.addChild("script", new String[] {"type", "src"}, new String[] {"text/javascript",  "/static/js/checkall.js"});
 							}
 							HTMLNode peerTable = form.addChild("table", "class", "darknet_connections");
 							if (core.node.isFProxyJavascriptEnabled()) {
 								HTMLNode headerRow = peerTable.addChild("tr");
-								headerRow.addChild("th").addChild("input", new String[] { "type", "onclick" }, new String[] { "checkbox", "checkAll(this)" });
+								headerRow.addChild("th").addChild("input", new String[] { "type", "onclick" }, new String[] { "checkbox", "checkAll(this, 'darknet_connections')" });
 								headerRow.addChild("th", NodeL10n.getBase().getString("QueueToadlet.recommendToFriends"));
 							} else {
 								peerTable.addChild("tr").addChild("th", "colspan", "2", NodeL10n.getBase().getString("QueueToadlet.recommendToFriends"));

--- a/src/freenet/clients/http/ConnectionsToadlet.java
+++ b/src/freenet/clients/http/ConnectionsToadlet.java
@@ -395,6 +395,15 @@ public abstract class ConnectionsToadlet extends Toadlet {
 				jsBuf.append( "    }\n" );
 				jsBuf.append( "    theobj.value=\"update_notes\";\n" );
 				jsBuf.append( "  }\n" );
+				// copypaste javascript from http://stackoverflow.com/a/7251104/7666
+				jsBuf.append( "  function checkAll(bx) {\n" );
+				jsBuf.append( "    var cbs = document.getElementsByClassName(\"darknet_connections\")[0].getElementsByTagName(\"input\");\n" );
+				jsBuf.append( "	   for(var i=0; i < cbs.length; i++) {\n" );
+				jsBuf.append( "	     if(cbs[i].type == \"checkbox\") {\n" );
+				jsBuf.append( "	       cbs[i].checked = bx.checked;\n" );
+				jsBuf.append( "	     }\n" );
+				jsBuf.append( "    }\n" );
+				jsBuf.append( "  }\n" );
 				contentNode.addChild("script", "type", "text/javascript").addChild("%", jsBuf.toString());
 			}
 			HTMLNode peerTableInfobox = contentNode.addChild("div", "class", "infobox infobox-normal");
@@ -431,8 +440,13 @@ public abstract class ConnectionsToadlet extends Toadlet {
 					peerTable = peerTableInfoboxContent.addChild("table", "class", "darknet_connections");
 				}
 				HTMLNode peerTableHeaderRow = peerTable.addChild("tr");
-				if(enablePeerActions)
-					peerTableHeaderRow.addChild("th");
+				if(enablePeerActions) {
+					if(fProxyJavascriptEnabled) {
+						peerTableHeaderRow.addChild("th").addChild("input", new String[] { "type", "onclick" }, new String[] { "checkbox", "checkAll(this)" });
+					} else {
+						peerTableHeaderRow.addChild("th");
+					}
+				}
 				peerTableHeaderRow.addChild("th").addChild("a", "href", sortString(isReversed, "status")).addChild("#", l10n("statusTitle"));
 				if(hasNameColumn())
 					peerTableHeaderRow.addChild("th").addChild("a", "href", sortString(isReversed, "name")).addChild("span", new String[] { "title", "style" }, new String[] { l10n("nameClickToMessage"), "border-bottom: 1px dotted; cursor: help;" }, l10n("nameTitle"));

--- a/src/freenet/clients/http/ConnectionsToadlet.java
+++ b/src/freenet/clients/http/ConnectionsToadlet.java
@@ -395,16 +395,8 @@ public abstract class ConnectionsToadlet extends Toadlet {
 				jsBuf.append( "    }\n" );
 				jsBuf.append( "    theobj.value=\"update_notes\";\n" );
 				jsBuf.append( "  }\n" );
-				// copypaste javascript from http://stackoverflow.com/a/7251104/7666
-				jsBuf.append( "  function checkAll(bx) {\n" );
-				jsBuf.append( "    var cbs = document.getElementsByClassName(\"darknet_connections\")[0].getElementsByTagName(\"input\");\n" );
-				jsBuf.append( "	   for(var i=0; i < cbs.length; i++) {\n" );
-				jsBuf.append( "	     if(cbs[i].type == \"checkbox\") {\n" );
-				jsBuf.append( "	       cbs[i].checked = bx.checked;\n" );
-				jsBuf.append( "	     }\n" );
-				jsBuf.append( "    }\n" );
-				jsBuf.append( "  }\n" );
 				contentNode.addChild("script", "type", "text/javascript").addChild("%", jsBuf.toString());
+				contentNode.addChild("script", new String[] {"type", "src"}, new String[] {"text/javascript",  "/static/js/checkall.js"});
 			}
 			HTMLNode peerTableInfobox = contentNode.addChild("div", "class", "infobox infobox-normal");
 			HTMLNode peerTableInfoboxHeader = peerTableInfobox.addChild("div", "class", "infobox-header");
@@ -442,7 +434,7 @@ public abstract class ConnectionsToadlet extends Toadlet {
 				HTMLNode peerTableHeaderRow = peerTable.addChild("tr");
 				if(enablePeerActions) {
 					if(fProxyJavascriptEnabled) {
-						peerTableHeaderRow.addChild("th").addChild("input", new String[] { "type", "onclick" }, new String[] { "checkbox", "checkAll(this)" });
+						peerTableHeaderRow.addChild("th").addChild("input", new String[] { "type", "onclick" }, new String[] { "checkbox", "checkAll(this, 'darknet_connections')" });
 					} else {
 						peerTableHeaderRow.addChild("th");
 					}

--- a/src/freenet/clients/http/QueueToadlet.java
+++ b/src/freenet/clients/http/QueueToadlet.java
@@ -873,9 +873,27 @@ public class QueueToadlet extends Toadlet implements RequestCompletionCallback, 
 				        new String[]{"id", "name", "row", "cols"},
 				        new String[]{"descB", "description", "3", "70"});
 				form.addChild("br");
-
+				if (core.node.isFProxyJavascriptEnabled()) {
+					StringBuilder jsBuf = new StringBuilder();
+					// copypaste javascript from http://stackoverflow.com/a/7251104/7666
+					jsBuf.append( "  function checkAll(bx) {\n" );
+					jsBuf.append( "    var cbs = document.getElementsByClassName(\"darknet_connections\")[0].getElementsByTagName(\"input\");\n" );
+					jsBuf.append( "	   for(var i=0; i < cbs.length; i++) {\n" );
+					jsBuf.append( "	     if(cbs[i].type == \"checkbox\") {\n" );
+					jsBuf.append( "	       cbs[i].checked = bx.checked;\n" );
+					jsBuf.append( "	     }\n" );
+					jsBuf.append( "    }\n" );
+					jsBuf.append( "  }\n" );
+					form.addChild("script", "type", "text/javascript").addChild("%", jsBuf.toString());
+				}
 				HTMLNode peerTable = form.addChild("table", "class", "darknet_connections");
-				peerTable.addChild("th", "colspan", "2", l10n("recommendToFriends"));
+				if (core.node.isFProxyJavascriptEnabled()) {
+					HTMLNode headerRow = peerTable.addChild("tr");
+					headerRow.addChild("th").addChild("input", new String[] { "type", "onclick" }, new String[] { "checkbox", "checkAll(this)" });
+					headerRow.addChild("th", l10n("recommendToFriends"));
+				} else {
+					peerTable.addChild("tr").addChild("th", "colspan", "2", l10n("recommendToFriends"));
+				}
 				for(DarknetPeerNode peer : core.node.getDarknetConnections()) {
 					HTMLNode peerRow = peerTable.addChild("tr", "class", "darknet_connections_normal");
 					peerRow.addChild("td", "class", "peer-marker").addChild("input",

--- a/src/freenet/clients/http/QueueToadlet.java
+++ b/src/freenet/clients/http/QueueToadlet.java
@@ -874,22 +874,12 @@ public class QueueToadlet extends Toadlet implements RequestCompletionCallback, 
 				        new String[]{"descB", "description", "3", "70"});
 				form.addChild("br");
 				if (core.node.isFProxyJavascriptEnabled()) {
-					StringBuilder jsBuf = new StringBuilder();
-					// copypaste javascript from http://stackoverflow.com/a/7251104/7666
-					jsBuf.append( "  function checkAll(bx) {\n" );
-					jsBuf.append( "    var cbs = document.getElementsByClassName(\"darknet_connections\")[0].getElementsByTagName(\"input\");\n" );
-					jsBuf.append( "	   for(var i=0; i < cbs.length; i++) {\n" );
-					jsBuf.append( "	     if(cbs[i].type == \"checkbox\") {\n" );
-					jsBuf.append( "	       cbs[i].checked = bx.checked;\n" );
-					jsBuf.append( "	     }\n" );
-					jsBuf.append( "    }\n" );
-					jsBuf.append( "  }\n" );
-					form.addChild("script", "type", "text/javascript").addChild("%", jsBuf.toString());
+					form.addChild("script", new String[] {"type", "src"}, new String[] {"text/javascript",  "/static/js/checkall.js"});
 				}
 				HTMLNode peerTable = form.addChild("table", "class", "darknet_connections");
 				if (core.node.isFProxyJavascriptEnabled()) {
 					HTMLNode headerRow = peerTable.addChild("tr");
-					headerRow.addChild("th").addChild("input", new String[] { "type", "onclick" }, new String[] { "checkbox", "checkAll(this)" });
+					headerRow.addChild("th").addChild("input", new String[] { "type", "onclick" }, new String[] { "checkbox", "checkAll(this, 'darknet_connections')" });
 					headerRow.addChild("th", l10n("recommendToFriends"));
 				} else {
 					peerTable.addChild("tr").addChild("th", "colspan", "2", l10n("recommendToFriends"));

--- a/src/freenet/clients/http/WelcomeToadlet.java
+++ b/src/freenet/clients/http/WelcomeToadlet.java
@@ -344,9 +344,28 @@ public class WelcomeToadlet extends Toadlet {
                 if(node.getDarknetConnections().length > 0) {
                 	addForm.addChild("br");
                 	addForm.addChild("br");
-
+                	if (node.isFProxyJavascriptEnabled()) {
+                		StringBuilder jsBuf = new StringBuilder();
+                		// copypaste javascript from http://stackoverflow.com/a/7251104/7666
+                		jsBuf.append( "  function checkAll(bx) {\n" );
+                		jsBuf.append( "    var cbs = document.getElementsByClassName(\"darknet_connections\")[0].getElementsByTagName(\"input\");\n" );
+                		jsBuf.append( "	   for(var i=0; i < cbs.length; i++) {\n" );
+                		jsBuf.append( "	     if(cbs[i].type == \"checkbox\") {\n" );
+                		jsBuf.append( "	       cbs[i].checked = bx.checked;\n" );
+                		jsBuf.append( "	     }\n" );
+                		jsBuf.append( "    }\n" );
+                		jsBuf.append( "  }\n" );
+                		addForm.addChild("script", "type", "text/javascript").addChild("%", jsBuf.toString());
+                	}
+                	
                 	HTMLNode peerTable = addForm.addChild("table", "class", "darknet_connections");
-                	peerTable.addChild("th", "colspan", "2", NodeL10n.getBase().getString("BookmarkEditorToadlet.recommendToFriends"));
+                	if (node.isFProxyJavascriptEnabled()) {
+                		HTMLNode headerRow = peerTable.addChild("tr");
+                		headerRow.addChild("th").addChild("input", new String[] { "type", "onclick" }, new String[] { "checkbox", "checkAll(this)" });
+                		headerRow.addChild("th", NodeL10n.getBase().getString("QueueToadlet.recommendToFriends"));
+                	} else {
+                		peerTable.addChild("tr").addChild("th", "colspan", "2", NodeL10n.getBase().getString("QueueToadlet.recommendToFriends"));
+                	}
                 	for(DarknetPeerNode peer : node.getDarknetConnections()) {
                 		HTMLNode peerRow = peerTable.addChild("tr", "class", "darknet_connections_normal");
                 		peerRow.addChild("td", "class", "peer-marker").addChild("input", new String[] { "type", "name" }, new String[] { "checkbox", "node_" + peer.hashCode() });

--- a/src/freenet/clients/http/WelcomeToadlet.java
+++ b/src/freenet/clients/http/WelcomeToadlet.java
@@ -345,23 +345,13 @@ public class WelcomeToadlet extends Toadlet {
                 	addForm.addChild("br");
                 	addForm.addChild("br");
                 	if (node.isFProxyJavascriptEnabled()) {
-                		StringBuilder jsBuf = new StringBuilder();
-                		// copypaste javascript from http://stackoverflow.com/a/7251104/7666
-                		jsBuf.append( "  function checkAll(bx) {\n" );
-                		jsBuf.append( "    var cbs = document.getElementsByClassName(\"darknet_connections\")[0].getElementsByTagName(\"input\");\n" );
-                		jsBuf.append( "	   for(var i=0; i < cbs.length; i++) {\n" );
-                		jsBuf.append( "	     if(cbs[i].type == \"checkbox\") {\n" );
-                		jsBuf.append( "	       cbs[i].checked = bx.checked;\n" );
-                		jsBuf.append( "	     }\n" );
-                		jsBuf.append( "    }\n" );
-                		jsBuf.append( "  }\n" );
-                		addForm.addChild("script", "type", "text/javascript").addChild("%", jsBuf.toString());
+                		addForm.addChild("script", new String[] {"type", "src"}, new String[] {"text/javascript",  "/static/js/checkall.js"});
                 	}
                 	
                 	HTMLNode peerTable = addForm.addChild("table", "class", "darknet_connections");
                 	if (node.isFProxyJavascriptEnabled()) {
                 		HTMLNode headerRow = peerTable.addChild("tr");
-                		headerRow.addChild("th").addChild("input", new String[] { "type", "onclick" }, new String[] { "checkbox", "checkAll(this)" });
+                		headerRow.addChild("th").addChild("input", new String[] { "type", "onclick" }, new String[] { "checkbox", "checkAll(this, 'darknet_connections')" });
                 		headerRow.addChild("th", NodeL10n.getBase().getString("QueueToadlet.recommendToFriends"));
                 	} else {
                 		peerTable.addChild("tr").addChild("th", "colspan", "2", NodeL10n.getBase().getString("QueueToadlet.recommendToFriends"));

--- a/src/freenet/clients/http/staticfiles/js/checkall.js
+++ b/src/freenet/clients/http/staticfiles/js/checkall.js
@@ -1,0 +1,9 @@
+// copypaste javascript from http://stackoverflow.com/a/7251104/7666
+function checkAll(bx, classname) {
+  var cbs = document.getElementsByClassName(classname)[0].getElementsByTagName("input");
+  for(var i=0; i < cbs.length; i++) {
+    if(cbs[i].type == "checkbox") {
+      cbs[i].checked = bx.checked;
+    }
+  }
+}


### PR DESCRIPTION
This adds a feature I wanted to have for months: Just select all my friends with a single click.

A nice improvement would be to have a central place for the Javascript, but I’m not sure where to put that.

I’m working on adding the select-all logic for the queue, too. But I think it should ideally be in all tables which have check boxes on each line: click the box in the header to check or uncheck all boxes.