### PR TITLE
Fix: Transfer backoff was never being reset.

### DIFF
--- a/src/freenet/node/PeerNode.java
+++ b/src/freenet/node/PeerNode.java
@@ -3227,9 +3227,9 @@ public abstract class PeerNode implements USKRetrieverCallback, BasePeerNode, Pe
 			long until;
 			if(now > (until = realTime ? transferBackedOffUntilRT : transferBackedOffUntilBulk)) {
 				if(realTime)
-					routingBackoffLengthRT = INITIAL_TRANSFER_BACKOFF_LENGTH;
+					transferBackoffLengthRT = INITIAL_TRANSFER_BACKOFF_LENGTH;
 				else
-					routingBackoffLengthBulk = INITIAL_TRANSFER_BACKOFF_LENGTH;
+					transferBackoffLengthBulk = INITIAL_TRANSFER_BACKOFF_LENGTH;
 				if(logMINOR)
 					Logger.minor(this, "Resetting transfer backoff on " + peer);
 			} else {


### PR DESCRIPTION
This bug has been present since introduction of different backoff types in 2008.
See commit: 514b85cb197777345c451342b33dd2f85b20747f