### PR TITLE
Remove xml index plugins

### DIFF
--- a/src/freenet/pluginmanager/OfficialPlugins.java
+++ b/src/freenet/pluginmanager/OfficialPlugins.java
@@ -71,18 +71,6 @@ public class OfficialPlugins {
 					.essential()
 					.minimumVersion(10003)
 					.loadedFrom("CHK@ICSu1tgnNxJ0bApWkL-fQFswbfi9KPnmWI3Is4eq0iw,Sj1N3zdDHBbL3Uc3~eY4elqWwSP7IR1uHrKVR2-nA0s,AAMC--8/UPnP-10006.jar");
-			addPlugin("XMLLibrarian")
-					.inGroup("index")
-					.minimumVersion(26)
-					.usesXml()
-					.loadedFrom("CHK@TvjyCaG1dx0xIBSJkXSKA1ZT4I~NkRKeQqwC0a0bhFM,JiQe4CRjF1RwhQRFFQzP-ih9t2i0peV0tBCfJAeFCdk,AAIC--8/XMLLibrarian.jar")
-					.deprecated();
-			addPlugin("XMLSpider")
-					.inGroup("index")
-					.minimumVersion(48)
-					.usesXml()
-					.loadedFrom("CHK@ne-aaLuzVZLcHj0YmrclaCXJqxsSb7q-J0eYEiL9V9o,v0EdgDGBhTE9k6GsB44UrQ4ADUq5LCUVknLaE4iSEBk,AAMC--8/XMLSpider.jar")
-					.deprecated();
 			addPlugin("Freereader")
 					.inGroup("index")
 					.minimumVersion(4)

--- a/src/freenet/pluginmanager/PluginManager.java
+++ b/src/freenet/pluginmanager/PluginManager.java
@@ -101,6 +101,11 @@ public class PluginManager {
 
 	private boolean alwaysLoadOfficialPluginsFromCentralServer = false;
 
+  private final String[] NoLongerOfficialPluginNames = {
+          "XMLLibrarian",
+          "XMLSpider",
+  };
+
 	static final short PRIO = RequestStarter.INTERACTIVE_PRIORITY_CLASS;
 
 	public PluginManager(Node node, int lastVersion) {
@@ -453,6 +458,9 @@ public class PluginManager {
 					}, 0);
 				}
 			}
+      // If an official plugin has become no longer official failure to load it is okay.
+      // TODO: Remove a no longer official plugin from list of plugins to load on failure.
+      if (!Arrays.asList(NoLongerOfficialPluginNames).contains(filename)) {
 			PluginLoadFailedUserAlert newAlert =
 				new PluginLoadFailedUserAlert(filename,
 						pdl instanceof PluginDownLoaderOfficialHTTPS || pdl instanceof PluginDownLoaderOfficialFreenet, pdl instanceof PluginDownLoaderOfficialFreenet, stillTrying, e);
@@ -462,6 +470,7 @@ public class PluginManager {
 			}
 			core.alerts.register(newAlert);
 			core.alerts.unregister(oldAlert);
+      }
 		} catch (UnsupportedClassVersionError e) {
 			Logger.error(this, "Could not load plugin " + filename + " : " + e,
 					e);


### PR DESCRIPTION
The XML index plugins have long been obsolete and deprecated, are no longer maintained, and the time has come to remove them. (Rather than spend time updating them for purge-db4o.)

While this implementation will work, perhaps a better way to do it would be avoid the multiple maintenance points of `NoLongerOfficialPluginNames`, introduce a `.removed()`, and change the XMLLibrarian and XMLSpider `.deprecated()` to it.