### PR TITLE
Fix leak warnings and issues with temporary files/buckets/buffers

### DIFF
--- a/src/freenet/clients/fcp/ClientPutBase.java
+++ b/src/freenet/clients/fcp/ClientPutBase.java
@@ -176,8 +176,8 @@ public abstract class ClientPutBase extends ClientRequest implements ClientPutCa
 			if(generatedURI == null)
 				Logger.error(this, "No generated URI in onSuccess() for "+this+" from "+state);
 		}
-		// Could restart, and is on the putter, don't free data until we remove the putter
-		//freeData(container);
+		if(persistence == Persistence.CONNECTION)
+		    freeData();
 		finish();
 		trySendFinalMessage(null);
 		if(client != null)
@@ -193,8 +193,8 @@ public abstract class ClientPutBase extends ClientRequest implements ClientPutCa
 			completionTime = System.currentTimeMillis();
 			putFailedMessage = new PutFailedMessage(e, identifier, global);
 		}
-		// Could restart, and is on the putter, don't free data until we remove the putter
-		//freeData(container);
+        if(persistence == Persistence.CONNECTION)
+            freeData();
 		finish();
 		trySendFinalMessage(null);
 		if(client != null)

--- a/src/freenet/support/io/SwitchableProxyRandomAccessBuffer.java
+++ b/src/freenet/support/io/SwitchableProxyRandomAccessBuffer.java
@@ -81,17 +81,23 @@ abstract class SwitchableProxyRandomAccessBuffer implements LockableRandomAccess
 
     @Override
     public void free() {
+        innerFree();
+    }
+    
+    /** @return True unless the buffer has already been freed. */
+    protected boolean innerFree() {
         try {
             // Write lock as we're going to change the underlying pointer.
             lock.writeLock().lock();
             closed = true; // Effectively ...
-            if(underlying == null) return;
+            if(underlying == null) return false;
             underlying.free();
             underlying = null;
         }  finally {
             lock.writeLock().unlock();
         }
         afterFreeUnderlying();
+        return true;
     }
     
     public boolean hasBeenFreed() {

--- a/src/freenet/support/io/SwitchableProxyRandomAccessBuffer.java
+++ b/src/freenet/support/io/SwitchableProxyRandomAccessBuffer.java
@@ -103,7 +103,8 @@ abstract class SwitchableProxyRandomAccessBuffer implements LockableRandomAccess
         }
     }
 
-    /** Called after freeing underlying. */ 
+    /** Called after freeing the underlying storage. That includes when migrating, not just when
+     * free() is called! */ 
     protected void afterFreeUnderlying() {
         // Do nothing.
     }

--- a/src/freenet/support/io/TempBucketFactory.java
+++ b/src/freenet/support/io/TempBucketFactory.java
@@ -843,7 +843,7 @@ public class TempBucketFactory implements BucketFactory, LockableRandomAccessBuf
 
         @Override
         public void free() {
-            super.free();
+            if(!super.innerFree()) return;
             if(logMINOR) Logger.minor(this, "Freed "+this, new Exception("debug"));
             if(original != null) {
                 // Tell the TempBucket to prevent log spam. Don't call free().

--- a/src/freenet/support/io/TempBucketFactory.java
+++ b/src/freenet/support/io/TempBucketFactory.java
@@ -457,6 +457,11 @@ public class TempBucketFactory implements BucketFactory, LockableRandomAccessBuf
 				}
 			}
 		}
+		
+		/** Called only by TempRandomAccessBuffer */
+		private synchronized void onFreed() {
+            hasBeenFreed = true;
+		}
 
 		@Override
 		public RandomAccessBucket createShadow() {
@@ -832,7 +837,8 @@ public class TempBucketFactory implements BucketFactory, LockableRandomAccessBuf
             super.free();
             if(logMINOR) Logger.minor(this, "Freed "+this, new Exception("debug"));
             if(original != null) {
-                original.free(); // Set the freed flag to prevent log spam, won't come back here.
+                // Tell the TempBucket to prevent log spam. Don't call free().
+                original.onFreed();
             }
         }
         


### PR DESCRIPTION
Fixes bogus leak warnings by ensuring that the Buffer calls the Bucket when it is closed. This exposes some wider issues with temp buckets. Also adds a few comments explaining as this can be a bit tangled.