### PR TITLE
Fix RGA.wakeupTime never getting set.

### DIFF
--- a/src/freenet/support/RandomGrabArray.java
+++ b/src/freenet/support/RandomGrabArray.java
@@ -246,28 +246,28 @@ public class RandomGrabArray implements RemoveRandom, RequestSelectionTreeNode {
 					continue;
 				}
 				boolean excludeItem = false;
-				long excludeTime = item.getWakeupTime(context, now);
-				if(excludeTime > 0) {
-					// In cooldown, will be wanted later.
+				long itemWakeTime = item.getWakeupTime(context, now);
+				if (itemWakeTime > 0) {
+					// The item is in cooldown, will be wanted later.
 					excludeItem = true;
-					if(wakeupTime > excludeTime) wakeupTime = excludeTime;
-				} else {
-					long itemWakeTime = item.getWakeupTime(context, now);
-					if(itemWakeTime == -1) {
-						if(logMINOR) Logger.minor(this, "Removing "+item+" on "+this);
-						// We are doing compaction here. We don't need to swap with the end; we write valid ones to the target location.
-						reqsReading[offset] = null;
-						item.setParentGrabArray(null);
-						continue;
-					} else if(itemWakeTime > 0) {
-						if(itemWakeTime < wakeupTime) wakeupTime = itemWakeTime;
-						excludeItem = true;
+					if (itemWakeTime < wakeupTime) {
+						wakeupTime = itemWakeTime;
 					}
-					if(!excludeItem) {
-						itemWakeTime = excluding.exclude(item, context, now);
-						if(itemWakeTime > 0) {
-							if(itemWakeTime < wakeupTime) wakeupTime = itemWakeTime;
-							excludeItem = true;
+				} else if (itemWakeTime == -1) {
+					// The item is no longer needed and should be removed.
+					if(logMINOR) {
+						Logger.minor(this, "Removing "+item+" on "+this);
+					}
+					// We are doing compaction here. We don't need to swap with the end; we write valid ones to the target location.
+					reqsReading[offset] = null;
+					item.setParentGrabArray(null);
+					continue;
+				} else {
+					long excludeTime = excluding.exclude(item, context, now);
+					if (excludeTime > 0) {
+						excludeItem = true;
+						if(excludeTime < wakeupTime) {
+							wakeupTime = excludeTime;
 						}
 					}
 				}


### PR DESCRIPTION
Please consider for the next-but-one build. And test!!!
(Thanks for bertm for finding this problem, and for contributing some additional cleanup)

RGA.wakeupTime was always 0. Functionally this should not have any great
impact, although clearly the code was wrong.

SRGA.removeRandomExhaustive calls getWakeupTime and then if that returns 0
(indicating not in cooldown), it calls RGA.removeRandom. Which will then
return a positive cooldown time if it's actually in cooldown - so SRGA will
set itself into cooldown on the basis of that value. We were always returning
0 from RGA.getWakeupTime(); this fixes that, which should speed up SRGA
slightly.

There could be a correctness issue if reduceWakeupTime is being called a lot.
Currently IIRC we call clearWakeupTime instead in the common case where a
request finishes and becomes sendable (because it failed).

NEEDS TESTING!!! Bugs in this code could cause SEVERE problems!