### PR TITLE
themes: avoid styling headers as normal text

### DIFF
--- a/src/freenet/clients/http/staticfiles/base.css
+++ b/src/freenet/clients/http/staticfiles/base.css
@@ -75,11 +75,6 @@
 
 div,
 body,
-h1,
-h2,
-h3,
-h4,
-h5,
 li,
 p,
 span,
@@ -167,7 +162,9 @@ body {
 }
 
 #topbar h1 {
+	font-family: Arial;
 	font-size: 1.818em; /* 1.818em = 20pt based on an 11pt reference */
+	font-weight: normal;
 	/* FIXME the following line looks redundant but things break if you remove it. */
 	margin: 0px;
 	padding-top: 0.35em; /* 7px based on an 20pt reference */

--- a/src/freenet/clients/http/staticfiles/themes/boxed/layout.css
+++ b/src/freenet/clients/http/staticfiles/themes/boxed/layout.css
@@ -13,11 +13,6 @@
 
 div,
 body,
-h1,
-h2,
-h3,
-h4,
-h5,
 li,
 p,
 span,
@@ -68,6 +63,7 @@ body {
 }
 
 #topbar h1 {
+	font-family: tahoma;
 	font-size: 2em;
 	font-weight: bold;
 	padding-top: 0px;

--- a/src/freenet/clients/http/staticfiles/themes/grayandblue/layout.css
+++ b/src/freenet/clients/http/staticfiles/themes/grayandblue/layout.css
@@ -8,11 +8,6 @@
 
 div,
 body,
-h1,
-h2,
-h3,
-h4,
-h5,
 li,
 p,
 span,
@@ -48,6 +43,7 @@ form {
 }
 
 #topbar h1 {
+	font-family: Verdana;
 	font-size: 2.1em;
 	font-weight: 900;
 	padding-top: 20px;


### PR DESCRIPTION
This overly broad directive caused headers in fniki and FlogHelper
previews to appear as normal text.

The only place Fred uses headers is page titles, so this moves its
styling to a selector specific to it.