### PR TITLE
Fix recovery condition

### DIFF
--- a/src/freenet/client/async/ClientLayerPersister.java
+++ b/src/freenet/client/async/ClientLayerPersister.java
@@ -233,10 +233,10 @@ public class ClientLayerPersister extends PersistentJobRunnerImpl {
         if(clientDatExists) {
             innerLoad(loaded, makeBucket(dir, baseName, false, null), noSerialize, context, requestStarters, random);
         }
-        if(clientDatCryptExists && loaded.needsMore()) {
+        if(clientDatCryptExists) {
             innerLoad(loaded, makeBucket(dir, baseName, false, encryptionKey), noSerialize, context, requestStarters, random);
         }
-        if(clientDatBakExists) {
+        if(clientDatBakExists && loaded.needsMore()) {
             innerLoad(loaded, makeBucket(dir, baseName, true, null), noSerialize, context, requestStarters, random);
         }
         if(clientDatBakCryptExists && loaded.needsMore()) {

--- a/src/freenet/client/async/ClientLayerPersister.java
+++ b/src/freenet/client/async/ClientLayerPersister.java
@@ -230,16 +230,16 @@ public class ClientLayerPersister extends PersistentJobRunnerImpl {
         }
         boolean failedSerialize = false;
         PartialLoad loaded = new PartialLoad();
-        if(clientDatExists) {
+        if (clientDatExists) {
             innerLoad(loaded, makeBucket(dir, baseName, false, null), noSerialize, context, requestStarters, random);
         }
-        if(clientDatCryptExists) {
+        if (clientDatCryptExists) {
             innerLoad(loaded, makeBucket(dir, baseName, false, encryptionKey), noSerialize, context, requestStarters, random);
         }
-        if(clientDatBakExists && loaded.needsMore()) {
+        if (clientDatBakExists && loaded.needsMore()) {
             innerLoad(loaded, makeBucket(dir, baseName, true, null), noSerialize, context, requestStarters, random);
         }
-        if(clientDatBakCryptExists && loaded.needsMore()) {
+        if (clientDatBakCryptExists && loaded.needsMore()) {
             innerLoad(loaded, makeBucket(dir, baseName, true, encryptionKey), noSerialize, context, requestStarters, random);
         }
         


### PR DESCRIPTION
Should improve recovery behaviour: We were recovering old requests from the .crypt file when it exists, but not using the .bak.crypt when we needed it.

Not tested, will look into this myself when I get around to it.