### PR TITLE
Fix another unit test race condition.

### DIFF
--- a/test/freenet/client/async/SplitFileInserterStorageTest.java
+++ b/test/freenet/client/async/SplitFileInserterStorageTest.java
@@ -1348,7 +1348,6 @@ public class SplitFileInserterStorageTest extends TestCase {
             cb.waitForFinishedEncode();
             assertFalse(true); // Should have failed.
         } catch (InsertException e) {
-            assertTrue(executor.isIdle());
             assertFalse(segment.isEncoding());
             assertEquals(storage.getStatus(), Status.FAILED);
         }


### PR DESCRIPTION
Assert is bogus. The callback is called from a thread on the executor, which
might or might not have actually exited at this point. Does not affect the
other 2 assertions, which should both definitely be true; the first one is
the crucial bit, we don't get the actual failure until after the encode has
completed, but then we get a failure and not an encoded notice.