### PR TITLE
MessageAuthCode: fix JVM-version-dependent test failure

### DIFF
--- a/src/freenet/crypt/MessageAuthCode.java
+++ b/src/freenet/crypt/MessageAuthCode.java
@@ -235,6 +235,18 @@ public final class MessageAuthCode {
      * @return Returns true if the MACs match, otherwise false.
      */
     public final static boolean verify(byte[] mac1, byte[] mac2){
+        /*
+         * An April 2015 patch prevented null input from throwing. JVMs without that patch will
+         * throw, so the change is included here for consistent behavior.
+         *
+         * http://hg.openjdk.java.net/jdk8u/jdk8u/jdk/rev/10929#l8.13
+         */
+        if (mac1 == mac2) {
+            return true;
+        }
+        if (mac1 == null || mac2 == null) {
+            return false;
+        }
         return MessageDigest.isEqual(mac1, mac2);
     }
     

--- a/test/freenet/crypt/MessageAuthCodeTest.java
+++ b/test/freenet/crypt/MessageAuthCodeTest.java
@@ -289,16 +289,16 @@ public class MessageAuthCodeTest{
         assertFalse(MessageAuthCode.verify(trueMacs[3], falseMacs[3]));
     }
 
-    @Test (expected = NullPointerException.class)
+    @Test
     public void testVerifyNullInput1() {
         byte[] nullArray = null;
-        MessageAuthCode.verify(nullArray, trueMacs[3]);
+        assertFalse(MessageAuthCode.verify(nullArray, trueMacs[3]));
     }
 
-    @Test (expected = NullPointerException.class)
+    @Test
     public void testVerifyNullInput2() {
         byte[] nullArray = null;
-        MessageAuthCode.verify(trueMacs[1], nullArray);
+        assertFalse(MessageAuthCode.verify(trueMacs[1], nullArray));
     }
 
     @Test
@@ -342,14 +342,8 @@ public class MessageAuthCodeTest{
             else{
                 mac = new MessageAuthCode(types[i], keys[i]);
             }
-            boolean throwNull = false;
             byte[] nullArray = null;
-            try{
-                mac.verifyData(nullArray, messages[i]);
-            }catch(NullPointerException e){
-                throwNull = true;
-            }
-            assertTrue("MACType: "+types[i].name(), throwNull);
+            assertFalse("MACType: "+types[i].name(), mac.verifyData(nullArray, messages[i]));
         }
     }
 


### PR DESCRIPTION
This fixes the test failures discussed [on devl](https://emu.freenetproject.org/pipermail/devl/2015-August/038145.html) by preventing `MessageAuthCode.verify()` from throwing when given `null`. Is this an appropriate way to go about it? I didn't find any callers where this would change behaviour.