### PR TITLE
Update WebOfTrust to build0015

### DIFF
--- a/src/freenet/pluginmanager/OfficialPlugins.java
+++ b/src/freenet/pluginmanager/OfficialPlugins.java
@@ -100,9 +100,9 @@ public class OfficialPlugins {
 					.advanced();
 			addPlugin("WebOfTrust")
 					.inGroup("communication")
-					.minimumVersion(13)
+					.minimumVersion(15)
 					.usesXml()
-					.loadedFrom("CHK@dSfeVmjFX15QVyFCTUQmZItrJi8XnoYpiapxLTxaQeg,wizfFOtkKSBEdjUYgjCUJczjl74r0CjRBfzvaRvKUMo,AAMC--8/WebOfTrust.jar");
+					.loadedFrom("CHK@1FWUqydeyTbxC3fut51QT8VGnokQFYHMoLsqzP4RU60,BM3ibZYejeo2-sC7WklJ9I8ZJysMpO9~l9MZ8NUzP2c,AAMC--8/WebOfTrust-build0015.jar");
 			addPlugin("FlogHelper")
 					.inGroup("communication")
 					.minimumVersion(31)


### PR DESCRIPTION
build0014 includes a huge amount of work: fixes bugs, updates for
purge-db4o, and adds an event-based API. build0015 is a small build and
tests fix on top of it - it makes no functional changes. The minimum
version is set to it because earlier versions will be broken with
purge-db4o.