### PR TITLE
hide the no-library warning.

### DIFF
--- a/src/freenet/clients/http/WelcomeToadlet.java
+++ b/src/freenet/clients/http/WelcomeToadlet.java
@@ -112,12 +112,15 @@ public class WelcomeToadlet extends Toadlet {
 
     public boolean showSearchBox()  {
         // Only show it if Library is loaded.
-        if (node.pluginManager != null &&
-            node.pluginManager.isPluginLoaded("plugins.Library.Main")) {
-            return true;
-        } else {
-            return false;
-        }
+        return (node.pluginManager != null &&
+                node.pluginManager.isPluginLoaded("plugins.Library.Main"));
+    }
+    
+    public boolean showSearchBoxLoading()  {
+        // Only show it if Library is loaded.
+        return (node.pluginManager == null ||
+                (!node.pluginManager.isPluginLoaded("plugins.Library.Main") &&
+                 node.pluginManager.isPluginLoadedOrLoadingOrWantLoad("Library")));
     }
 
     public void addSearchBox(HTMLNode contentNode)  {
@@ -128,8 +131,7 @@ public class WelcomeToadlet extends Toadlet {
         searchBox.addChild("div", "class", "infobox-header").addChild("span", "class", "search-title-label", NodeL10n.getBase().getString("WelcomeToadlet.searchBoxLabel"));
         HTMLNode searchBoxContent = searchBox.addChild("div", "class", "infobox-content");
         // Search form
-        if(node.pluginManager != null &&
-           node.pluginManager.isPluginLoaded("plugins.Library.Main")) {
+        if(showSearchBox()) {
             // FIXME: Remove this once we have a non-broken index.
             searchBoxContent.addChild("span", "class", "search-warning-text", l10n("searchBoxWarningSlow"));
             HTMLNode searchForm = container.addFormChild(searchBoxContent, "/library/", "searchform");
@@ -137,8 +139,7 @@ public class WelcomeToadlet extends Toadlet {
             searchForm.addChild("input", new String[] { "type", "name", "value" }, new String[] { "submit", "find", l10n("searchFreenet") });
             // Search must be in a new window so that the user is able to browse the bookmarks.
             searchForm.addAttribute("target", "_blank");
-        } else if(node.pluginManager == null ||
-                  node.pluginManager.isPluginLoadedOrLoadingOrWantLoad("Library")) {
+        } else if(showSearchBoxLoading()) {
             // Warn that search plugin is not loaded.
             HTMLNode textSpan = searchBoxContent.addChild("span", "class", "search-not-availible-warning");
             NodeL10n.getBase().addL10nSubstitution(textSpan, "WelcomeToadlet.searchPluginLoading", new String[] { "link" }, new HTMLNode[] { HTMLNode.link("/plugins/") });

--- a/src/freenet/clients/http/WelcomeToadlet.java
+++ b/src/freenet/clients/http/WelcomeToadlet.java
@@ -131,7 +131,7 @@ public class WelcomeToadlet extends Toadlet {
         searchBox.addChild("div", "class", "infobox-header").addChild("span", "class", "search-title-label", NodeL10n.getBase().getString("WelcomeToadlet.searchBoxLabel"));
         HTMLNode searchBoxContent = searchBox.addChild("div", "class", "infobox-content");
         // Search form
-        if(showSearchBox()) {
+        if (showSearchBox()) {
             // FIXME: Remove this once we have a non-broken index.
             searchBoxContent.addChild("span", "class", "search-warning-text", l10n("searchBoxWarningSlow"));
             HTMLNode searchForm = container.addFormChild(searchBoxContent, "/library/", "searchform");
@@ -139,7 +139,7 @@ public class WelcomeToadlet extends Toadlet {
             searchForm.addChild("input", new String[] { "type", "name", "value" }, new String[] { "submit", "find", l10n("searchFreenet") });
             // Search must be in a new window so that the user is able to browse the bookmarks.
             searchForm.addAttribute("target", "_blank");
-        } else if(showSearchBoxLoading()) {
+        } else if (showSearchBoxLoading()) {
             // Warn that search plugin is not loaded.
             HTMLNode textSpan = searchBoxContent.addChild("span", "class", "search-not-availible-warning");
             NodeL10n.getBase().addL10nSubstitution(textSpan, "WelcomeToadlet.searchPluginLoading", new String[] { "link" }, new HTMLNode[] { HTMLNode.link("/plugins/") });

--- a/src/freenet/clients/http/WelcomeToadlet.java
+++ b/src/freenet/clients/http/WelcomeToadlet.java
@@ -110,6 +110,47 @@ public class WelcomeToadlet extends Toadlet {
     	return true;
     }
 
+    public boolean showSearchBox()  {
+        // Only show it if Library is loaded.
+        if (node.pluginManager != null &&
+            node.pluginManager.isPluginLoaded("plugins.Library.Main")) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    public void addSearchBox(HTMLNode contentNode)  {
+        // search box is BELOW bookmarks for now, until we get search
+        // fixed properly.  This function still contains legacy cruft
+        // because we might need that again when Library becomes
+        // usable again.
+        HTMLNode searchBox = contentNode.addChild("div", "class", "infobox infobox-normal");
+        searchBox.addAttribute("id", "search-freenet");
+        searchBox.addChild("div", "class", "infobox-header").addChild("span", "class", "search-title-label", NodeL10n.getBase().getString("WelcomeToadlet.searchBoxLabel"));
+        HTMLNode searchBoxContent = searchBox.addChild("div", "class", "infobox-content");
+        // Search form
+        if(node.pluginManager != null &&
+           node.pluginManager.isPluginLoaded("plugins.Library.Main")) {
+            // FIXME: Remove this once we have a non-broken index.
+            searchBoxContent.addChild("span", "class", "search-warning-text", l10n("searchBoxWarningSlow"));
+            HTMLNode searchForm = container.addFormChild(searchBoxContent, "/library/", "searchform");
+            searchForm.addChild("input", new String[] { "type", "size", "name" }, new String[] { "text", "80", "search" });
+            searchForm.addChild("input", new String[] { "type", "name", "value" }, new String[] { "submit", "find", l10n("searchFreenet") });
+            // Search must be in a new window so that the user is able to browse the bookmarks.
+            searchForm.addAttribute("target", "_blank");
+        } else if(node.pluginManager == null ||
+                  node.pluginManager.isPluginLoadedOrLoadingOrWantLoad("Library")) {
+            // Warn that search plugin is not loaded.
+            HTMLNode textSpan = searchBoxContent.addChild("span", "class", "search-not-availible-warning");
+            NodeL10n.getBase().addL10nSubstitution(textSpan, "WelcomeToadlet.searchPluginLoading", new String[] { "link" }, new HTMLNode[] { HTMLNode.link("/plugins/") });
+        } else {
+            // Warn that search plugin is not loaded.
+            HTMLNode textSpan = searchBoxContent.addChild("span", "class", "search-not-availible-warning");
+            NodeL10n.getBase().addL10nSubstitution(textSpan, "WelcomeToadlet.searchPluginNotLoaded", new String[] { "link" }, new HTMLNode[] { HTMLNode.link("/plugins/") });
+        }
+    }
+
 	public void handleMethodPOST(URI uri, HTTPRequest request, ToadletContext ctx) throws ToadletContextClosedException, IOException {
         if(!ctx.checkFullAccess(this))
             return;
@@ -414,34 +455,9 @@ public class WelcomeToadlet extends Toadlet {
 			addCategoryToList(BookmarkManager.DEFAULT_CATEGORY, bookmarksList, (!container.enableActivelinks()) || (useragent != null && useragent.contains("khtml") && !useragent.contains("chrome")), ctx);
 		}
 
-        // Search Box: Only show it if Library is loaded.
-        if(node.pluginManager != null &&
-           node.pluginManager.isPluginLoaded("plugins.Library.Main")) {
-            // search box is BELOW bookmarks for now, until we get search fixed properly.
-            HTMLNode searchBox = contentNode.addChild("div", "class", "infobox infobox-normal");
-            searchBox.addAttribute("id", "search-freenet");
-            searchBox.addChild("div", "class", "infobox-header").addChild("span", "class", "search-title-label", NodeL10n.getBase().getString("WelcomeToadlet.searchBoxLabel"));
-            HTMLNode searchBoxContent = searchBox.addChild("div", "class", "infobox-content");
-            // Search form
-            if(node.pluginManager != null &&
-               node.pluginManager.isPluginLoaded("plugins.Library.Main")) {
-                // FIXME: Remove this once we have a non-broken index.
-                searchBoxContent.addChild("span", "class", "search-warning-text", l10n("searchBoxWarningSlow"));
-                HTMLNode searchForm = container.addFormChild(searchBoxContent, "/library/", "searchform");
-                searchForm.addChild("input", new String[] { "type", "size", "name" }, new String[] { "text", "80", "search" });
-                searchForm.addChild("input", new String[] { "type", "name", "value" }, new String[] { "submit", "find", l10n("searchFreenet") });
-                // Search must be in a new window so that the user is able to browse the bookmarks.
-                searchForm.addAttribute("target", "_blank");
-            } else if(node.pluginManager == null ||
-                      node.pluginManager.isPluginLoadedOrLoadingOrWantLoad("Library")) {
-                // Warn that search plugin is not loaded.
-                HTMLNode textSpan = searchBoxContent.addChild("span", "class", "search-not-availible-warning");
-                NodeL10n.getBase().addL10nSubstitution(textSpan, "WelcomeToadlet.searchPluginLoading", new String[] { "link" }, new HTMLNode[] { HTMLNode.link("/plugins/") });
-            } else {
-                // Warn that search plugin is not loaded.
-                HTMLNode textSpan = searchBoxContent.addChild("span", "class", "search-not-availible-warning");
-                NodeL10n.getBase().addL10nSubstitution(textSpan, "WelcomeToadlet.searchPluginNotLoaded", new String[] { "link" }, new HTMLNode[] { HTMLNode.link("/plugins/") });
-            }
+        // Search Box
+        if (showSearchBox()) {
+            addSearchBox(contentNode);
         }
 
         // Fetch key box if the theme wants it below the bookmarks.

--- a/src/freenet/clients/http/WelcomeToadlet.java
+++ b/src/freenet/clients/http/WelcomeToadlet.java
@@ -110,20 +110,20 @@ public class WelcomeToadlet extends Toadlet {
     	return true;
     }
 
-    public boolean showSearchBox()  {
+    public boolean showSearchBox() {
         // Only show it if Library is loaded.
         return (node.pluginManager != null &&
                 node.pluginManager.isPluginLoaded("plugins.Library.Main"));
     }
     
-    public boolean showSearchBoxLoading()  {
+    public boolean showSearchBoxLoading() {
         // Only show it if Library is loaded.
         return (node.pluginManager == null ||
                 (!node.pluginManager.isPluginLoaded("plugins.Library.Main") &&
                  node.pluginManager.isPluginLoadedOrLoadingOrWantLoad("Library")));
     }
 
-    public void addSearchBox(HTMLNode contentNode)  {
+    public void addSearchBox(HTMLNode contentNode) {
         // This function still contains legacy cruft because we might
         // need that again when Library becomes usable again.
         HTMLNode searchBox = contentNode.addChild("div", "class", "infobox infobox-normal");

--- a/src/freenet/clients/http/WelcomeToadlet.java
+++ b/src/freenet/clients/http/WelcomeToadlet.java
@@ -414,33 +414,37 @@ public class WelcomeToadlet extends Toadlet {
 			addCategoryToList(BookmarkManager.DEFAULT_CATEGORY, bookmarksList, (!container.enableActivelinks()) || (useragent != null && useragent.contains("khtml") && !useragent.contains("chrome")), ctx);
 		}
 
-		// Search Box
-        // FIXME search box is BELOW bookmarks for now, until we get search fixed properly.
-		HTMLNode searchBox = contentNode.addChild("div", "class", "infobox infobox-normal");
-		searchBox.addAttribute("id", "search-freenet");
-        searchBox.addChild("div", "class", "infobox-header").addChild("span", "class", "search-title-label", NodeL10n.getBase().getString("WelcomeToadlet.searchBoxLabel"));
-		HTMLNode searchBoxContent = searchBox.addChild("div", "class", "infobox-content");
-		// Search form
-		if(node.pluginManager != null &&
-				node.pluginManager.isPluginLoaded("plugins.Library.Main")) {
-        	// FIXME: Remove this once we have a non-broken index.
-        	searchBoxContent.addChild("span", "class", "search-warning-text", l10n("searchBoxWarningSlow"));
-			HTMLNode searchForm = container.addFormChild(searchBoxContent, "/library/", "searchform");
-        	searchForm.addChild("input", new String[] { "type", "size", "name" }, new String[] { "text", "80", "search" });
-        	searchForm.addChild("input", new String[] { "type", "name", "value" }, new String[] { "submit", "find", l10n("searchFreenet") });
-        	// Search must be in a new window so that the user is able to browse the bookmarks.
-        	searchForm.addAttribute("target", "_blank");
-        } else if(node.pluginManager == null || 
-        		node.pluginManager.isPluginLoadedOrLoadingOrWantLoad("Library")) {
-			// Warn that search plugin is not loaded.
-			HTMLNode textSpan = searchBoxContent.addChild("span", "class", "search-not-availible-warning");
-			NodeL10n.getBase().addL10nSubstitution(textSpan, "WelcomeToadlet.searchPluginLoading", new String[] { "link" }, new HTMLNode[] { HTMLNode.link("/plugins/") });
-        } else {
-			// Warn that search plugin is not loaded.
-			HTMLNode textSpan = searchBoxContent.addChild("span", "class", "search-not-availible-warning");
-			NodeL10n.getBase().addL10nSubstitution(textSpan, "WelcomeToadlet.searchPluginNotLoaded", new String[] { "link" }, new HTMLNode[] { HTMLNode.link("/plugins/") });
-		}
-		
+        // Search Box: Only show it if Library is loaded.
+        if(node.pluginManager != null &&
+           node.pluginManager.isPluginLoaded("plugins.Library.Main")) {
+            // search box is BELOW bookmarks for now, until we get search fixed properly.
+            HTMLNode searchBox = contentNode.addChild("div", "class", "infobox infobox-normal");
+            searchBox.addAttribute("id", "search-freenet");
+            searchBox.addChild("div", "class", "infobox-header").addChild("span", "class", "search-title-label", NodeL10n.getBase().getString("WelcomeToadlet.searchBoxLabel"));
+            HTMLNode searchBoxContent = searchBox.addChild("div", "class", "infobox-content");
+            // Search form
+            if(node.pluginManager != null &&
+               node.pluginManager.isPluginLoaded("plugins.Library.Main")) {
+                // FIXME: Remove this once we have a non-broken index.
+                searchBoxContent.addChild("span", "class", "search-warning-text", l10n("searchBoxWarningSlow"));
+                HTMLNode searchForm = container.addFormChild(searchBoxContent, "/library/", "searchform");
+                searchForm.addChild("input", new String[] { "type", "size", "name" }, new String[] { "text", "80", "search" });
+                searchForm.addChild("input", new String[] { "type", "name", "value" }, new String[] { "submit", "find", l10n("searchFreenet") });
+                // Search must be in a new window so that the user is able to browse the bookmarks.
+                searchForm.addAttribute("target", "_blank");
+            } else if(node.pluginManager == null ||
+                      node.pluginManager.isPluginLoadedOrLoadingOrWantLoad("Library")) {
+                // Warn that search plugin is not loaded.
+                HTMLNode textSpan = searchBoxContent.addChild("span", "class", "search-not-availible-warning");
+                NodeL10n.getBase().addL10nSubstitution(textSpan, "WelcomeToadlet.searchPluginLoading", new String[] { "link" }, new HTMLNode[] { HTMLNode.link("/plugins/") });
+            } else {
+                // Warn that search plugin is not loaded.
+                HTMLNode textSpan = searchBoxContent.addChild("span", "class", "search-not-availible-warning");
+                NodeL10n.getBase().addL10nSubstitution(textSpan, "WelcomeToadlet.searchPluginNotLoaded", new String[] { "link" }, new HTMLNode[] { HTMLNode.link("/plugins/") });
+            }
+        }
+
+        // Fetch key box if the theme wants it below the bookmarks.
         if (!ctx.getPageMaker().getTheme().fetchKeyBoxAboveBookmarks) {
             this.putFetchKeyBox(ctx, contentNode);
         }

--- a/src/freenet/clients/http/WelcomeToadlet.java
+++ b/src/freenet/clients/http/WelcomeToadlet.java
@@ -121,10 +121,8 @@ public class WelcomeToadlet extends Toadlet {
     }
 
     public void addSearchBox(HTMLNode contentNode)  {
-        // search box is BELOW bookmarks for now, until we get search
-        // fixed properly.  This function still contains legacy cruft
-        // because we might need that again when Library becomes
-        // usable again.
+        // This function still contains legacy cruft because we might
+        // need that again when Library becomes usable again.
         HTMLNode searchBox = contentNode.addChild("div", "class", "infobox infobox-normal");
         searchBox.addAttribute("id", "search-freenet");
         searchBox.addChild("div", "class", "infobox-header").addChild("span", "class", "search-title-label", NodeL10n.getBase().getString("WelcomeToadlet.searchBoxLabel"));


### PR DESCRIPTION
I kept the switch code inside to allow for easily re-adding this in case library should work well again (since we want to have a working search box again).

I used spaces for indentation - should I switch to tabs for consistency or keep spaces because that’s what we want to have in future?

If we have no other pull-requests against the WelcomeToadlet, I could also reindent the whole file.

Caveat: Library does not load for me at all, so I cannot test whether the search box gets shown correctly. For that we’d need a Library plugin which works with purge-db4o.