### PR TITLE
Load management send slow down when close to limit (without strict fairness)

### DIFF
--- a/src/freenet/node/CHKInsertHandler.java
+++ b/src/freenet/node/CHKInsertHandler.java
@@ -119,14 +119,6 @@ public class CHKInsertHandler implements PrioRunnable, ByteCounter {
 			return;
 		}
 		
-		if(tag.shouldSlowDown()) {
-			try {
-				source.sendAsync(DMT.createFNPRejectedOverload(uid, false, false, realTimeFlag), null, this);
-			} catch (NotConnectedException e) {
-				// Ignore.
-			}
-		}
-		
         // Source will send us a DataInsert
         
         MessageFilter mf;

--- a/src/freenet/node/NodeDispatcher.java
+++ b/src/freenet/node/NodeDispatcher.java
@@ -21,6 +21,7 @@ import freenet.keys.Key;
 import freenet.keys.KeyBlock;
 import freenet.keys.NodeCHK;
 import freenet.keys.NodeSSK;
+import freenet.node.NodeStats.Accept;
 import freenet.node.NodeStats.AcceptStatus;
 import freenet.node.NodeStats.PeerLoadStats;
 import freenet.node.NodeStats.RejectReason;
@@ -378,6 +379,15 @@ public class NodeDispatcher implements Dispatcher, Runnable {
 			return true;
 		}
 		
+        if(status != null && status.slowDown()) {
+            Message rejected = DMT.createFNPRejectedOverload(uid, false, true, realTimeFlag);
+            try {
+                source.sendAsync(rejected, null, node.failureTable.senderCounter);
+            } catch (NotConnectedException e) {
+                // Ignore
+            }
+        }
+        
 		} catch (Error e) {
 			tag.unlockHandler();
 			throw e;
@@ -387,6 +397,8 @@ public class NodeDispatcher implements Dispatcher, Runnable {
 		} // Otherwise, sendOfferedKey is responsible for unlocking. 
 		
 		// Accept it.
+		
+
 		
 		try {
 			node.failureTable.sendOfferedKey(key, isSSK, needPubKey, uid, source, tag,realTimeFlag);
@@ -542,6 +554,14 @@ public class NodeDispatcher implements Dispatcher, Runnable {
 			// failure table even though we didn't accept any of them.
 			return;
 		}
+        if(status != null && status.slowDown()) {
+            Message rejected = DMT.createFNPRejectedOverload(id, false, true, realTimeFlag);
+            try {
+                source.sendAsync(rejected, null, node.failureTable.senderCounter);
+            } catch (NotConnectedException e) {
+                // Ignore
+            }
+        }
 		nodeStats.reportIncomingRequestLocation(key.toNormalizedDouble());
 		//if(!node.lockUID(id)) return false;
 		boolean needsPubKey = false;
@@ -604,6 +624,14 @@ public class NodeDispatcher implements Dispatcher, Runnable {
 			tag.unlockHandler(rejectReason.soft);
 			return;
 		}
+        if(status != null && status.slowDown()) {
+            Message rejected = DMT.createFNPRejectedOverload(id, false, true, realTimeFlag);
+            try {
+                source.sendAsync(rejected, null, node.failureTable.senderCounter);
+            } catch (NotConnectedException e) {
+                // Ignore
+            }
+        }
 		long now = System.currentTimeMillis();
 		if(m.getSpec().equals(DMT.FNPSSKInsertRequest)) {
 			NodeSSK key = (NodeSSK) m.getObject(DMT.FREENET_ROUTING_KEY);

--- a/src/freenet/node/NodeStats.java
+++ b/src/freenet/node/NodeStats.java
@@ -1278,7 +1278,7 @@ public class NodeStats implements Persistable, BlockTimeCallback {
 		
 		// Check bandwidth-based limits, with fair sharing.
 		
-		RejectReason r = checkBandwidthLiability(getOutputBandwidthUpperLimit(limit, nonOverheadFraction), requestsSnapshot, peerRequestsSnapshot, false, limit,
+		AcceptStatus r = checkBandwidthLiability(getOutputBandwidthUpperLimit(limit, nonOverheadFraction), requestsSnapshot, peerRequestsSnapshot, false, limit,
 				source, isLocal, isSSK, isInsert, isOfferReply, hasInStore, transfersPerInsert, realTimeFlag, maxOutputTransfers, maxTransfersOutPeerLimit, tag);  
 		if(r != null) return r;
 		
@@ -1341,7 +1341,7 @@ public class NodeStats implements Persistable, BlockTimeCallback {
 		if(tag != null) tag.setAccepted();
 		
 		// Accept
-		return null;
+		return new Accept();
 		}
 	}
 	
@@ -1463,7 +1463,7 @@ public class NodeStats implements Persistable, BlockTimeCallback {
 	 * request.
 	 * @return A string explaining why, or null if we can accept the request.
 	 */
-	private RejectReason checkBandwidthLiability(double bandwidthAvailableOutputUpperLimit,
+	private AcceptStatus checkBandwidthLiability(double bandwidthAvailableOutputUpperLimit,
 			RunningRequestsSnapshot requestsSnapshot, RunningRequestsSnapshot peerRequestsSnapshot, boolean input, long limit,
 			PeerNode source, boolean isLocal, boolean isSSK, boolean isInsert, boolean isOfferReply, boolean hasInStore, int transfersPerInsert, boolean realTimeFlag, int maxOutputTransfers, int maxOutputTransfersPeerLimit, UIDTag tag) {
 		String name = input ? "Input" : "Output";
@@ -1527,10 +1527,10 @@ public class NodeStats implements Persistable, BlockTimeCallback {
 			if(logMINOR)
 				Logger.minor(this, "Total usage is "+bandwidthLiabilityOutput+" below lower limit "+bandwidthAvailableOutputLowerLimit+" for "+name);
 		}
-		return null;
+		return new Accept();
 	}
 	
-	private RejectReason checkMaxOutputTransfers(int maxOutputTransfers,
+	private AcceptStatus checkMaxOutputTransfers(int maxOutputTransfers,
 			int maxTransfersOutUpperLimit, int maxTransfersOutLowerLimit,
 			int maxTransfersOutPeerLimit,
 			RunningRequestsSnapshot requestsSnapshot,
@@ -1561,7 +1561,7 @@ public class NodeStats implements Persistable, BlockTimeCallback {
 //			if(peerOutTransfers > Math.max(1, maxTransfersOutPeerLimit * SOFT_REJECT_MAX_BANDWIDTH_USAGE))
 //				// Send slow-down's if we are using more than 80% of our peer limit.
 //				slowDown("TooManyTransfers: Fair sharing between peers", isLocal, isInsert, isSSK, isOfferReply, realTime, tag);
-			return null;
+			return new Accept();
 		}
 		rejected("TooManyTransfers: Fair sharing between peers", isLocal, isInsert, isSSK, isOfferReply, realTime);
 		return new RejectReason("TooManyTransfers: Fair sharing between peers", true);

--- a/src/freenet/node/NodeStats.java
+++ b/src/freenet/node/NodeStats.java
@@ -1371,7 +1371,11 @@ public class NodeStats implements Persistable, BlockTimeCallback {
 //	}
 
 	private int getLimitSeconds(boolean realTimeFlag) {
-		return realTimeFlag ? BANDWIDTH_LIABILITY_LIMIT_SECONDS_REALTIME : BANDWIDTH_LIABILITY_LIMIT_SECONDS_BULK;
+		int x = realTimeFlag ? BANDWIDTH_LIABILITY_LIMIT_SECONDS_REALTIME : BANDWIDTH_LIABILITY_LIMIT_SECONDS_BULK;
+		// Increase the limit to compensate for the early warning threshold. We want and expect load to 
+		// average around the threshold, so we target that.
+		x = (int) ((double)x / EARLY_WARNING);
+		return x;
 	}
 
 	public int calculateMaxTransfersOut(PeerNode peer, boolean realTime,

--- a/src/freenet/node/NodeStats.java
+++ b/src/freenet/node/NodeStats.java
@@ -696,8 +696,8 @@ public class NodeStats implements Persistable, BlockTimeCallback {
 	 * actually happens) - but this should be very rare. */
 	static final double MIN_NON_OVERHEAD = 0.5;
 	
-	/** Start sending slow-down messages, without actually rejecting requests, at 80% utilisation */
-	static final double EARLY_WARNING = 0.8;
+	/** Start sending slow-down messages, without actually rejecting requests, at 75% utilisation */
+	static final double EARLY_WARNING = 0.75;
 	
 	// FIXME slowdown
 //	/** Proportion of the thread limit we can use without triggering slow-down messages */

--- a/src/freenet/node/NodeStats.java
+++ b/src/freenet/node/NodeStats.java
@@ -1111,6 +1111,8 @@ public class NodeStats implements Persistable, BlockTimeCallback {
 	
 	static abstract class AcceptStatus {
 	    public abstract boolean accept();
+
+        public abstract boolean slowDown();
 	}
 	
 	static class RejectReason extends AcceptStatus {
@@ -1130,6 +1132,10 @@ public class NodeStats implements Persistable, BlockTimeCallback {
 		public boolean accept() {
 		    return false;
 		}
+        @Override
+        public boolean slowDown() {
+            return false;
+        }
 	}
 	
 	static class Accept extends AcceptStatus {
@@ -1141,6 +1147,10 @@ public class NodeStats implements Persistable, BlockTimeCallback {
 	    public boolean accept() {
 	        return true;
 	    }
+        @Override
+        public boolean slowDown() {
+            return slowDown;
+        }
 	}
 	
 	private final Object serializeShouldRejectRequest = new Object();

--- a/src/freenet/node/NodeStats.java
+++ b/src/freenet/node/NodeStats.java
@@ -1106,7 +1106,11 @@ public class NodeStats implements Persistable, BlockTimeCallback {
 	 * etc. */
 	static final int TRANSFER_OUT_IN_OVERHEAD = 256;
 	
-	static class RejectReason {
+	static abstract class AcceptStatus {
+	    public abstract boolean accept();
+	}
+	
+	static class RejectReason extends AcceptStatus {
 		public final String name;
 		/** If true, rejected because of preemptive bandwidth limiting, i.e. "soft", at least somewhat predictable, can be retried.
 		 * If false, hard rejection, should backoff and not retry. */
@@ -1119,6 +1123,17 @@ public class NodeStats implements Persistable, BlockTimeCallback {
 		public String toString() {
 			return (soft ? "SOFT" : "HARD") + ":" + name;
 		}
+		@Override
+		public boolean accept() {
+		    return false;
+		}
+	}
+	
+	static class Accept extends AcceptStatus {
+	    @Override
+	    public boolean accept() {
+	        return true;
+	    }
 	}
 	
 	private final Object serializeShouldRejectRequest = new Object();
@@ -1160,7 +1175,7 @@ public class NodeStats implements Persistable, BlockTimeCallback {
 	 * separately.
 	 * @return The reason for rejecting it, or null to accept it.
 	 */
-	public RejectReason shouldRejectRequest(boolean canAcceptAnyway, boolean isInsert, boolean isSSK, boolean isLocal, boolean isOfferReply, PeerNode source, boolean hasInStore, boolean preferInsert, boolean realTimeFlag, UIDTag tag) {
+	public AcceptStatus shouldRejectRequest(boolean canAcceptAnyway, boolean isInsert, boolean isSSK, boolean isLocal, boolean isOfferReply, PeerNode source, boolean hasInStore, boolean preferInsert, boolean realTimeFlag, UIDTag tag) {
 		// Serialise shouldRejectRequest.
 		// It's not always called on the same thread, and things could be problematic if they interfere with each other.
 		synchronized(serializeShouldRejectRequest) {

--- a/src/freenet/node/RequestHandler.java
+++ b/src/freenet/node/RequestHandler.java
@@ -165,14 +165,6 @@ public class RequestHandler implements PrioRunnable, ByteCounter, RequestSenderL
 		Message accepted = DMT.createFNPAccepted(uid);
 		source.sendAsync(accepted, null, this);
 		
-		if(tag.shouldSlowDown()) {
-			try {
-				source.sendAsync(DMT.createFNPRejectedOverload(uid, false, false, realTimeFlag), null, this);
-			} catch (NotConnectedException e) {
-				// Ignore.
-			}
-		}
-		
 		Object o;
 		if(passedInKeyBlock != null) {
 			tag.setServedFromDatastore();

--- a/src/freenet/node/RequestStarter.java
+++ b/src/freenet/node/RequestStarter.java
@@ -11,6 +11,7 @@ import freenet.client.async.ClientContext;
 import freenet.client.async.RequestSelectionTreeNode;
 import freenet.client.async.ChosenBlockImpl;
 import freenet.keys.Key;
+import freenet.node.NodeStats.AcceptStatus;
 import freenet.node.NodeStats.RejectReason;
 import freenet.support.LogThresholdCallback;
 import freenet.support.Logger;
@@ -176,7 +177,7 @@ public class RequestStarter implements Runnable, RandomGrabArrayItemExclusionLis
 //					// Note that while waitFor() is blocking, we need such a limit anyway.
 //					if(localRequestsWaitingForSlots > maxWaitingForSlots) continue;
 //				}
-				RejectReason reason;
+				AcceptStatus reason;
 				assert(req.realTimeFlag == realTime);
 				if(LOCAL_REQUESTS_COMPETE_FAIRLY && !req.localRequestOnly) {
 					reason = stats.shouldRejectRequest(true, isInsert, isSSK, true, false, null, false, 

--- a/src/freenet/node/SSKInsertHandler.java
+++ b/src/freenet/node/SSKInsertHandler.java
@@ -103,14 +103,6 @@ public class SSKInsertHandler implements PrioRunnable, ByteCounter {
 			return;
 		}
 		
-		if(tag.shouldSlowDown()) {
-			try {
-				source.sendAsync(DMT.createFNPRejectedOverload(uid, false, false, realTimeFlag), null, this);
-			} catch (NotConnectedException e) {
-				// Ignore.
-			}
-		}
-		
 		while(headers == null || data == null || pubKey == null) {
 			MessageFilter mfDataInsertRejected = MessageFilter.create().setType(DMT.FNPDataInsertRejected).setField(DMT.UID, uid).setSource(source).setTimeout(DATA_INSERT_TIMEOUT);
 			MessageFilter mf = mfDataInsertRejected;

--- a/src/freenet/node/UIDTag.java
+++ b/src/freenet/node/UIDTag.java
@@ -35,7 +35,6 @@ public abstract class UIDTag {
 	protected final RequestTracker tracker;
 	protected boolean accepted;
 	protected boolean sourceRestarted;
-	private boolean slowDown;
 	
 	/** Nodes we have routed to at some point */
 	private HashSet<PeerNode> routedTo = null;
@@ -462,15 +461,5 @@ public abstract class UIDTag {
 	
 	public synchronized boolean isWaitingForSlot() {
 		return waitingForSlot;
-	}
-
-	/** Set a flag indicating the originator should slow down. Only used at the shouldRejectRequest stage. */
-	synchronized void slowDown() {
-		slowDown = true;
-	}
-
-	/** Query the slow-down flag. Should be checked after shouldRejectRequest. */
-	synchronized boolean shouldSlowDown() {
-		return slowDown;
 	}
 }


### PR DESCRIPTION
This makes fred send a slow-down signal when load is above 75% of the node's capacity, rather than only sending slow-down signals when we reject requests. The idea is to reduce the number of rejections (which can cause misrouting). The details are complicated and need reviewing.

Note that this is different to https://github.com/freenet/fred/pull/313 because it does NOT include the strict fairness code (and so doesn't need the associated changes to messages). IMHO that is probably not a good idea. The slow-down criteria are different too; it's a bit of a messy kludge, but strict fairness would probably cost us too much (at least if traffic is bursty).