### PR TITLE
Prioritise memory jobs

### DIFF
--- a/src/freenet/client/async/SplitFileFetcherSegmentStorage.java
+++ b/src/freenet/client/async/SplitFileFetcherSegmentStorage.java
@@ -28,6 +28,7 @@ import freenet.node.KeysFetchingLocally;
 import freenet.support.Logger;
 import freenet.support.MemoryLimitedChunk;
 import freenet.support.MemoryLimitedJob;
+import freenet.support.MemoryLimitedJobRunner;
 import freenet.support.api.LockableRandomAccessBuffer.RAFLock;
 import freenet.support.io.NativeThread;
 import freenet.support.io.StorageFormatException;
@@ -286,7 +287,7 @@ public class SplitFileFetcherSegmentStorage {
         long limit = totalBlocks() * CHKBlock.DATA_LENGTH + 
             Math.max(parent.fecCodec.maxMemoryOverheadDecode(blocksForDecode(), checkBlocks),
                     parent.fecCodec.maxMemoryOverheadEncode(blocksForDecode(), checkBlocks));
-        final int prio = NativeThread.LOW_PRIORITY;
+        final int prio = parent.getPriorityClass();
         parent.memoryLimitedJobRunner.queueJob(new MemoryLimitedJob(limit) {
             
             @Override
@@ -324,7 +325,7 @@ public class SplitFileFetcherSegmentStorage {
                         if(!shutdown)
                             parent.finishedEncoding(SplitFileFetcherSegmentStorage.this);
                     } finally {
-                        if(lock != null) lock.unlock(false, prio);
+                        if(lock != null) lock.unlock(false, MemoryLimitedJobRunner.THREAD_PRIORITY);
                     }
                 }
                 return true;

--- a/src/freenet/client/async/SplitFileFetcherStorage.java
+++ b/src/freenet/client/async/SplitFileFetcherStorage.java
@@ -1116,8 +1116,6 @@ public class SplitFileFetcherStorage {
         }
         throw new IllegalStateException("Unable to allocate cross data block!");
     }
-
-
     
     public short getPriorityClass() {
         return fetcher.getPriorityClass();

--- a/src/freenet/client/async/SplitFileInserter.java
+++ b/src/freenet/client/async/SplitFileInserter.java
@@ -284,4 +284,9 @@ public class SplitFileInserter implements ClientPutState, Serializable, SplitFil
         sender.clearWakeupTime(context);
     }
 
+    @Override
+    public short getPriorityClass() {
+        return parent.getPriorityClass();
+    }
+
 }

--- a/src/freenet/client/async/SplitFileInserterCrossSegmentStorage.java
+++ b/src/freenet/client/async/SplitFileInserterCrossSegmentStorage.java
@@ -13,6 +13,7 @@ import freenet.keys.ClientCHK;
 import freenet.support.Logger;
 import freenet.support.MemoryLimitedChunk;
 import freenet.support.MemoryLimitedJob;
+import freenet.support.MemoryLimitedJobRunner;
 import freenet.support.api.LockableRandomAccessBuffer.RAFLock;
 import freenet.support.io.CountedOutputStream;
 import freenet.support.io.NativeThread;
@@ -149,7 +150,7 @@ public class SplitFileInserterCrossSegmentStorage {
         }
     }
 
-    public synchronized void startEncode() {
+    public synchronized void startEncode(final short prio) {
         if(encoded) return;
         if(cancelled) return;
         if(encoding) return;
@@ -157,7 +158,6 @@ public class SplitFileInserterCrossSegmentStorage {
         long limit = totalBlocks * CHKBlock.DATA_LENGTH + 
             Math.max(parent.codec.maxMemoryOverheadDecode(dataBlockCount, crossCheckBlockCount),
                 parent.codec.maxMemoryOverheadEncode(dataBlockCount, crossCheckBlockCount));
-        final int prio = NativeThread.LOW_PRIORITY;
         parent.memoryLimitedJobRunner.queueJob(new MemoryLimitedJob(limit) {
             
             @Override
@@ -188,7 +188,7 @@ public class SplitFileInserterCrossSegmentStorage {
                         }
                     } finally {
                         // Callback is part of the persistent job, unlock *after* calling it.
-                        if(lock != null) lock.unlock(false, prio);
+                        if(lock != null) lock.unlock(false, MemoryLimitedJobRunner.THREAD_PRIORITY);
                     }
                 }
                 return true;

--- a/src/freenet/client/async/SplitFileInserterStorage.java
+++ b/src/freenet/client/async/SplitFileInserterStorage.java
@@ -1135,14 +1135,16 @@ public class SplitFileInserterStorage {
     }
 
     private void startSegmentEncode() {
+        short prio = callback.getPriorityClass();
         for (SplitFileInserterSegmentStorage segment : segments)
-            segment.startEncode();
+            segment.startEncode(prio);
     }
 
     private void startCrossSegmentEncode() {
+        short prio = callback.getPriorityClass();
         // Start cross-segment encode.
         for (SplitFileInserterCrossSegmentStorage segment : crossSegments)
-            segment.startEncode();
+            segment.startEncode(prio);
     }
 
     /** Called when a cross-segment finishes encoding blocks. Can be called inside locks as it runs

--- a/src/freenet/client/async/SplitFileInserterStorageCallback.java
+++ b/src/freenet/client/async/SplitFileInserterStorageCallback.java
@@ -35,5 +35,8 @@ public interface SplitFileInserterStorageCallback {
     /** Called when a block becomes fetchable (unless because of an encode, in which case we only 
      * call encodingProgress() ) */
     void clearCooldown();
+    
+    /** Get request priority class for FEC jobs etc */
+    short getPriorityClass();
 
 }

--- a/src/freenet/node/NodeClientCore.java
+++ b/src/freenet/node/NodeClientCore.java
@@ -431,7 +431,7 @@ public class NodeClientCore implements Persistable {
                     }
 		    
 		}, true);
-		memoryLimitedJobRunner = new MemoryLimitedJobRunner(nodeConfig.getLong("memoryLimitedJobMemoryLimit"), nodeConfig.getInt("memoryLimitedJobThreadLimit"), node.executor, NativeThread.JAVA_PRIORITY_RANGE);
+		memoryLimitedJobRunner = new MemoryLimitedJobRunner(nodeConfig.getLong("memoryLimitedJobMemoryLimit"), nodeConfig.getInt("memoryLimitedJobThreadLimit"), node.executor, RequestStarter.NUMBER_OF_PRIORITY_CLASSES);
 		shutdownHook.addEarlyJob(new NativeThread("Shutdown FEC", NativeThread.HIGH_PRIORITY, true) {
 		    
 		    public void realRun() {

--- a/src/freenet/node/NodeClientCore.java
+++ b/src/freenet/node/NodeClientCore.java
@@ -431,7 +431,7 @@ public class NodeClientCore implements Persistable {
                     }
 		    
 		}, true);
-		memoryLimitedJobRunner = new MemoryLimitedJobRunner(nodeConfig.getLong("memoryLimitedJobMemoryLimit"), nodeConfig.getInt("memoryLimitedJobThreadLimit"), node.executor);
+		memoryLimitedJobRunner = new MemoryLimitedJobRunner(nodeConfig.getLong("memoryLimitedJobMemoryLimit"), nodeConfig.getInt("memoryLimitedJobThreadLimit"), node.executor, NativeThread.JAVA_PRIORITY_RANGE);
 		shutdownHook.addEarlyJob(new NativeThread("Shutdown FEC", NativeThread.HIGH_PRIORITY, true) {
 		    
 		    public void realRun() {

--- a/src/freenet/support/MemoryLimitedJob.java
+++ b/src/freenet/support/MemoryLimitedJob.java
@@ -9,7 +9,7 @@ public abstract class MemoryLimitedJob {
         this.initialAllocation = initial;
     }
     
-    /** Does not affect queueing, only the priority of the thread when it is run. */
+    /** All memory limited jobs run at LOW_PRIORITY. This affects queueing. */
     public abstract int getPriority();
     
     /** Start the job. Generally called by MemoryLimitedJobRunner, which schedules jobs within

--- a/src/freenet/support/MemoryLimitedJobRunner.java
+++ b/src/freenet/support/MemoryLimitedJobRunner.java
@@ -4,6 +4,7 @@ import java.util.ArrayDeque;
 import java.util.Deque;
 
 import freenet.node.PrioRunnable;
+import freenet.support.io.NativeThread;
 
 /** Start jobs as long as there is sufficient memory (or other limited resource) available, then 
  * queue them. FIXME I bet there is something like this in the standard libraries?
@@ -11,6 +12,7 @@ import freenet.node.PrioRunnable;
  */
 public class MemoryLimitedJobRunner {
     
+    public static final int THREAD_PRIORITY = NativeThread.LOW_PRIORITY;
     public long capacity;
     /** The amount of some limited resource that is in use */
     private long counter;
@@ -85,7 +87,7 @@ public class MemoryLimitedJobRunner {
             
             @Override
             public int getPriority() {
-                return job.getPriority();
+                return THREAD_PRIORITY;
             }
             
         });

--- a/test/freenet/client/async/ClientRequestSelectorTest.java
+++ b/test/freenet/client/async/ClientRequestSelectorTest.java
@@ -49,6 +49,7 @@ import freenet.support.io.BucketTools;
 import freenet.support.io.ByteArrayRandomAccessBufferFactory;
 import freenet.support.io.FileUtil;
 import freenet.support.io.FilenameGenerator;
+import freenet.support.io.NativeThread;
 import freenet.support.io.NullOutputStream;
 import freenet.support.io.PersistentFileTracker;
 import freenet.support.io.PooledFileRandomAccessBufferFactory;
@@ -100,7 +101,7 @@ public class ClientRequestSelectorTest extends TestCase {
         cryptoKey = new byte[32];
         r.nextBytes(cryptoKey);
         checker = new CRCChecksumChecker();
-        memoryLimitedJobRunner = new MemoryLimitedJobRunner(9*1024*1024L, 20, executor);
+        memoryLimitedJobRunner = new MemoryLimitedJobRunner(9*1024*1024L, 20, executor, NativeThread.JAVA_PRIORITY_RANGE);
         jobRunner = new DummyJobRunner(executor, null);
         URI = FreenetURI.generateRandomCHK(r);
     }

--- a/test/freenet/client/async/ClientRequestSelectorTest.java
+++ b/test/freenet/client/async/ClientRequestSelectorTest.java
@@ -206,6 +206,11 @@ public class ClientRequestSelectorTest extends TestCase {
             return finishedEncode;
         }
 
+        @Override
+        public short getPriorityClass() {
+            return 0;
+        }
+
     }
     
     private HashResult[] getHashes(LockableRandomAccessBuffer data) throws IOException {

--- a/test/freenet/client/async/SplitFileFetcherStorageTest.java
+++ b/test/freenet/client/async/SplitFileFetcherStorageTest.java
@@ -49,6 +49,7 @@ import freenet.support.compress.Compressor.COMPRESSOR_TYPE;
 import freenet.support.io.ArrayBucketFactory;
 import freenet.support.io.BucketTools;
 import freenet.support.io.ByteArrayRandomAccessBufferFactory;
+import freenet.support.io.NativeThread;
 import freenet.support.io.StorageFormatException;
 import junit.framework.TestCase;
 
@@ -70,7 +71,7 @@ public class SplitFileFetcherStorageTest extends TestCase {
     static final WaitableExecutor exec = new WaitableExecutor(new PooledExecutor());
     static final PersistentJobRunner jobRunner = new DummyJobRunner(exec, null);
     static final Ticker ticker = new CheatingTicker(exec);
-    static MemoryLimitedJobRunner memoryLimitedJobRunner = new MemoryLimitedJobRunner(9*1024*1024L, 20, exec);
+    static MemoryLimitedJobRunner memoryLimitedJobRunner = new MemoryLimitedJobRunner(9*1024*1024L, 20, exec, NativeThread.JAVA_PRIORITY_RANGE);
     static final int BLOCK_SIZE = CHKBlock.DATA_LENGTH;
     private static final OnionFECCodec codec = new OnionFECCodec();
     private static final int MAX_SEGMENT_SIZE = 256;

--- a/test/freenet/client/async/SplitFileInserterStorageTest.java
+++ b/test/freenet/client/async/SplitFileInserterStorageTest.java
@@ -215,6 +215,11 @@ public class SplitFileInserterStorageTest extends TestCase {
             return finishedEncode;
         }
 
+        @Override
+        public short getPriorityClass() {
+            return 0;
+        }
+
     }
     
     public void testSmallSplitfileNoLastBlock() throws IOException, InsertException {

--- a/test/freenet/client/async/SplitFileInserterStorageTest.java
+++ b/test/freenet/client/async/SplitFileInserterStorageTest.java
@@ -61,6 +61,7 @@ import freenet.support.io.BucketTools;
 import freenet.support.io.ByteArrayRandomAccessBufferFactory;
 import freenet.support.io.FileUtil;
 import freenet.support.io.FilenameGenerator;
+import freenet.support.io.NativeThread;
 import freenet.support.io.NullOutputStream;
 import freenet.support.io.PersistentFileTracker;
 import freenet.support.io.PooledFileRandomAccessBufferFactory;
@@ -114,7 +115,7 @@ public class SplitFileInserterStorageTest extends TestCase {
         cryptoKey = new byte[32];
         r.nextBytes(cryptoKey);
         checker = new CRCChecksumChecker();
-        memoryLimitedJobRunner = new MemoryLimitedJobRunner(9*1024*1024L, 20, executor);
+        memoryLimitedJobRunner = new MemoryLimitedJobRunner(9*1024*1024L, 20, executor, NativeThread.JAVA_PRIORITY_RANGE);
         jobRunner = new DummyJobRunner(executor, null);
         URI = FreenetURI.generateRandomCHK(r);
     }
@@ -895,7 +896,7 @@ public class SplitFileInserterStorageTest extends TestCase {
         MyCallback cb = new MyCallback();
         MyKeysFetchingLocally keys = new MyKeysFetchingLocally();
         // Only enough for one segment at a time.
-        MemoryLimitedJobRunner memoryLimitedJobRunner = new MemoryLimitedJobRunner(9*1024*1024L, 1, executor);
+        MemoryLimitedJobRunner memoryLimitedJobRunner = new MemoryLimitedJobRunner(9*1024*1024L, 1, executor, NativeThread.JAVA_PRIORITY_RANGE);
         SplitFileInserterStorage storage = new SplitFileInserterStorage(data, size, cb, null,
                 new ClientMetadata(), false, null, smallRAFFactory, true, baseContext.clone(), 
                 cryptoAlgorithm, cryptoKey, null, hashes, smallBucketFactory, checker, 
@@ -907,7 +908,7 @@ public class SplitFileInserterStorageTest extends TestCase {
         SplitFileInserterStorage resumed = null;
         if(storage.crossSegments != null) {
             for(int i=0;i<storage.crossSegments.length;i++) {
-                memoryLimitedJobRunner = new MemoryLimitedJobRunner(9*1024*1024L, 1, executor);
+                memoryLimitedJobRunner = new MemoryLimitedJobRunner(9*1024*1024L, 1, executor, NativeThread.JAVA_PRIORITY_RANGE);
                 resumed = new SplitFileInserterStorage(storage.getRAF(), data, cb, r, 
                         memoryLimitedJobRunner, jobRunner, ticker, keys, fg, persistentFileTracker, null);
                 assertEquals(i, countEncodedCrossSegments(resumed));
@@ -922,7 +923,7 @@ public class SplitFileInserterStorageTest extends TestCase {
         }
         
         for(int i=0;i<storage.segments.length;i++) {
-            memoryLimitedJobRunner = new MemoryLimitedJobRunner(9*1024*1024L, 1, executor);
+            memoryLimitedJobRunner = new MemoryLimitedJobRunner(9*1024*1024L, 1, executor, NativeThread.JAVA_PRIORITY_RANGE);
             resumed = new SplitFileInserterStorage(storage.getRAF(), data, cb, r, 
                     memoryLimitedJobRunner, jobRunner, ticker, keys, fg, persistentFileTracker, null);
             assertEquals(i, countEncodedSegments(resumed));

--- a/test/freenet/support/MemoryLimitedJobRunnerTest.java
+++ b/test/freenet/support/MemoryLimitedJobRunnerTest.java
@@ -113,7 +113,7 @@ public class MemoryLimitedJobRunnerTest extends TestCase {
         for(int i=0;i<jobs.length;i++) jobs[i] = new SynchronousJob(JOB_SIZE, startLive, completion);
         // If it all fits, run all the jobs at once. If some are going to be queued, use a small thread limit.
         int maxThreads = JOB_COUNT <= JOB_LIMIT ? JOB_COUNT : 10;
-        MemoryLimitedJobRunner runner = new MemoryLimitedJobRunner(JOB_LIMIT, maxThreads, executor);
+        MemoryLimitedJobRunner runner = new MemoryLimitedJobRunner(JOB_LIMIT, maxThreads, executor, NativeThread.JAVA_PRIORITY_RANGE);
         for(SynchronousJob job : jobs)
             runner.queueJob(job);
         Thread.sleep(100);
@@ -307,7 +307,7 @@ public class MemoryLimitedJobRunnerTest extends TestCase {
         for(int i=0;i<jobs.length;i++) jobs[i] = new SynchronousJob(JOB_SIZE, startLive, completion);
         // If it all fits, run all the jobs at once. If some are going to be queued, use a small thread limit.
         int maxThreads = JOB_COUNT <= JOB_LIMIT ? JOB_COUNT : 10;
-        MemoryLimitedJobRunner runner = new MemoryLimitedJobRunner(JOB_LIMIT, maxThreads, executor);
+        MemoryLimitedJobRunner runner = new MemoryLimitedJobRunner(JOB_LIMIT, maxThreads, executor, NativeThread.JAVA_PRIORITY_RANGE);
         for(SynchronousJob job : jobs)
             runner.queueJob(job);
         Thread.sleep(100);


### PR DESCRIPTION
Priorities for MemoryLimitedJob's, i.e. FEC decode/encode jobs. Please check the call stack to ensure that there are no locking issues, but there shouldn't be any.

This should ensure that fproxy is reasonably responsive even when there are big files completing, and mitigate the damage caused by BC < 1.52 with encrypted disk enabled.