### PR TITLE
Linear complexity bounds on SplitFileInserterStorage.chooseBlock / SplitFileFetcherStorage.chooseRandomKey

### DIFF
--- a/src/freenet/support/RandomArrayIterator.java
+++ b/src/freenet/support/RandomArrayIterator.java
@@ -1,0 +1,107 @@
+package freenet.support;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.Random;
+
+/**
+ * Reusable read-only iterator with randomized array iteration order.
+ *
+ * This iterator iterates over the underlying array, yielding its elements in an (optionally)
+ * randomized order. Instances can be reused by {@link #reset(Random) resetting} them to their
+ * original position, optionally yielding a new random permutation of the array elements.
+ *
+ * Storage requirements are linear in the size of the underlying array, all instance operations
+ * finish in constant time.
+ *
+ * Instances of this class are not thread-safe.
+ *
+ * @author bertm
+ */
+public class RandomArrayIterator<E> implements Iterator<E> {
+    /** The underlying array. */
+    private final E[] array;
+
+    /** Permutation state. This array contains a permutation of indices into {@link #array}. */
+    private final int[] indices;
+    /** Random source for the current run. */
+    private Random random;
+    /** Current position in indices array. */
+    private int i;
+
+    /**
+     * Creates a new randomized iterator for the given array.
+     * @param array The underlying array
+     * @param random Random source for the iteration order
+     */
+    public RandomArrayIterator(E[] array, Random random) {
+        this.array = array;
+        this.indices = sequence(array.length);
+        reset(random);
+    }
+
+    /**
+     * Creates a new iterator for the given array. Initially, the array is iterated in the original
+     * ordering, {@link #reset(Random)} the iterator to get a new random iteration ordering.
+     * @param array The underlying array
+     */
+    public RandomArrayIterator(E[] array) {
+        this(array, null);
+    }
+
+    /**
+     * Resets this iterator. If a random source is given, the next sequence of calls to
+     * {@link #next()} will iterate over the array in a new random order. If it is {@code null},
+     * the iteration order remains unaltered.
+     * @param random Random source for the next run, or {@code null} to repeat the previous run
+     */
+    public void reset(Random random) {
+        this.random = random;
+        i = 0;
+    }
+
+    @Override
+    public boolean hasNext() {
+        return i < indices.length;
+    }
+
+    @Override
+    public E next() {
+        if (!hasNext()) {
+            throw new NoSuchElementException();
+        }
+        if (random != null) {
+            shuffleStep();
+        }
+        return array[indices[i++]];
+    }
+
+    @Override
+    public void remove() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Creates an integer sequence array.
+     * @param length The length of the resulting array.
+     * @return an array holding values [0, 1, ..., length - 1]
+     */
+    private int[] sequence(int length) {
+        final int[] ret = new int[length];
+        for (int i = 0; i < length; i++) {
+            ret[i] = i;
+        }
+        return ret;
+    }
+
+    /**
+     * Perfoms a Fisher–Yates shuffle step from the current position.
+     */
+    private void shuffleStep() {
+        // Swap the index at position i with a random subsequent index.
+        final int j = random.nextInt(indices.length - i) + i;
+        final int tmp = indices[j];
+        indices[j] = indices[i];
+        indices[i] = tmp;
+    }
+}

--- a/test/freenet/support/RandomArrayIteratorTest.java
+++ b/test/freenet/support/RandomArrayIteratorTest.java
@@ -1,0 +1,107 @@
+package freenet.support;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.NoSuchElementException;
+import java.util.Random;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class RandomArrayIteratorTest {
+    private static final int NUM_ELEMENTS = 100;
+
+    private RandomArrayIterator<Integer> iter;
+
+    @Before
+    public void setUp() {
+        Integer[] objects = new Integer[NUM_ELEMENTS];
+        for (int i = 0; i < NUM_ELEMENTS; i++) {
+            objects[i] = i;
+        }
+        iter = new RandomArrayIterator<Integer>(objects);
+    }
+
+    /**
+     * Tests that reset() function correctly, both with non-null and null argument.
+     */
+    @Test
+    public void testReset() {
+        testDefaultOrder();
+        iter.reset(null);
+        testDefaultOrder();
+        iter.reset(new Random(0));
+        int[] order = new int[NUM_ELEMENTS];
+        for (int i = NUM_ELEMENTS; iter.hasNext(); i--) {
+            int next = iter.next();
+            // Make sure we see each element exactly once
+            assertEquals(order[next], 0);
+            order[next] = i;
+        }
+        // Ensure we did not see the default order
+        boolean defaultOrder = true;
+        for (int i = 0; i < NUM_ELEMENTS; i++) {
+            if (NUM_ELEMENTS - i != order[i]) {
+                defaultOrder = false;
+                break;
+            }
+        }
+        assertFalse(defaultOrder);
+        iter.reset(null);
+        // Ensure we still see the same non-default order after non-randomizing reset
+        for (int i = NUM_ELEMENTS; iter.hasNext(); i--) {
+            int next = iter.next();
+            assertEquals(order[next], i);
+        }
+    }
+
+    /**
+     * Tests that the iterator yields the elements in their default order.
+     */
+    @Test
+    public void testDefaultOrder() {
+        for (int i = 0; i < NUM_ELEMENTS; i++) {
+            assertTrue(iter.hasNext());
+            assertEquals((int)iter.next(), i);
+        }
+        assertFalse(iter.hasNext());
+    }
+
+    /**
+     * Tests that when hasNext() returns false, next() throws.
+     */
+    @Test
+    public void testNoSuchElement() {
+        // Exhaust the iterator first
+        testDefaultOrder();
+        assertFalse(iter.hasNext());
+        try {
+            iter.next();
+            throw new AssertionError();
+        } catch(NoSuchElementException expected) {
+            assertFalse(iter.hasNext());
+        }
+    }
+
+    /**
+     * Tests that remove() throws.
+     */
+    @Test
+    public void testReadonly() {
+        // Try to remove each element
+        for (int i = 0; i < NUM_ELEMENTS; i++) {
+            iter.next();
+            try {
+                iter.remove();
+                throw new AssertionError();
+            } catch (UnsupportedOperationException expected) {
+                // remove() should throw
+            }
+        }
+        // Make sure remove() did not modify anything before throwing
+        iter.reset(null);
+        testDefaultOrder();
+    }
+}


### PR DESCRIPTION
This rewrites `chooseBlock` to be functionally equivalent to the existing code, but linear in worst case complexity in terms of number of segments (as compared to non-terminating previously). In the most common case, where (almost) all segments yield blocks, this method maintains O(1) complexity.

The primary feature of this pull request is to replace the following line, which is obviously non-terminating in the worst case (although such an infinite run happens with zero probability):
```java
while(tried[segNo = random.nextInt(segments.length)]);
```

Additional costs in memory are insignificant: they are limited to one integer per segment to maintain a permutation of segment array indices to shuffle.