### PR TITLE
Async chkinserthandler

### DIFF
--- a/src/freenet/node/CHKInsertHandler.java
+++ b/src/freenet/node/CHKInsertHandler.java
@@ -446,6 +446,11 @@ public class CHKInsertHandler implements PrioRunnable, ByteCounter, InsertSender
         	}
 		}
 		
+        finishFinish(block, code);
+    }
+    
+    private void finishFinish(CHKBlock block, int code) {
+        
 		// Don't commit until after we have received all the downstream transfer completion notifications.
 		// We don't want an attacker to see a ULPR notice from the inserter before he sees it from the end of the chain (bug 3338).
 		if(block != null) {

--- a/src/freenet/node/CHKInsertHandler.java
+++ b/src/freenet/node/CHKInsertHandler.java
@@ -448,15 +448,17 @@ public class CHKInsertHandler implements PrioRunnable, ByteCounter, InsertSender
     @Override
     public void onCompletion(CHKInsertSender sender) {
         boolean routingTookTooLong;
+        int code;
         synchronized(this) {
             routingTookTooLong = this.routingTookTooLong;
             calledCompletion = true;
+            code = finishingCode;
         }
         if(routingTookTooLong) {
             if(logMINOR) Logger.minor(this, "Completed after telling downstream on "+this);
         }
         
-        finishFinish(verify(), sender.getStatus());
+        finishFinish(verify(), code);
     }
     
     private void finishFinish(CHKBlock block, int code) {

--- a/src/freenet/node/CHKInsertHandler.java
+++ b/src/freenet/node/CHKInsertHandler.java
@@ -464,7 +464,7 @@ public class CHKInsertHandler implements PrioRunnable, ByteCounter, InsertSender
     	    sendCompletionSync(sender != null && sender.anyTransfersFailed());
     	else {
     	    if(logMINOR)
-    	        Logger.minor(this, "Not sending completion because of non-committing failure mode for "+this);
+    	        Logger.minor(this, "Not sending completion because of non-committing failure mode for "+this+" status="+code+" receive failed="+receiveFailed());
     	}
 		
         if(code != CHKInsertSender.TIMED_OUT && code != CHKInsertSender.GENERATED_REJECTED_OVERLOAD && 

--- a/src/freenet/node/CHKInsertHandler.java
+++ b/src/freenet/node/CHKInsertHandler.java
@@ -376,8 +376,6 @@ public class CHKInsertHandler implements PrioRunnable, ByteCounter, InsertSender
 	}
 
 	private boolean canCommit = false;
-    private boolean sentCompletion = false;
-    private Object sentCompletionLock = new Object();
     
     /**
      * If canCommit, and we have received all the data, and it
@@ -402,11 +400,7 @@ public class CHKInsertHandler implements PrioRunnable, ByteCounter, InsertSender
 		// If we wanted to reduce latency at the cost of security (bug 3338), we'd commit here, or even on the receiver thread.
 		
         // Wait for completion
-        boolean sentCompletionWasSet;
-        synchronized(sentCompletionLock) {
-        	sentCompletionWasSet = sentCompletion;
-        	sentCompletion = true;
-        }
+        boolean sentCompletionWasSet = false;
         
 		Message m=null;
 		

--- a/src/freenet/node/CHKInsertHandler.java
+++ b/src/freenet/node/CHKInsertHandler.java
@@ -206,7 +206,8 @@ public class CHKInsertHandler implements PrioRunnable, ByteCounter, InsertSender
         if(logMINOR) Logger.minor(this, "Sender finished with status "+status+" on "+this+" from "+sender);
         try {
             if(receiveFailed()) {
-                // Nothing else we can do
+                // Sender has just got back to us after an earlier receive failure.
+                // Nothing else we can do. Do not commit.
                 finish(CHKInsertSender.RECEIVE_FAILED);
                 return;
             }

--- a/src/freenet/node/CHKInsertHandler.java
+++ b/src/freenet/node/CHKInsertHandler.java
@@ -60,7 +60,7 @@ public class CHKInsertHandler implements PrioRunnable, ByteCounter, InsertSender
     private byte[] headers;
     private BlockReceiver br;
     private Thread runThread;
-    PartiallyReceivedBlock prb;
+    private PartiallyReceivedBlock prb;
     final InsertTag tag;
     private boolean canWriteDatastore;
 	private final boolean forkOnCacheable;

--- a/src/freenet/node/CHKInsertHandler.java
+++ b/src/freenet/node/CHKInsertHandler.java
@@ -405,7 +405,7 @@ public class CHKInsertHandler implements PrioRunnable, ByteCounter, InsertSender
 		Message m=null;
 		
 		boolean routingTookTooLong = false;
-        if((sender != null) && (!sentCompletionWasSet)) {
+        if(sender != null) {
             if(logMINOR) Logger.minor(this, "Waiting for completion");
             long startedTime = System.currentTimeMillis();
 			//If there are downstream senders, our final success report depends on there being no timeouts in the chain.

--- a/src/freenet/node/CHKInsertHandler.java
+++ b/src/freenet/node/CHKInsertHandler.java
@@ -448,6 +448,10 @@ public class CHKInsertHandler implements PrioRunnable, ByteCounter, InsertSender
         
         Logger.error(this, "Insert took too long, telling downstream that it's finished and reassigning to self on "+this);
         // Wait for completion.
+        if(sender.completed()) {
+            Logger.error(this, "Missed completion notification on "+this);
+            onCompletion(sender);
+        }
     }
     
     @Override

--- a/src/freenet/node/CHKInsertHandler.java
+++ b/src/freenet/node/CHKInsertHandler.java
@@ -518,6 +518,12 @@ public class CHKInsertHandler implements PrioRunnable, ByteCounter, InsertSender
         }
     }
     
+    @Override
+    public void onCompletion(CHKInsertSender sender) {
+        // TODO Auto-generated method stub
+        
+    }
+    
     /**
      * Verify data, or send DataInsertRejected.
      */
@@ -700,5 +706,5 @@ public class CHKInsertHandler implements PrioRunnable, ByteCounter, InsertSender
 		}
 		
 	};
-    
+
 }

--- a/src/freenet/node/CHKInsertHandler.java
+++ b/src/freenet/node/CHKInsertHandler.java
@@ -400,7 +400,7 @@ public class CHKInsertHandler implements PrioRunnable, ByteCounter, InsertSender
 		// If we wanted to reduce latency at the cost of security (bug 3338), we'd commit here, or even on the receiver thread.
 		
         // Wait for completion
-        boolean sentCompletionWasSet = false;
+        boolean sentCompletion = false;
         
 		Message m=null;
 		
@@ -428,7 +428,7 @@ public class CHKInsertHandler implements PrioRunnable, ByteCounter, InsertSender
         	}
         	if(routingTookTooLong) {
         		tag.timedOutToHandlerButContinued();
-        		sentCompletionWasSet = true;
+        		sentCompletion = true;
         		try {
         			source.sendAsync(DMT.createFNPInsertTransfersCompleted(uid, true), null, this);
         		} catch (NotConnectedException e) {
@@ -453,11 +453,11 @@ public class CHKInsertHandler implements PrioRunnable, ByteCounter, InsertSender
         		if(logMINOR) Logger.minor(this, "Completed after telling downstream on "+this);
         	}
         	boolean failed = sender.anyTransfersFailed();
-        	if(!sentCompletionWasSet)
+        	if(!sentCompletion)
         		m = DMT.createFNPInsertTransfersCompleted(uid, failed);
 		}
 		
-		if((sender == null) && (!sentCompletionWasSet) && (canCommit)) {
+		if((sender == null) && (!sentCompletion) && (canCommit)) {
 			//There are no downstream senders, but we stored the data locally, report successful transfer.
 			//Note that this is done even if the verify fails.
 			m = DMT.createFNPInsertTransfersCompleted(uid, false /* no timeouts */);

--- a/src/freenet/node/CHKInsertHandler.java
+++ b/src/freenet/node/CHKInsertHandler.java
@@ -287,7 +287,7 @@ public class CHKInsertHandler implements PrioRunnable, ByteCounter, InsertSender
             finish(CHKInsertSender.INTERNAL_ERROR);
             return;
         } finally {
-            if(!(waitingCompletion || waitingReceiveFinish))
+            if(!(waitingCompletion || waitingReceiveFinish || waitingCompletion))
                 tag.unlockHandler();
         }
 	}

--- a/src/freenet/node/CHKInsertHandler.java
+++ b/src/freenet/node/CHKInsertHandler.java
@@ -460,6 +460,7 @@ public class CHKInsertHandler implements PrioRunnable, ByteCounter, InsertSender
         int code;
         synchronized(this) {
             routingTookTooLong = this.routingTookTooLong;
+            if(calledCompletion) return;
             calledCompletion = true;
             code = finishingCode;
             if(!waitingCompletion) return;

--- a/src/freenet/node/CHKInsertSender.java
+++ b/src/freenet/node/CHKInsertSender.java
@@ -1416,9 +1416,7 @@ public final class CHKInsertSender extends BaseSender implements PrioRunnable, A
 	private synchronized void callListenersOffThread(final int status) {
 	    assert(status != NOT_FINISHED);
 	    if(calledListenersStatus) {
-	        // FIXME is this legal or not?
-	        Logger.error(this, "Calling listeners twice for "+this+" with status "+status, 
-	                new Exception("debug"));
+	        // Status changed e.g. due to receive failure after InsertReply.
 	        return;
 	    }
 	    // Whether it's legal or not, the listeners only want to be called ONCE.

--- a/src/freenet/node/CHKInsertSender.java
+++ b/src/freenet/node/CHKInsertSender.java
@@ -1411,6 +1411,12 @@ public final class CHKInsertSender extends BaseSender implements PrioRunnable, A
 	    if(status != NOT_FINISHED) {
 	        callListenerOffThread(listener, status);
 	    }
+	    if(calledListenersCompletion) {
+	        callListenerOffThreadCompletion(listener);
+	    }
+	    if(hasForwardedRejectedOverload) {
+	        callListenerOffThreadRejectedOverload(listener);
+	    }
 	}
 	
 	private synchronized void callListenersOffThread(final int status) {

--- a/src/freenet/node/CHKInsertSender.java
+++ b/src/freenet/node/CHKInsertSender.java
@@ -1425,7 +1425,7 @@ public final class CHKInsertSender extends BaseSender implements PrioRunnable, A
 	        callListenerOffThread(listener, status);
 	}
 
-    private synchronized void callListenersCompletion() {
+    private synchronized void callListenersOffThreadCompletion() {
         if(calledListenersCompletion) return;
         calledListenersCompletion = true;
         for(InsertSenderListener listener : listeners)

--- a/src/freenet/node/CHKInsertSender.java
+++ b/src/freenet/node/CHKInsertSender.java
@@ -363,7 +363,7 @@ public final class CHKInsertSender extends BaseSender implements PrioRunnable, A
     
     /** List of nodes we are waiting for either a transfer completion
      * notice or a transfer completion from. Also used as a sync object for waiting for transfer completion. */
-    private List<BackgroundTransfer> backgroundTransfers;
+    private final List<BackgroundTransfer> backgroundTransfers;
     
     private final CopyOnWriteArrayList<InsertSenderListener> listeners = 
             new CopyOnWriteArrayList<InsertSenderListener>();

--- a/src/freenet/node/CHKInsertSender.java
+++ b/src/freenet/node/CHKInsertSender.java
@@ -367,7 +367,7 @@ public final class CHKInsertSender extends BaseSender implements PrioRunnable, A
     
     private final CopyOnWriteArrayList<InsertSenderListener> listeners = 
             new CopyOnWriteArrayList<InsertSenderListener>();
-    private boolean calledListeners = false;
+    private boolean calledListenersStatus = false;
     
     /** Have all transfers completed and all nodes reported completion status? */
     private boolean allTransfersCompleted;
@@ -1409,14 +1409,14 @@ public final class CHKInsertSender extends BaseSender implements PrioRunnable, A
 	
 	private synchronized void callListenersOffThread(final int status) {
 	    assert(status != NOT_FINISHED);
-	    if(calledListeners) {
+	    if(calledListenersStatus) {
 	        // FIXME is this legal or not?
 	        Logger.error(this, "Calling listeners twice for "+this+" with status "+status, 
 	                new Exception("debug"));
 	        return;
 	    }
 	    // Whether it's legal or not, the listeners only want to be called ONCE.
-	    calledListeners = true;
+	    calledListenersStatus = true;
 	    for(InsertSenderListener listener : listeners)
 	        callListenerOffThread(listener, status);
 	}

--- a/src/freenet/node/CHKInsertSender.java
+++ b/src/freenet/node/CHKInsertSender.java
@@ -1430,16 +1430,11 @@ public final class CHKInsertSender extends BaseSender implements PrioRunnable, A
             }
  
             @Override
-            public String toString() {
-                return "CHKInsertHandler callback for "+uid;
-            }
-            
-            @Override
             public int getPriority() {
                 return NativeThread.HIGH_PRIORITY;
             }
             
-        });
+        }, "CHKInsertHandler callback for "+uid);
     }
 
 }

--- a/src/freenet/node/CHKInsertSender.java
+++ b/src/freenet/node/CHKInsertSender.java
@@ -771,9 +771,11 @@ public final class CHKInsertSender extends BaseSender implements PrioRunnable, A
     	if(hasForwardedRejectedOverload) return;
     	hasForwardedRejectedOverload = true;
    		notifyAll();
+        for(InsertSenderListener listener : listeners)
+            callListenerOffThreadRejectedOverload(listener);
 	}
 	
-	private void setTransferTimedOut() {
+    private void setTransferTimedOut() {
 		synchronized(this) {
 			if(!transferTimedOut) {
 				transferTimedOut = true;
@@ -1463,5 +1465,23 @@ public final class CHKInsertSender extends BaseSender implements PrioRunnable, A
             
         }, "CHKInsertHandler completion callback for "+uid);
     }
+    
+    private void callListenerOffThreadRejectedOverload(final InsertSenderListener listener) {
+        node.executor.execute(new PrioRunnable() {
+
+            @Override
+            public void run() {
+                listener.onReceivedRejectedOverload(CHKInsertSender.this);
+            }
+ 
+            @Override
+            public int getPriority() {
+                return NativeThread.HIGH_PRIORITY;
+            }
+            
+        }, "CHKInsertHandler rejected overload callback for "+uid);
+    }
+
+
 
 }

--- a/src/freenet/node/CHKInsertSender.java
+++ b/src/freenet/node/CHKInsertSender.java
@@ -368,6 +368,7 @@ public final class CHKInsertSender extends BaseSender implements PrioRunnable, A
     private final CopyOnWriteArrayList<InsertSenderListener> listeners = 
             new CopyOnWriteArrayList<InsertSenderListener>();
     private boolean calledListenersStatus = false;
+    private boolean calledListenersCompletion = false;
     
     /** Have all transfers completed and all nodes reported completion status? */
     private boolean allTransfersCompleted;
@@ -840,6 +841,7 @@ public final class CHKInsertSender extends BaseSender implements PrioRunnable, A
 				allTransfersCompleted = true;
 				notifyAll();
 				callListenersOffThread(status);
+				callListenersOffThreadCompletion();
 			}
 		}
         	
@@ -892,6 +894,7 @@ public final class CHKInsertSender extends BaseSender implements PrioRunnable, A
     		allTransfersCompleted = true;
     		notifyAll();
     		callListenersOffThread(status);
+    		callListenersOffThreadCompletion();
     	}
     	// Do not call finish(), that can only be called on the main thread and it will block.
     }
@@ -945,6 +948,7 @@ public final class CHKInsertSender extends BaseSender implements PrioRunnable, A
 				synchronized(CHKInsertSender.this) {
 					allTransfersCompleted = true;
 					CHKInsertSender.this.notifyAll();
+					callListenersOffThreadCompletion();
 				}
 			}
 		}
@@ -1421,6 +1425,13 @@ public final class CHKInsertSender extends BaseSender implements PrioRunnable, A
 	        callListenerOffThread(listener, status);
 	}
 
+    private synchronized void callListenersCompletion() {
+        if(calledListenersCompletion) return;
+        calledListenersCompletion = true;
+        for(InsertSenderListener listener : listeners)
+            callListenerOffThreadCompletion(listener);
+    }
+
     private void callListenerOffThread(final InsertSenderListener listener, final int status) {
         node.executor.execute(new PrioRunnable() {
 
@@ -1435,6 +1446,22 @@ public final class CHKInsertSender extends BaseSender implements PrioRunnable, A
             }
             
         }, "CHKInsertHandler callback for "+uid);
+    }
+
+    private void callListenerOffThreadCompletion(final InsertSenderListener listener) {
+        node.executor.execute(new PrioRunnable() {
+
+            @Override
+            public void run() {
+                listener.onCompletion(CHKInsertSender.this);
+            }
+ 
+            @Override
+            public int getPriority() {
+                return NativeThread.HIGH_PRIORITY;
+            }
+            
+        }, "CHKInsertHandler completion callback for "+uid);
     }
 
 }

--- a/src/freenet/node/CHKInsertSender.java
+++ b/src/freenet/node/CHKInsertSender.java
@@ -1422,11 +1422,21 @@ public final class CHKInsertSender extends BaseSender implements PrioRunnable, A
 	}
 
     private void callListenerOffThread(final InsertSenderListener listener, final int status) {
-        node.executor.execute(new Runnable() {
+        node.executor.execute(new PrioRunnable() {
 
             @Override
             public void run() {
                 listener.onInsertSenderFinished(status, CHKInsertSender.this);
+            }
+ 
+            @Override
+            public String toString() {
+                return "CHKInsertHandler callback for "+uid;
+            }
+            
+            @Override
+            public int getPriority() {
+                return NativeThread.HIGH_PRIORITY;
             }
             
         });

--- a/src/freenet/node/InsertSenderListener.java
+++ b/src/freenet/node/InsertSenderListener.java
@@ -1,0 +1,6 @@
+package freenet.node;
+
+interface InsertSenderListener {
+    /** Called when the insert finishes. Called off-thread so safe to block etc. */
+    void onInsertSenderFinished(int status, CHKInsertSender sender);
+}

--- a/src/freenet/node/InsertSenderListener.java
+++ b/src/freenet/node/InsertSenderListener.java
@@ -3,4 +3,6 @@ package freenet.node;
 interface InsertSenderListener {
     /** Called when the insert finishes. Called off-thread so safe to block etc. */
     void onInsertSenderFinished(int status, CHKInsertSender sender);
+    /** Called when completed() becomes true */
+    void onCompletion(CHKInsertSender sender);
 }

--- a/src/freenet/node/InsertSenderListener.java
+++ b/src/freenet/node/InsertSenderListener.java
@@ -5,4 +5,6 @@ interface InsertSenderListener {
     void onInsertSenderFinished(int status, CHKInsertSender sender);
     /** Called when completed() becomes true */
     void onCompletion(CHKInsertSender sender);
+    /** Called when we receive a non-local RejectedOverload to relay upstream */
+    void onReceivedRejectedOverload(CHKInsertSender sender);
 }


### PR DESCRIPTION
This eliminates all blocking waits (except for synchronous message sending) in CHKInsertHandler. It has not been properly tested yet; testing should include e.g. running the multi-node-one-VM simulations. This plus a similar solution for CHKInsertSender (which is probably much more work) should solve the thread limit problem currently causing difficulties for very high bandwidth nodes.