### PR TITLE
Fix not unregistering inserts

### DIFF
--- a/src/freenet/client/async/SplitFileFetcher.java
+++ b/src/freenet/client/async/SplitFileFetcher.java
@@ -74,6 +74,7 @@ public class SplitFileFetcher implements ClientGetState, SplitFileFetcherStorage
         Logger.registerClass(SplitFileFetcher.class);
     }
 
+    /** Stores the progress of the download, including the actual data, in a separate file. */
     private transient SplitFileFetcherStorage storage;
     /** Kept here so we can resume from storage */
     private LockableRandomAccessBuffer raf;
@@ -90,6 +91,7 @@ public class SplitFileFetcher implements ClientGetState, SplitFileFetcherStorage
     final long token;
     /** Storage doesn't have a ClientContext so we need one here. */
     private transient ClientContext context;
+    /** Does the actual requests. */
     private transient SplitFileFetcherGet getter;
     private boolean failed;
     private boolean succeeded;

--- a/src/freenet/client/async/SplitFileFetcher.java
+++ b/src/freenet/client/async/SplitFileFetcher.java
@@ -74,8 +74,9 @@ public class SplitFileFetcher implements ClientGetState, SplitFileFetcherStorage
         Logger.registerClass(SplitFileFetcher.class);
     }
 
-    /** Stores the progress of the download, including the actual data, in a separate file. */
-    private transient SplitFileFetcherStorage storage;
+    /** Stores the progress of the download, including the actual data, in a separate file. 
+     * Created in onResume() or in the constructor, so must be volatile. */
+    private transient volatile SplitFileFetcherStorage storage;
     /** Kept here so we can resume from storage */
     private LockableRandomAccessBuffer raf;
     final ClientRequester parent;
@@ -91,8 +92,9 @@ public class SplitFileFetcher implements ClientGetState, SplitFileFetcherStorage
     final long token;
     /** Storage doesn't have a ClientContext so we need one here. */
     private transient ClientContext context;
-    /** Does the actual requests. */
-    private transient SplitFileFetcherGet getter;
+    /** Does the actual requests. 
+     * Created in onResume() or in the constructor, so must be volatile. */
+    private transient volatile SplitFileFetcherGet getter;
     private boolean failed;
     private boolean succeeded;
     private final boolean wantBinaryBlob;

--- a/src/freenet/client/async/SplitFileInserter.java
+++ b/src/freenet/client/async/SplitFileInserter.java
@@ -46,10 +46,12 @@ public class SplitFileInserter implements ClientPutState, Serializable, SplitFil
     private final boolean freeData;
     /** The RAF that stores check blocks and status info, used and created by storage. */
     private final LockableRandomAccessBuffer raf;
-    /** Stores the state of the insert and does most of the work. */
-    private transient SplitFileInserterStorage storage;
-    /** Actually does the insert */
-    private transient SplitFileInserterSender sender;
+    /** Stores the state of the insert and does most of the work. 
+     * Created in onResume() or in the constructor, so must be volatile. */
+    private transient volatile SplitFileInserterStorage storage;
+    /** Actually does the insert.
+     * Created in onResume() or in the constructor, so must be volatile. */
+    private transient volatile SplitFileInserterSender sender;
     /** Used any time a callback from storage needs us to do something higher level */
     private transient ClientContext context;
     /** Is the insert real-time? */

--- a/src/freenet/client/async/SplitFileInserter.java
+++ b/src/freenet/client/async/SplitFileInserter.java
@@ -238,8 +238,7 @@ public class SplitFileInserter implements ClientPutState, Serializable, SplitFil
     }
 
     protected void unregisterSender() {
-        if (sender != null)
-            sender.unregister(context, parent.getPriorityClass());
+        sender.unregister(context, parent.getPriorityClass());
     }
 
     protected void reportMetadata(Metadata metadata) {

--- a/src/freenet/client/async/SplitFileInserter.java
+++ b/src/freenet/client/async/SplitFileInserter.java
@@ -219,6 +219,7 @@ public class SplitFileInserter implements ClientPutState, Serializable, SplitFil
             @Override
             public boolean run(ClientContext context) {
                 if(logMINOR) Logger.minor(this, "Succeeding on "+SplitFileInserter.this);
+                unregisterSender();
                 if(!(ctx.earlyEncode || ctx.getCHKOnly)) {
                     reportMetadata(metadata);
                 }
@@ -234,6 +235,11 @@ public class SplitFileInserter implements ClientPutState, Serializable, SplitFil
         });
     }
 
+    protected void unregisterSender() {
+        if(sender != null)
+            sender.unregister(context, parent.getPriorityClass());
+    }
+
     protected void reportMetadata(Metadata metadata) {
         // Splitfile insert is always reportMetadataOnly, i.e. it always passes the metadata back 
         // to the parent SingleFileInserter, which will write it to a Bucket and probably insert it.
@@ -246,6 +252,7 @@ public class SplitFileInserter implements ClientPutState, Serializable, SplitFil
 
             @Override
             public boolean run(ClientContext context) {
+                unregisterSender();
                 raf.close();
                 raf.free();
                 originalData.close();

--- a/src/freenet/client/async/SplitFileInserter.java
+++ b/src/freenet/client/async/SplitFileInserter.java
@@ -238,7 +238,7 @@ public class SplitFileInserter implements ClientPutState, Serializable, SplitFil
     }
 
     protected void unregisterSender() {
-        if(sender != null)
+        if (sender != null)
             sender.unregister(context, parent.getPriorityClass());
     }
 


### PR DESCRIPTION
Fixes the underlying bug that put me onto #351. However that is still valid, as we should implement the contract.

Testing procedure: (Appears to be working)
- Start a node *without* #351 but with this patch (cherry-pick it).
- Start a bunch of inserts at priority 3 and a bunch at priority 4.
- After the inserts at 3 finish, the inserts at 4 should proceed.
- Without this patch, this does not happen. At least sometimes it doesn't. That's what put me on to #351...