### PR TITLE
Fix broken splitfile wakeup times

### DIFF
--- a/src/freenet/client/async/SplitFileFetcherStorage.java
+++ b/src/freenet/client/async/SplitFileFetcherStorage.java
@@ -1642,9 +1642,8 @@ public class SplitFileFetcherStorage {
 
     /** Returns -1 if the request is finished, otherwise the wakeup time. */
     public long getCooldownWakeupTime(long now) {
-        // It is OK to use the main lock here.
-        // Cooldown is a separate lock because updating it is tricky.
-        // FIXME maybe set cooldown when finish and avoid this.
+        // LOCKING: hasFinished() uses (this), separate from cooldownLock.
+        // It is safe to use both here (on the request selection thread), one after the other.
         if(hasFinished()) return -1;
         synchronized(cooldownLock) {
             if(overallCooldownWakeupTime < now) overallCooldownWakeupTime = 0;

--- a/src/freenet/client/async/SplitFileFetcherStorage.java
+++ b/src/freenet/client/async/SplitFileFetcherStorage.java
@@ -1474,6 +1474,9 @@ public class SplitFileFetcherStorage {
     /** Choose a random key which can be fetched at the moment. Must not update any persistent data;
      * it's okay to update caches and other stuff that isn't stored to disk. If we fail etc we 
      * should do it off-thread.
+     * 
+     * FIXME make SplitFileFetcherGet per-segment, eliminate all this unnecessary complexity!
+     * 
      * @return The block number to be fetched, as an integer.
      */
     public MyKey chooseRandomKey() {

--- a/src/freenet/client/async/SplitFileFetcherStorage.java
+++ b/src/freenet/client/async/SplitFileFetcherStorage.java
@@ -1647,9 +1647,9 @@ public class SplitFileFetcherStorage {
     public long getCooldownWakeupTime(long now) {
         // LOCKING: hasFinished() uses (this), separate from cooldownLock.
         // It is safe to use both here (on the request selection thread), one after the other.
-        if(hasFinished()) return -1;
+        if (hasFinished()) return -1;
         synchronized(cooldownLock) {
-            if(overallCooldownWakeupTime < now) overallCooldownWakeupTime = 0;
+            if (overallCooldownWakeupTime < now) overallCooldownWakeupTime = 0;
             return overallCooldownWakeupTime;
         }
     }

--- a/src/freenet/client/async/SplitFileFetcherStorage.java
+++ b/src/freenet/client/async/SplitFileFetcherStorage.java
@@ -1640,7 +1640,12 @@ public class SplitFileFetcherStorage {
         fetcher.clearCooldown();
     }
 
+    /** Returns -1 if the request is finished, otherwise the wakeup time. */
     public long getCooldownWakeupTime(long now) {
+        // It is OK to use the main lock here.
+        // Cooldown is a separate lock because updating it is tricky.
+        // FIXME maybe set cooldown when finish and avoid this.
+        if(hasFinished()) return -1;
         synchronized(cooldownLock) {
             if(overallCooldownWakeupTime < now) overallCooldownWakeupTime = 0;
             return overallCooldownWakeupTime;

--- a/src/freenet/client/async/SplitFileInserterSender.java
+++ b/src/freenet/client/async/SplitFileInserterSender.java
@@ -212,14 +212,6 @@ public class SplitFileInserterSender extends SendableInsert {
     
     @Override
     public long getWakeupTime(ClientContext context, long now) {
-        // As with the fetcher, it is safe to use the main lock here, cooldown is separate because
-        // it's messy calculating it.
-        // FIXME set the flag when calculating it.
-        if(storage.hasFinished()) 
-            return -1;
-        if(storage.noBlocksToSend())
-            return Long.MAX_VALUE;
-        else
-            return 0;
+        return storage.getWakeupTime(context, now);
     }
 }

--- a/src/freenet/client/async/SplitFileInserterSender.java
+++ b/src/freenet/client/async/SplitFileInserterSender.java
@@ -212,6 +212,11 @@ public class SplitFileInserterSender extends SendableInsert {
     
     @Override
     public long getWakeupTime(ClientContext context, long now) {
+        // As with the fetcher, it is safe to use the main lock here, cooldown is separate because
+        // it's messy calculating it.
+        // FIXME set the flag when calculating it.
+        if(storage.hasFinished()) 
+            return -1;
         if(storage.noBlocksToSend())
             return Long.MAX_VALUE;
         else

--- a/src/freenet/client/async/SplitFileInserterStorage.java
+++ b/src/freenet/client/async/SplitFileInserterStorage.java
@@ -1693,7 +1693,9 @@ public class SplitFileInserterStorage {
         }
     }
     
-    /** Choose a block to insert */
+    /** Choose a block to insert.
+     * FIXME make SplitFileInserterSender per-segment, eliminate a lot of unnecessary complexity.
+     */
     public BlockInsert chooseBlock() {
         // FIXME this should probably use SimpleBlockChooser and hence use lowest-retry-count from each segment?
         // Less important for inserts than for requests though...

--- a/src/freenet/client/async/SplitFileInserterStorage.java
+++ b/src/freenet/client/async/SplitFileInserterStorage.java
@@ -1762,9 +1762,8 @@ public class SplitFileInserterStorage {
 
     /** @return -1 if the insert has finished, 0 if has blocks to send, otherwise Long.MAX_VALUE. */
     public long getWakeupTime(ClientContext context, long now) {
-        // As with the fetcher, it is safe to use the main lock here, cooldown is separate because
-        // it's messy calculating it.
-        // FIXME set the flag when calculating it.
+        // LOCKING: hasFinished() uses (this), separate from cooldownLock.
+        // It is safe to use both here (on the request selection thread), one after the other.
         if(hasFinished()) 
             return -1;
         if(noBlocksToSend())

--- a/src/freenet/client/async/SplitFileInserterStorage.java
+++ b/src/freenet/client/async/SplitFileInserterStorage.java
@@ -1766,9 +1766,9 @@ public class SplitFileInserterStorage {
     public long getWakeupTime(ClientContext context, long now) {
         // LOCKING: hasFinished() uses (this), separate from cooldownLock.
         // It is safe to use both here (on the request selection thread), one after the other.
-        if(hasFinished()) 
+        if (hasFinished()) 
             return -1;
-        if(noBlocksToSend())
+        if (noBlocksToSend())
             return Long.MAX_VALUE;
         else
             return 0;

--- a/src/freenet/client/async/SplitFileInserterStorage.java
+++ b/src/freenet/client/async/SplitFileInserterStorage.java
@@ -1760,4 +1760,17 @@ public class SplitFileInserterStorage {
         this.callback.clearCooldown();
     }
 
+    /** @return -1 if the insert has finished, 0 if has blocks to send, otherwise Long.MAX_VALUE. */
+    public long getWakeupTime(ClientContext context, long now) {
+        // As with the fetcher, it is safe to use the main lock here, cooldown is separate because
+        // it's messy calculating it.
+        // FIXME set the flag when calculating it.
+        if(hasFinished()) 
+            return -1;
+        if(noBlocksToSend())
+            return Long.MAX_VALUE;
+        else
+            return 0;
+    }
+
 }


### PR DESCRIPTION
Fix a serious bug in the new client layer causing completed inserts (and possibly requests too) to not get removed from the internal queue structures (RGAs) and thus prevent other inserts from running. This is the minimal version of the fix. However the other one may make more sense given that the locking is pretty tricky either way. Please review with care; this one is much shorter!

It is important that this goes in for 1468, i.e. before purge-db4o is public.