### PR TITLE
Add request identifiers to persistent requests

### DIFF
--- a/src/freenet/clients/fcp/ClientPutBase.java
+++ b/src/freenet/clients/fcp/ClientPutBase.java
@@ -180,7 +180,7 @@ public abstract class ClientPutBase extends ClientRequest implements ClientPutCa
       freeData();
     }
 		finish();
-		trySendFinalMessage(null);
+		trySendFinalMessage(null, null);
 		if(client != null)
 			client.notifySuccess(this);
 	}
@@ -198,7 +198,7 @@ public abstract class ClientPutBase extends ClientRequest implements ClientPutCa
       freeData();
     }
 		finish();
-		trySendFinalMessage(null);
+		trySendFinalMessage(null, null);
 		if(client != null)
 			client.notifyFailure(this);
 	}
@@ -215,7 +215,7 @@ public abstract class ClientPutBase extends ClientRequest implements ClientPutCa
 				generatedURI = uri;
 			}
 		}
-		trySendGeneratedURIMessage(null);
+		trySendGeneratedURIMessage(null, null);
 		if(client != null) {
 			RequestStatusCache cache = client.getRequestStatusCache();
 			if(cache != null) {
@@ -244,7 +244,7 @@ public abstract class ClientPutBase extends ClientRequest implements ClientPutCa
 		if(delete) {
 			metadata.free();
 		} else {
-			trySendGeneratedMetadataMessage(metadata, null);
+			trySendGeneratedMetadataMessage(metadata, null, null);
 		}
 	}
 	
@@ -257,7 +257,7 @@ public abstract class ClientPutBase extends ClientRequest implements ClientPutCa
 				InsertException cancelled = new InsertException(InsertExceptionMode.CANCELLED);
 				putFailedMessage = new PutFailedMessage(cancelled, identifier, global);
 			}
-			trySendFinalMessage(null);
+			trySendFinalMessage(null, null);
 		}
 		// notify client that request was removed
 		FCPMessage msg = new PersistentRequestRemovedMessage(getIdentifier(), global);
@@ -344,7 +344,7 @@ public abstract class ClientPutBase extends ClientRequest implements ClientPutCa
 		}
 	}
 
-	private void trySendFinalMessage(FCPConnectionOutputHandler handler) {
+	private void trySendFinalMessage(FCPConnectionOutputHandler handler, String listRequestIdentifier) {
 
 		FCPMessage msg;
 		synchronized (this) {
@@ -361,13 +361,13 @@ public abstract class ClientPutBase extends ClientRequest implements ClientPutCa
 			if(persistence == Persistence.CONNECTION && handler == null)
 				handler = origHandler.outputHandler;
 			if(handler != null)
-				handler.queue(msg);
+				handler.queue(FCPMessage.withListRequestIdentifier(msg, listRequestIdentifier));
 			else
-				client.queueClientRequestMessage(msg, 0);
+				client.queueClientRequestMessage(FCPMessage.withListRequestIdentifier(msg, listRequestIdentifier), 0);
 		}
 	}
 
-	private void trySendGeneratedURIMessage(FCPConnectionOutputHandler handler) {
+	private void trySendGeneratedURIMessage(FCPConnectionOutputHandler handler, String listRequestIdentifier) {
 		FCPMessage msg;
 		synchronized(this) {
 			msg = new URIGeneratedMessage(generatedURI, identifier, isGlobalQueue());
@@ -375,7 +375,7 @@ public abstract class ClientPutBase extends ClientRequest implements ClientPutCa
 		if(persistence == Persistence.CONNECTION && handler == null)
 			handler = origHandler.outputHandler;
 		if(handler != null)
-			handler.queue(msg);
+			handler.queue(FCPMessage.withListRequestIdentifier(msg, listRequestIdentifier));
 		else
 			client.queueClientRequestMessage(msg, 0);
 	}
@@ -383,10 +383,10 @@ public abstract class ClientPutBase extends ClientRequest implements ClientPutCa
 	/**
 	 * @param metadata Activated by caller.
 	 * @param handler
-	 * @param container
+	 * @param listRequestIdentifier
 	 */
-	private void trySendGeneratedMetadataMessage(Bucket metadata, FCPConnectionOutputHandler handler) {
-		FCPMessage msg = new GeneratedMetadataMessage(identifier, global, metadata);
+	private void trySendGeneratedMetadataMessage(Bucket metadata, FCPConnectionOutputHandler handler, String listRequestIdentifier) {
+		FCPMessage msg = FCPMessage.withListRequestIdentifier(new GeneratedMetadataMessage(identifier, global, metadata), listRequestIdentifier);
 		if(persistence == Persistence.CONNECTION && handler == null)
 			handler = origHandler.outputHandler;
 		if(handler != null)
@@ -415,10 +415,12 @@ public abstract class ClientPutBase extends ClientRequest implements ClientPutCa
 			client.queueClientRequestMessage(msg, verbosity);
 	}
 
+	protected abstract FCPMessage persistentTagMessage();
+
 	@Override
-	public void sendPendingMessages(FCPConnectionOutputHandler handler, boolean includePersistentRequest, boolean includeData, boolean onlyData) {
+	public void sendPendingMessages(FCPConnectionOutputHandler handler, String listRequestIdentifier, boolean includePersistentRequest, boolean includeData, boolean onlyData) {
 		if(includePersistentRequest) {
-			FCPMessage msg = persistentTagMessage();
+			FCPMessage msg = FCPMessage.withListRequestIdentifier(persistentTagMessage(), listRequestIdentifier);
 			handler.queue(msg);
 		}
 
@@ -428,18 +430,18 @@ public abstract class ClientPutBase extends ClientRequest implements ClientPutCa
 		Bucket meta;
 		synchronized (this) {
 			generated = generatedURI != null;
-			msg = progressMessage;
+			msg = FCPMessage.withListRequestIdentifier(progressMessage, listRequestIdentifier);
 			fin = finished;
 			meta = generatedMetadata;
 		}
 		if(generated)
-			trySendGeneratedURIMessage(handler);
+			trySendGeneratedURIMessage(handler, listRequestIdentifier);
 		if(meta != null)
-			trySendGeneratedMetadataMessage(meta, handler);
+			trySendGeneratedMetadataMessage(meta, handler, listRequestIdentifier);
 		if(msg != null)
 			handler.queue(msg);
 		if(fin)
-			trySendFinalMessage(handler);
+			trySendFinalMessage(handler, listRequestIdentifier);
 	}
 
 	protected abstract String getTypeName();

--- a/src/freenet/clients/fcp/ClientRequest.java
+++ b/src/freenet/clients/fcp/ClientRequest.java
@@ -177,7 +177,7 @@ public abstract class ClientRequest implements Serializable {
 	public abstract void onLostConnection(ClientContext context);
 
 	/** Send any pending messages for a persistent request e.g. after reconnecting */
-	public abstract void sendPendingMessages(FCPConnectionOutputHandler handler, boolean includePersistentRequest, boolean includeData, boolean onlyData);
+	public abstract void sendPendingMessages(FCPConnectionOutputHandler handler, String listRequestIdentifier, boolean includePersistentRequest, boolean includeData, boolean onlyData);
 
 	// Persistence
 
@@ -309,8 +309,6 @@ public abstract class ClientRequest implements Serializable {
 	public abstract boolean canRestart();
 
 	public abstract boolean restart(ClientContext context, boolean disableFilterData) throws PersistenceDisabledException;
-
-	protected abstract FCPMessage persistentTagMessage();
 
 	/**
 	 * Called after a ModifyPersistentRequest.

--- a/src/freenet/clients/fcp/EndListPersistentRequestsMessage.java
+++ b/src/freenet/clients/fcp/EndListPersistentRequestsMessage.java
@@ -9,10 +9,17 @@ import freenet.support.SimpleFieldSet;
 public class EndListPersistentRequestsMessage extends FCPMessage {
 
 	static final String name = "EndListPersistentRequests";
-	
+	private final String listRequestIdentifier;
+
+	public EndListPersistentRequestsMessage(String listRequestIdentifier) {
+		this.listRequestIdentifier = listRequestIdentifier;
+	}
+
 	@Override
 	public SimpleFieldSet getFieldSet() {
-		return new SimpleFieldSet(true);
+		SimpleFieldSet simpleFieldSet = new SimpleFieldSet(true);
+		simpleFieldSet.putSingle("Identifier", listRequestIdentifier);
+		return simpleFieldSet;
 	}
 
 	@Override

--- a/src/freenet/clients/fcp/FCPMessage.java
+++ b/src/freenet/clients/fcp/FCPMessage.java
@@ -179,6 +179,9 @@ public abstract class FCPMessage {
 	 * @return The new FCP message
 	 */
 	public static FCPMessage withListRequestIdentifier(final FCPMessage fcpMessage, final String listRequestIdentifier) {
+		if (listRequestIdentifier == null) {
+			return fcpMessage;
+		}
 		return new FCPMessage() {
 			@Override
 			public SimpleFieldSet getFieldSet() {

--- a/src/freenet/clients/fcp/FCPMessage.java
+++ b/src/freenet/clients/fcp/FCPMessage.java
@@ -165,6 +165,40 @@ public abstract class FCPMessage {
 		return FCPMessage.create(name, fs, null, null);
 	}
 
+	/**
+	 * Returns an FCP message that delegates the methods {@link #getFieldSet()}, {@link #getName()},
+	 * and {@link #run(FCPConnectionHandler, Node)} to the given FCP message, adding a
+	 * “ListRequestIdentifier” field to the {@link SimpleFieldSet} returned by {@link
+	 * #getFieldSet()}.
+	 *
+	 * @param fcpMessage
+	 *         The FCP message to wrap
+	 * @param listRequestIdentifier
+	 *         The list request identifier to add (may be {@code null} in which case nothing is
+	 *         added)
+	 * @return The new FCP message
+	 */
+	public static FCPMessage withListRequestIdentifier(final FCPMessage fcpMessage, final String listRequestIdentifier) {
+		return new FCPMessage() {
+			@Override
+			public SimpleFieldSet getFieldSet() {
+				SimpleFieldSet fieldSet = fcpMessage.getFieldSet();
+				fieldSet.putSingle("ListRequestIdentifier", listRequestIdentifier);
+				return fieldSet;
+			}
+
+			@Override
+			public String getName() {
+				return fcpMessage.getName();
+			}
+
+			@Override
+			public void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException {
+				fcpMessage.run(handler, node);
+			}
+		};
+	}
+
 	/** Do whatever it is that we do with this type of message. 
 	 * @throws MessageInvalidException */
 	public abstract void run(FCPConnectionHandler handler, Node node) throws MessageInvalidException;

--- a/src/freenet/clients/fcp/GetRequestStatusMessage.java
+++ b/src/freenet/clients/fcp/GetRequestStatusMessage.java
@@ -54,7 +54,7 @@ public class GetRequestStatusMessage extends FCPMessage {
                             ProtocolErrorMessage msg = new ProtocolErrorMessage(ProtocolErrorMessage.NO_SUCH_IDENTIFIER, false, null, identifier, global);
                             handler.outputHandler.queue(msg);
                         } else {
-                            req.sendPendingMessages(handler.outputHandler, true, true, onlyData);
+                            req.sendPendingMessages(handler.outputHandler, identifier, true, true, onlyData);
                         }
                         return false;
                     }
@@ -65,7 +65,7 @@ public class GetRequestStatusMessage extends FCPMessage {
                 handler.outputHandler.queue(msg);
             }
 		} else {
-			req.sendPendingMessages(handler.outputHandler, true, true, onlyData);
+			req.sendPendingMessages(handler.outputHandler, identifier, true, true, onlyData);
 		}
 	}
 

--- a/src/freenet/clients/fcp/ListPersistentRequestsMessage.java
+++ b/src/freenet/clients/fcp/ListPersistentRequestsMessage.java
@@ -55,7 +55,7 @@ public class ListPersistentRequestsMessage extends FCPMessage {
 					reschedule(context);
 					return false;
 				}
-				int p = client.queuePendingMessagesOnConnectionRestart(outputHandler, progressCompleted, 30);
+				int p = client.queuePendingMessagesOnConnectionRestart(outputHandler, listRequestIdentifier, progressCompleted, 30);
 				if(p <= progressCompleted) {
 					sentRestartJobs = true;
 					break;
@@ -70,7 +70,7 @@ public class ListPersistentRequestsMessage extends FCPMessage {
 					reschedule(context);
 					return false;
 				}
-				int p = client.queuePendingMessagesFromRunningRequests(outputHandler, progressRunning, 30);
+				int p = client.queuePendingMessagesFromRunningRequests(outputHandler, listRequestIdentifier, progressRunning, 30);
 				if(p <= progressRunning) {
 					complete(context);
 					return false;

--- a/src/freenet/clients/fcp/ListPersistentRequestsMessage.java
+++ b/src/freenet/clients/fcp/ListPersistentRequestsMessage.java
@@ -15,11 +15,8 @@ public class ListPersistentRequestsMessage extends FCPMessage {
 	static final String NAME = "ListPersistentRequests";
 	private final String identifier;
 
-	public ListPersistentRequestsMessage(SimpleFieldSet fs) throws MessageInvalidException {
+	public ListPersistentRequestsMessage(SimpleFieldSet fs) {
 		identifier = fs.get("Identifier");
-		if (identifier == null) {
-			throw new MessageInvalidException(ProtocolErrorMessage.MISSING_FIELD, "Must contain an Identifier field", null, false);
-		}
 	}
 	
 	@Override

--- a/src/freenet/clients/fcp/PersistentRequestClient.java
+++ b/src/freenet/clients/fcp/PersistentRequestClient.java
@@ -153,7 +153,7 @@ public class PersistentRequestClient {
 
 	public void queuePendingMessagesOnConnectionRestartAsync(FCPConnectionOutputHandler outputHandler, ClientContext context) {
 		if(persistence == Persistence.FOREVER) {
-			PersistentListJob job = new PersistentListJob(this, outputHandler, context) {
+			PersistentListJob job = new PersistentListJob(this, outputHandler, context, null) {
 
 				@Override
 				void complete(ClientContext context) {
@@ -163,7 +163,7 @@ public class PersistentRequestClient {
 			};
 			job.run(context);
 		} else {
-			TransientListJob job = new TransientListJob(this, outputHandler, context) {
+			TransientListJob job = new TransientListJob(this, outputHandler, context, null) {
 
 				@Override
 				void complete(ClientContext context) {

--- a/src/freenet/clients/fcp/PersistentRequestClient.java
+++ b/src/freenet/clients/fcp/PersistentRequestClient.java
@@ -183,7 +183,7 @@ public class PersistentRequestClient {
 	 * requests, to be immediately sent. This happens automatically on startup and hopefully
 	 * will encourage clients to acknowledge persistent requests!
 	 */
-	public int queuePendingMessagesOnConnectionRestart(FCPConnectionOutputHandler outputHandler, int offset, int max) {
+	public int queuePendingMessagesOnConnectionRestart(FCPConnectionOutputHandler outputHandler, String listRequestIdentifier, int offset, int max) {
 		Object[] reqs;
 		synchronized(this) {
 			reqs = completedUnackedRequests.toArray();
@@ -191,7 +191,7 @@ public class PersistentRequestClient {
 		int i = 0;
 		for(i=offset;i<Math.min(reqs.length,offset+max);i++) {
 			ClientRequest req = (ClientRequest) reqs[i];
-			((ClientRequest)reqs[i]).sendPendingMessages(outputHandler, true, false, false);
+			((ClientRequest)reqs[i]).sendPendingMessages(outputHandler, listRequestIdentifier, true, false, false);
 		}
 		return i;
 	}
@@ -199,7 +199,7 @@ public class PersistentRequestClient {
 	/**
 	 * Queue any and all pending messages from running requests. Happens on demand.
 	 */
-	public int queuePendingMessagesFromRunningRequests(FCPConnectionOutputHandler outputHandler, int offset, int max) {
+	public int queuePendingMessagesFromRunningRequests(FCPConnectionOutputHandler outputHandler, String listRequestIdentifier, int offset, int max) {
 		Object[] reqs;
 		synchronized(this) {
 			reqs = runningPersistentRequests.toArray();
@@ -207,7 +207,7 @@ public class PersistentRequestClient {
 		int i = 0;
 		for(i=offset;i<Math.min(reqs.length,offset+max);i++) {
 			ClientRequest req = (ClientRequest) reqs[i];
-			req.sendPendingMessages(outputHandler, true, false, false);
+			req.sendPendingMessages(outputHandler, listRequestIdentifier, true, false, false);
 		}
 		return i;
 	}


### PR DESCRIPTION
I’m currently writing a new high-level FCP client implementation and I’m facing a problem with processing the various replies to a `ListPersistentRequests`. Usually, when I send an Identifier with a request, the response carries the same Identifier; associating one with the other is a breeze. However, the replies to a `ListPersistentRequests` all have their own identifiers so it is impossible to associate the replies with a request. Using the approach of “use everything until you get an `EndListPersistentRequests`” will only work if all replies to a `ListPersistentRequests` are sent atomically. Unless that is guaranteed, a second `ListPersistentRequests` on the same connection will happily interleave its replies with the replies to the first request. Madness will ensue.

This pull request contains changes to all involved classes that will cause all messages sent as reply to a `ListPersistentRequests` to contains a `ListRequestIdentifier` field which works similar to the usual `Identifier` field; only that it does not contain the identifier of the request itself but the identifier of the request that caused the sending of the messages. The `EndListPersistentRequests` message contains the usual `Identifier` field, though.