### PR TITLE
Cleanup peernode

### DIFF
--- a/src/freenet/node/Announcer.java
+++ b/src/freenet/node/Announcer.java
@@ -223,7 +223,7 @@ public class Announcer {
 			SimpleFieldSet fs = ListUtils.removeRandomBySwapLastSimple(node.random, seeds);
 			try {
 				SeedServerPeerNode seed =
-					new SeedServerPeerNode(fs, node, om.crypto, node.peers, false, om.crypto.packetMangler);
+					new SeedServerPeerNode(fs, node, om.crypto, false, om.crypto.packetMangler);
 				if(node.wantAnonAuth(true) && Arrays.equals(node.getOpennetPubKeyHash(), seed.pubKeyHash)) {
                                     if(logMINOR)
                                         Logger.minor("Not adding: I am a seednode attempting to connect to myself!", seed.userToString());

--- a/src/freenet/node/Announcer.java
+++ b/src/freenet/node/Announcer.java
@@ -223,7 +223,7 @@ public class Announcer {
 			SimpleFieldSet fs = ListUtils.removeRandomBySwapLastSimple(node.random, seeds);
 			try {
 				SeedServerPeerNode seed =
-					new SeedServerPeerNode(fs, node, om.crypto, false, om.crypto.packetMangler);
+					new SeedServerPeerNode(fs, node, om.crypto, false);
 				if(node.wantAnonAuth(true) && Arrays.equals(node.getOpennetPubKeyHash(), seed.pubKeyHash)) {
                                     if(logMINOR)
                                         Logger.minor("Not adding: I am a seednode attempting to connect to myself!", seed.userToString());

--- a/src/freenet/node/DarknetPeerNode.java
+++ b/src/freenet/node/DarknetPeerNode.java
@@ -159,8 +159,8 @@ public class DarknetPeerNode extends PeerNode {
 	 * @param node2 The running Node we are part of.
 	 * @param trust If this is a new node, we will use this parameter to set the initial trust level.
 	 */
-	public DarknetPeerNode(SimpleFieldSet fs, Node node2, NodeCrypto crypto, PeerManager peers, boolean fromLocal, OutgoingPacketMangler mangler, FRIEND_TRUST trust, FRIEND_VISIBILITY visibility2) throws FSParseException, PeerParseException, ReferenceSignatureVerificationException {
-		super(fs, node2, crypto, peers, fromLocal, mangler);
+	public DarknetPeerNode(SimpleFieldSet fs, Node node2, NodeCrypto crypto, boolean fromLocal, OutgoingPacketMangler mangler, FRIEND_TRUST trust, FRIEND_VISIBILITY visibility2) throws FSParseException, PeerParseException, ReferenceSignatureVerificationException {
+		super(fs, node2, crypto, fromLocal, mangler);
 
 		logMINOR = Logger.shouldLog(LogLevel.MINOR, this);
 

--- a/src/freenet/node/DarknetPeerNode.java
+++ b/src/freenet/node/DarknetPeerNode.java
@@ -159,8 +159,8 @@ public class DarknetPeerNode extends PeerNode {
 	 * @param node2 The running Node we are part of.
 	 * @param trust If this is a new node, we will use this parameter to set the initial trust level.
 	 */
-	public DarknetPeerNode(SimpleFieldSet fs, Node node2, NodeCrypto crypto, boolean fromLocal, OutgoingPacketMangler mangler, FRIEND_TRUST trust, FRIEND_VISIBILITY visibility2) throws FSParseException, PeerParseException, ReferenceSignatureVerificationException {
-		super(fs, node2, crypto, fromLocal, mangler);
+	public DarknetPeerNode(SimpleFieldSet fs, Node node2, NodeCrypto crypto, boolean fromLocal, FRIEND_TRUST trust, FRIEND_VISIBILITY visibility2) throws FSParseException, PeerParseException, ReferenceSignatureVerificationException {
+		super(fs, node2, crypto, fromLocal);
 
 		logMINOR = Logger.shouldLog(LogLevel.MINOR, this);
 

--- a/src/freenet/node/DarknetPeerNode.java
+++ b/src/freenet/node/DarknetPeerNode.java
@@ -1977,4 +1977,9 @@ public class DarknetPeerNode extends PeerNode {
     public boolean canAcceptAnnouncements() {
         return node.passOpennetRefsThroughDarknet();
     }
+
+    @Override
+    protected void writePeers() {
+        node.peers.writePeers(false);
+    }
 }

--- a/src/freenet/node/DarknetPeerNode.java
+++ b/src/freenet/node/DarknetPeerNode.java
@@ -1972,4 +1972,9 @@ public class DarknetPeerNode extends PeerNode {
     public boolean isOpennetForNoderef() {
         return false;
     }
+
+    @Override
+    public boolean canAcceptAnnouncements() {
+        return node.passOpennetRefsThroughDarknet();
+    }
 }

--- a/src/freenet/node/DarknetPeerNode.java
+++ b/src/freenet/node/DarknetPeerNode.java
@@ -160,7 +160,7 @@ public class DarknetPeerNode extends PeerNode {
 	 * @param trust If this is a new node, we will use this parameter to set the initial trust level.
 	 */
 	public DarknetPeerNode(SimpleFieldSet fs, Node node2, NodeCrypto crypto, PeerManager peers, boolean fromLocal, OutgoingPacketMangler mangler, FRIEND_TRUST trust, FRIEND_VISIBILITY visibility2) throws FSParseException, PeerParseException, ReferenceSignatureVerificationException {
-		super(fs, node2, crypto, peers, fromLocal, false, mangler);
+		super(fs, node2, crypto, peers, fromLocal, mangler);
 
 		logMINOR = Logger.shouldLog(LogLevel.MINOR, this);
 

--- a/src/freenet/node/DarknetPeerNode.java
+++ b/src/freenet/node/DarknetPeerNode.java
@@ -160,7 +160,7 @@ public class DarknetPeerNode extends PeerNode {
 	 * @param trust If this is a new node, we will use this parameter to set the initial trust level.
 	 */
 	public DarknetPeerNode(SimpleFieldSet fs, Node node2, NodeCrypto crypto, PeerManager peers, boolean fromLocal, OutgoingPacketMangler mangler, FRIEND_TRUST trust, FRIEND_VISIBILITY visibility2) throws FSParseException, PeerParseException, ReferenceSignatureVerificationException {
-		super(fs, node2, crypto, peers, fromLocal, false, mangler, false);
+		super(fs, node2, crypto, peers, fromLocal, false, mangler);
 
 		logMINOR = Logger.shouldLog(LogLevel.MINOR, this);
 
@@ -1967,4 +1967,9 @@ public class DarknetPeerNode extends PeerNode {
 			}
 		}
 	}
+
+    @Override
+    public boolean isOpennetForNoderef() {
+        return false;
+    }
 }

--- a/src/freenet/node/FNPPacketMangler.java
+++ b/src/freenet/node/FNPPacketMangler.java
@@ -1491,7 +1491,7 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
 			}
 			PeerNode seed;
 			try {
-				seed = new SeedClientPeerNode(ref, node, crypto, node.peers, crypto.packetMangler);
+				seed = new SeedClientPeerNode(ref, node, crypto, crypto.packetMangler);
 				// Don't tell tracker yet as we don't have the address yet.
 			} catch (FSParseException e) {
 				Logger.error(this, "Invalid seed client noderef: "+e+" from "+from, e);

--- a/src/freenet/node/FNPPacketMangler.java
+++ b/src/freenet/node/FNPPacketMangler.java
@@ -1491,7 +1491,7 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
 			}
 			PeerNode seed;
 			try {
-				seed = new SeedClientPeerNode(ref, node, crypto, crypto.packetMangler);
+				seed = new SeedClientPeerNode(ref, node, crypto);
 				// Don't tell tracker yet as we don't have the address yet.
 			} catch (FSParseException e) {
 				Logger.error(this, "Invalid seed client noderef: "+e+" from "+from, e);

--- a/src/freenet/node/FNPPacketMangler.java
+++ b/src/freenet/node/FNPPacketMangler.java
@@ -1491,7 +1491,7 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
 			}
 			PeerNode seed;
 			try {
-				seed = new SeedClientPeerNode(ref, node, crypto, node.peers, false, true, crypto.packetMangler);
+				seed = new SeedClientPeerNode(ref, node, crypto, node.peers, crypto.packetMangler);
 				// Don't tell tracker yet as we don't have the address yet.
 			} catch (FSParseException e) {
 				Logger.error(this, "Invalid seed client noderef: "+e+" from "+from, e);

--- a/src/freenet/node/Node.java
+++ b/src/freenet/node/Node.java
@@ -4471,17 +4471,17 @@ public class Node implements TimeSkewDetectorCallback {
 
 
 	public DarknetPeerNode createNewDarknetNode(SimpleFieldSet fs, FRIEND_TRUST trust, FRIEND_VISIBILITY visibility) throws FSParseException, PeerParseException, ReferenceSignatureVerificationException {
-		return new DarknetPeerNode(fs, this, darknetCrypto, peers, false, darknetCrypto.packetMangler, trust, visibility);
+		return new DarknetPeerNode(fs, this, darknetCrypto, false, darknetCrypto.packetMangler, trust, visibility);
 	}
 
 	public OpennetPeerNode createNewOpennetNode(SimpleFieldSet fs) throws FSParseException, OpennetDisabledException, PeerParseException, ReferenceSignatureVerificationException {
 		if(opennet == null) throw new OpennetDisabledException("Opennet is not currently enabled");
-		return new OpennetPeerNode(fs, this, opennet.crypto, opennet, peers, false, opennet.crypto.packetMangler);
+		return new OpennetPeerNode(fs, this, opennet.crypto, opennet, false, opennet.crypto.packetMangler);
 	}
 
 	public SeedServerTestPeerNode createNewSeedServerTestPeerNode(SimpleFieldSet fs) throws FSParseException, OpennetDisabledException, PeerParseException, ReferenceSignatureVerificationException {
 		if(opennet == null) throw new OpennetDisabledException("Opennet is not currently enabled");
-		return new SeedServerTestPeerNode(fs, this, opennet.crypto, peers, true, opennet.crypto.packetMangler);
+		return new SeedServerTestPeerNode(fs, this, opennet.crypto, true, opennet.crypto.packetMangler);
 	}
 
 	public OpennetPeerNode addNewOpennetNode(SimpleFieldSet fs, ConnectionType connectionType) throws FSParseException, PeerParseException, ReferenceSignatureVerificationException {

--- a/src/freenet/node/Node.java
+++ b/src/freenet/node/Node.java
@@ -4471,17 +4471,17 @@ public class Node implements TimeSkewDetectorCallback {
 
 
 	public DarknetPeerNode createNewDarknetNode(SimpleFieldSet fs, FRIEND_TRUST trust, FRIEND_VISIBILITY visibility) throws FSParseException, PeerParseException, ReferenceSignatureVerificationException {
-		return new DarknetPeerNode(fs, this, darknetCrypto, false, darknetCrypto.packetMangler, trust, visibility);
+		return new DarknetPeerNode(fs, this, darknetCrypto, false, trust, visibility);
 	}
 
 	public OpennetPeerNode createNewOpennetNode(SimpleFieldSet fs) throws FSParseException, OpennetDisabledException, PeerParseException, ReferenceSignatureVerificationException {
 		if(opennet == null) throw new OpennetDisabledException("Opennet is not currently enabled");
-		return new OpennetPeerNode(fs, this, opennet.crypto, opennet, false, opennet.crypto.packetMangler);
+		return new OpennetPeerNode(fs, this, opennet.crypto, opennet, false);
 	}
 
 	public SeedServerTestPeerNode createNewSeedServerTestPeerNode(SimpleFieldSet fs) throws FSParseException, OpennetDisabledException, PeerParseException, ReferenceSignatureVerificationException {
 		if(opennet == null) throw new OpennetDisabledException("Opennet is not currently enabled");
-		return new SeedServerTestPeerNode(fs, this, opennet.crypto, true, opennet.crypto.packetMangler);
+		return new SeedServerTestPeerNode(fs, this, opennet.crypto, true);
 	}
 
 	public OpennetPeerNode addNewOpennetNode(SimpleFieldSet fs, ConnectionType connectionType) throws FSParseException, PeerParseException, ReferenceSignatureVerificationException {

--- a/src/freenet/node/OpennetManager.java
+++ b/src/freenet/node/OpennetManager.java
@@ -427,7 +427,7 @@ public class OpennetManager {
 		try {
 			// FIXME OPT can we do this cheaper?
 			// Maybe just parse the pubkey, and then compare it with the existing peers?
-			OpennetPeerNode pn = new OpennetPeerNode(fs, node, crypto, this, node.peers, false, crypto.packetMangler);
+			OpennetPeerNode pn = new OpennetPeerNode(fs, node, crypto, this, false, crypto.packetMangler);
 			if(lruQueue(pn).contains(pn)) {
 				if(logMINOR) Logger.minor(this, "Not adding "+pn.userToString()+" to opennet list as already there");
 				return true;
@@ -443,7 +443,7 @@ public class OpennetManager {
 
 	public OpennetPeerNode addNewOpennetNode(SimpleFieldSet fs, ConnectionType connectionType, boolean allowExisting) throws FSParseException, PeerParseException, ReferenceSignatureVerificationException {
 		try {
-		OpennetPeerNode pn = new OpennetPeerNode(fs, node, crypto, this, node.peers, false, crypto.packetMangler);
+		OpennetPeerNode pn = new OpennetPeerNode(fs, node, crypto, this, false, crypto.packetMangler);
 		if(Arrays.equals(pn.getPubKeyHash(), crypto.pubKeyHash)) {
 			if(logMINOR) Logger.minor(this, "Not adding self as opennet peer");
 			return null; // Equal to myself

--- a/src/freenet/node/OpennetManager.java
+++ b/src/freenet/node/OpennetManager.java
@@ -427,7 +427,7 @@ public class OpennetManager {
 		try {
 			// FIXME OPT can we do this cheaper?
 			// Maybe just parse the pubkey, and then compare it with the existing peers?
-			OpennetPeerNode pn = new OpennetPeerNode(fs, node, crypto, this, false, crypto.packetMangler);
+			OpennetPeerNode pn = new OpennetPeerNode(fs, node, crypto, this, false);
 			if(lruQueue(pn).contains(pn)) {
 				if(logMINOR) Logger.minor(this, "Not adding "+pn.userToString()+" to opennet list as already there");
 				return true;
@@ -443,7 +443,7 @@ public class OpennetManager {
 
 	public OpennetPeerNode addNewOpennetNode(SimpleFieldSet fs, ConnectionType connectionType, boolean allowExisting) throws FSParseException, PeerParseException, ReferenceSignatureVerificationException {
 		try {
-		OpennetPeerNode pn = new OpennetPeerNode(fs, node, crypto, this, false, crypto.packetMangler);
+		OpennetPeerNode pn = new OpennetPeerNode(fs, node, crypto, this, false);
 		if(Arrays.equals(pn.getPubKeyHash(), crypto.pubKeyHash)) {
 			if(logMINOR) Logger.minor(this, "Not adding self as opennet peer");
 			return null; // Equal to myself

--- a/src/freenet/node/OpennetPeerNode.java
+++ b/src/freenet/node/OpennetPeerNode.java
@@ -19,8 +19,8 @@ public class OpennetPeerNode extends PeerNode {
 	// Not persisted across restart, since after restart grace periods don't apply anyway (except disconnection, which is really separate anyway).
 	private ConnectionType opennetNodeAddedReason;
 	
-	public OpennetPeerNode(SimpleFieldSet fs, Node node2, NodeCrypto crypto, OpennetManager opennet, boolean fromLocal, OutgoingPacketMangler mangler) throws FSParseException, PeerParseException, ReferenceSignatureVerificationException {
-		super(fs, node2, crypto, fromLocal, mangler);
+	public OpennetPeerNode(SimpleFieldSet fs, Node node2, NodeCrypto crypto, OpennetManager opennet, boolean fromLocal) throws FSParseException, PeerParseException, ReferenceSignatureVerificationException {
+		super(fs, node2, crypto, fromLocal);
 
 		if (fromLocal) {
 			SimpleFieldSet metadata = fs.subset("metadata");

--- a/src/freenet/node/OpennetPeerNode.java
+++ b/src/freenet/node/OpennetPeerNode.java
@@ -299,4 +299,9 @@ public class OpennetPeerNode extends PeerNode {
         return true;
     }
 
+    @Override
+    protected void writePeers() {
+        node.peers.writePeers(true);
+    }
+
 }

--- a/src/freenet/node/OpennetPeerNode.java
+++ b/src/freenet/node/OpennetPeerNode.java
@@ -294,4 +294,9 @@ public class OpennetPeerNode extends PeerNode {
         return true;
     }
 
+    @Override
+    public boolean canAcceptAnnouncements() {
+        return true;
+    }
+
 }

--- a/src/freenet/node/OpennetPeerNode.java
+++ b/src/freenet/node/OpennetPeerNode.java
@@ -20,7 +20,7 @@ public class OpennetPeerNode extends PeerNode {
 	private ConnectionType opennetNodeAddedReason;
 	
 	public OpennetPeerNode(SimpleFieldSet fs, Node node2, NodeCrypto crypto, OpennetManager opennet, PeerManager peers, boolean fromLocal, OutgoingPacketMangler mangler) throws FSParseException, PeerParseException, ReferenceSignatureVerificationException {
-		super(fs, node2, crypto, peers, fromLocal, false, mangler, true);
+		super(fs, node2, crypto, peers, fromLocal, false, mangler);
 
 		if (fromLocal) {
 			SimpleFieldSet metadata = fs.subset("metadata");
@@ -287,6 +287,11 @@ public class OpennetPeerNode extends PeerNode {
             return LinkLengthClass.LONG;
         else
             return LinkLengthClass.SHORT;
+    }
+
+    @Override
+    public boolean isOpennetForNoderef() {
+        return true;
     }
 
 }

--- a/src/freenet/node/OpennetPeerNode.java
+++ b/src/freenet/node/OpennetPeerNode.java
@@ -20,7 +20,7 @@ public class OpennetPeerNode extends PeerNode {
 	private ConnectionType opennetNodeAddedReason;
 	
 	public OpennetPeerNode(SimpleFieldSet fs, Node node2, NodeCrypto crypto, OpennetManager opennet, PeerManager peers, boolean fromLocal, OutgoingPacketMangler mangler) throws FSParseException, PeerParseException, ReferenceSignatureVerificationException {
-		super(fs, node2, crypto, peers, fromLocal, false, mangler);
+		super(fs, node2, crypto, peers, fromLocal, mangler);
 
 		if (fromLocal) {
 			SimpleFieldSet metadata = fs.subset("metadata");

--- a/src/freenet/node/OpennetPeerNode.java
+++ b/src/freenet/node/OpennetPeerNode.java
@@ -19,8 +19,8 @@ public class OpennetPeerNode extends PeerNode {
 	// Not persisted across restart, since after restart grace periods don't apply anyway (except disconnection, which is really separate anyway).
 	private ConnectionType opennetNodeAddedReason;
 	
-	public OpennetPeerNode(SimpleFieldSet fs, Node node2, NodeCrypto crypto, OpennetManager opennet, PeerManager peers, boolean fromLocal, OutgoingPacketMangler mangler) throws FSParseException, PeerParseException, ReferenceSignatureVerificationException {
-		super(fs, node2, crypto, peers, fromLocal, mangler);
+	public OpennetPeerNode(SimpleFieldSet fs, Node node2, NodeCrypto crypto, OpennetManager opennet, boolean fromLocal, OutgoingPacketMangler mangler) throws FSParseException, PeerParseException, ReferenceSignatureVerificationException {
+		super(fs, node2, crypto, fromLocal, mangler);
 
 		if (fromLocal) {
 			SimpleFieldSet metadata = fs.subset("metadata");

--- a/src/freenet/node/PeerManager.java
+++ b/src/freenet/node/PeerManager.java
@@ -198,13 +198,12 @@ public class PeerManager {
 				else
 					darkFilename = filename;
 		}
-		OutgoingPacketMangler mangler = crypto.packetMangler;
 		int maxBackups = isOpennet ? BACKUPS_OPENNET : BACKUPS_DARKNET;
 		for(int i=0;i<=maxBackups;i++) {
 			File peersFile = this.getBackupFilename(filename, i);
 			// Try to read the node list from disk
 			if(peersFile.exists())
-				if(readPeers(peersFile, mangler, crypto, opennet, oldOpennetPeers)) {
+				if(readPeers(peersFile, crypto, opennet, oldOpennetPeers)) {
 					String msg;
 					if(oldOpennetPeers)
 						msg = "Read " + opennet.countOldOpennetPeers() + " old-opennet-peers from " + peersFile;
@@ -222,7 +221,7 @@ public class PeerManager {
 		// The other cases are less important.
 	}
 
-	private boolean readPeers(File peersFile, OutgoingPacketMangler mangler, NodeCrypto crypto, OpennetManager opennet, boolean oldOpennetPeers) {
+	private boolean readPeers(File peersFile, NodeCrypto crypto, OpennetManager opennet, boolean oldOpennetPeers) {
 		boolean someBroken = false;
 		boolean gotSome = false;
 		FileInputStream fis;
@@ -245,7 +244,7 @@ public class PeerManager {
 				SimpleFieldSet fs;
 				fs = new SimpleFieldSet(br, false, true);
 				try {
-					PeerNode pn = PeerNode.create(fs, node, crypto, opennet, this, mangler);
+					PeerNode pn = PeerNode.create(fs, node, crypto, opennet, this);
 					if(oldOpennetPeers) {
 					    if(!(pn instanceof OpennetPeerNode))
 					        Logger.error(this, "Darknet node in old opennet peers?!: "+pn);

--- a/src/freenet/node/PeerNode.java
+++ b/src/freenet/node/PeerNode.java
@@ -4045,9 +4045,7 @@ public abstract class PeerNode implements USKRetrieverCallback, BasePeerNode, Pe
 	public abstract boolean isRealConnection();
 
 	/** Can we accept announcements from this node? */
-	public boolean canAcceptAnnouncements() {
-		return isOpennet() || node.passOpennetRefsThroughDarknet();
-	}
+	public abstract boolean canAcceptAnnouncements();
 
 	public boolean handshakeUnknownInitiator() {
 		return false;

--- a/src/freenet/node/PeerNode.java
+++ b/src/freenet/node/PeerNode.java
@@ -2884,10 +2884,16 @@ public abstract class PeerNode implements USKRetrieverCallback, BasePeerNode, Pe
 		return fs;
 	}
 
+	/** @return True if the node is a full darknet peer ("Friend"), which should usually be in
+	 * the darknet routing table. */
 	public abstract boolean isDarknet();
 
+	/** @return True if the node is a full opennet peer ("Stranger"), which should usually be in
+	 * the OpennetManager and opennet routing table. */
 	public abstract boolean isOpennet();
 
+	/** @return True if the node is a seed client or seed server. These are never in the routing
+	 * table, but their noderefs should still say opennet=true. */
 	public abstract boolean isSeed();
 
 	/**

--- a/src/freenet/node/PeerNode.java
+++ b/src/freenet/node/PeerNode.java
@@ -454,7 +454,7 @@ public abstract class PeerNode implements USKRetrieverCallback, BasePeerNode, Pe
 	* @param fromLocal True if the noderef was read from the stored peers file and can contain
 	* local metadata, and won't be signed. Otherwise, it is a new node reference from elsewhere,
 	* should not contain metadata, and will be signed. */
-	public PeerNode(SimpleFieldSet fs, Node node2, NodeCrypto crypto, PeerManager peers, 
+	public PeerNode(SimpleFieldSet fs, Node node2, NodeCrypto crypto,
 	        boolean fromLocal, OutgoingPacketMangler mangler) 
 	                throws FSParseException, PeerParseException, ReferenceSignatureVerificationException {
 		boolean noSig = false;
@@ -466,7 +466,7 @@ public abstract class PeerNode implements USKRetrieverCallback, BasePeerNode, Pe
 		this.node = node2;
 		this.crypto = crypto;
 		assert(crypto.isOpennet == isOpennetForNoderef());
-		this.peers = peers;
+		this.peers = node.peers;
 		this.backedOffPercent = new TimeDecayingRunningAverage(0.0, 180000, 0.0, 1.0, node);
 		this.backedOffPercentRT = new TimeDecayingRunningAverage(0.0, 180000, 0.0, 1.0, node);
 		this.backedOffPercentBulk = new TimeDecayingRunningAverage(0.0, 180000, 0.0, 1.0, node);
@@ -3905,9 +3905,9 @@ public abstract class PeerNode implements USKRetrieverCallback, BasePeerNode, Pe
 	 */
 	public static PeerNode create(SimpleFieldSet fs, Node node2, NodeCrypto crypto, OpennetManager opennet, PeerManager manager, OutgoingPacketMangler mangler) throws FSParseException, PeerParseException, ReferenceSignatureVerificationException {
 		if(crypto.isOpennet)
-			return new OpennetPeerNode(fs, node2, crypto, opennet, manager, true, mangler);
+			return new OpennetPeerNode(fs, node2, crypto, opennet, true, mangler);
 		else
-			return new DarknetPeerNode(fs, node2, crypto, manager, true, mangler, null, null);
+			return new DarknetPeerNode(fs, node2, crypto, true, mangler, null, null);
 	}
 	
 	public byte[] getPubKeyHash() {

--- a/src/freenet/node/PeerNode.java
+++ b/src/freenet/node/PeerNode.java
@@ -1828,13 +1828,17 @@ public abstract class PeerNode implements USKRetrieverCallback, BasePeerNode, Pe
 		boolean anythingChanged = location.updateLocation(newLoc, newLocs);
 		node.peers.updatePMUserAlert();
 		if(anythingChanged)
-			// Not urgent. This makes up the majority of the total writes.
-			// Writing it on shutdown is sufficient.
-			node.peers.writePeers(isOpennet());
+		    writePeers();
 		setPeerNodeStatus(System.currentTimeMillis());
 	}
 
-	/**
+	private void writePeers() {
+        // Not urgent. This makes up the majority of the total writes.
+        // Writing it on shutdown is sufficient.
+        node.peers.writePeers(isOpennet());
+    }
+
+    /**
 	* Should we reject a swap request?
 	*/
 	public boolean shouldRejectSwapRequest() {
@@ -2520,7 +2524,7 @@ public abstract class PeerNode implements USKRetrieverCallback, BasePeerNode, Pe
 			Logger.minor(this, "Parsing: \n" + fs);
 		boolean changedAnything = innerProcessNewNoderef(fs, forARK, forDiffNodeRef, forFullNodeRef) || forARK;
 		if(changedAnything && !isSeed())
-			node.peers.writePeers(isOpennet());
+		    writePeers();
 		// FIXME should this be urgent if IPs change? Dunno.
 	}
 

--- a/src/freenet/node/PeerNode.java
+++ b/src/freenet/node/PeerNode.java
@@ -449,8 +449,15 @@ public abstract class PeerNode implements USKRetrieverCallback, BasePeerNode, Pe
 	* - physical.udp
 	* - setupKey
 	* Do not add self to PeerManager.
-	* @param fs The SimpleFieldSet to parse
+	* @param fs The node reference to parse.
 	* @param node2 The running Node we are part of.
+	* @param fromLocal True if the noderef was read from the stored peers file and can contain
+	* local metadata, and won't be signed. Otherwise, it is a new node reference from elsewhere,
+	* should not contain metadata, and will be signed. 
+	* @param fromAnonymousInitiator True if the node has just connected and given us a noderef,
+	* and we did not know it beforehand. This makes it a temporary connection. At the moment
+	* this only happens on seednodes.
+	* @param isOpennet True if the noderef should have opennet=true.
 	*/
 	public PeerNode(SimpleFieldSet fs, Node node2, NodeCrypto crypto, PeerManager peers, 
 	        boolean fromLocal, boolean fromAnonymousInitiator, OutgoingPacketMangler mangler, 

--- a/src/freenet/node/PeerNode.java
+++ b/src/freenet/node/PeerNode.java
@@ -452,7 +452,10 @@ public abstract class PeerNode implements USKRetrieverCallback, BasePeerNode, Pe
 	* @param fs The SimpleFieldSet to parse
 	* @param node2 The running Node we are part of.
 	*/
-	public PeerNode(SimpleFieldSet fs, Node node2, NodeCrypto crypto, PeerManager peers, boolean fromLocal, boolean fromAnonymousInitiator, OutgoingPacketMangler mangler, boolean isOpennet) throws FSParseException, PeerParseException, ReferenceSignatureVerificationException {
+	public PeerNode(SimpleFieldSet fs, Node node2, NodeCrypto crypto, PeerManager peers, 
+	        boolean fromLocal, boolean fromAnonymousInitiator, OutgoingPacketMangler mangler, 
+	        boolean isOpennet) 
+	                throws FSParseException, PeerParseException, ReferenceSignatureVerificationException {
 		boolean noSig = false;
 		if(fromLocal || fromAnonymousInitiator) noSig = true;
 		myRef = new WeakReference<PeerNode>(this);

--- a/src/freenet/node/PeerNode.java
+++ b/src/freenet/node/PeerNode.java
@@ -1832,11 +1832,8 @@ public abstract class PeerNode implements USKRetrieverCallback, BasePeerNode, Pe
 		setPeerNodeStatus(System.currentTimeMillis());
 	}
 
-	private void writePeers() {
-        // Not urgent. This makes up the majority of the total writes.
-        // Writing it on shutdown is sufficient.
-        node.peers.writePeers(isOpennet());
-    }
+	/** Write the peers list affecting this node. */
+	protected abstract void writePeers();
 
     /**
 	* Should we reject a swap request?

--- a/src/freenet/node/SeedClientPeerNode.java
+++ b/src/freenet/node/SeedClientPeerNode.java
@@ -17,7 +17,7 @@ import freenet.support.SimpleFieldSet;
 public class SeedClientPeerNode extends PeerNode {
 
 	public SeedClientPeerNode(SimpleFieldSet fs, Node node2, NodeCrypto crypto, PeerManager peers, boolean fromLocal, boolean noSig, OutgoingPacketMangler mangler) throws FSParseException, PeerParseException, ReferenceSignatureVerificationException {
-		super(fs, node2, crypto, peers, fromLocal, noSig, mangler, true);
+		super(fs, node2, crypto, peers, fromLocal, noSig, mangler);
 	}
 
 	@Override
@@ -171,6 +171,11 @@ public class SeedClientPeerNode extends PeerNode {
 	boolean dontKeepFullFieldSet() {
 		return true;
 	}
+
+    @Override
+    public boolean isOpennetForNoderef() {
+        return true;
+    }
 
 
 }

--- a/src/freenet/node/SeedClientPeerNode.java
+++ b/src/freenet/node/SeedClientPeerNode.java
@@ -16,8 +16,8 @@ import freenet.support.SimpleFieldSet;
  */
 public class SeedClientPeerNode extends PeerNode {
 
-	public SeedClientPeerNode(SimpleFieldSet fs, Node node2, NodeCrypto crypto, PeerManager peers, boolean fromLocal, boolean noSig, OutgoingPacketMangler mangler) throws FSParseException, PeerParseException, ReferenceSignatureVerificationException {
-		super(fs, node2, crypto, peers, fromLocal, noSig, mangler);
+	public SeedClientPeerNode(SimpleFieldSet fs, Node node2, NodeCrypto crypto, PeerManager peers, OutgoingPacketMangler mangler) throws FSParseException, PeerParseException, ReferenceSignatureVerificationException {
+		super(fs, node2, crypto, peers, false, mangler);
 	}
 
 	@Override
@@ -182,5 +182,9 @@ public class SeedClientPeerNode extends PeerNode {
         // Do not write peers as seed clients are not in the peers list and are not saved.
     }
 
+    @Override
+    protected boolean fromAnonymousInitiator() {
+        return true;
+    }
 
 }

--- a/src/freenet/node/SeedClientPeerNode.java
+++ b/src/freenet/node/SeedClientPeerNode.java
@@ -16,8 +16,8 @@ import freenet.support.SimpleFieldSet;
  */
 public class SeedClientPeerNode extends PeerNode {
 
-	public SeedClientPeerNode(SimpleFieldSet fs, Node node2, NodeCrypto crypto, OutgoingPacketMangler mangler) throws FSParseException, PeerParseException, ReferenceSignatureVerificationException {
-		super(fs, node2, crypto, false, mangler);
+	public SeedClientPeerNode(SimpleFieldSet fs, Node node2, NodeCrypto crypto) throws FSParseException, PeerParseException, ReferenceSignatureVerificationException {
+		super(fs, node2, crypto, false);
 	}
 
 	@Override

--- a/src/freenet/node/SeedClientPeerNode.java
+++ b/src/freenet/node/SeedClientPeerNode.java
@@ -177,5 +177,10 @@ public class SeedClientPeerNode extends PeerNode {
         return true;
     }
 
+    @Override
+    protected void writePeers() {
+        // Do not write peers as seed clients are not in the peers list and are not saved.
+    }
+
 
 }

--- a/src/freenet/node/SeedClientPeerNode.java
+++ b/src/freenet/node/SeedClientPeerNode.java
@@ -16,8 +16,8 @@ import freenet.support.SimpleFieldSet;
  */
 public class SeedClientPeerNode extends PeerNode {
 
-	public SeedClientPeerNode(SimpleFieldSet fs, Node node2, NodeCrypto crypto, PeerManager peers, OutgoingPacketMangler mangler) throws FSParseException, PeerParseException, ReferenceSignatureVerificationException {
-		super(fs, node2, crypto, peers, false, mangler);
+	public SeedClientPeerNode(SimpleFieldSet fs, Node node2, NodeCrypto crypto, OutgoingPacketMangler mangler) throws FSParseException, PeerParseException, ReferenceSignatureVerificationException {
+		super(fs, node2, crypto, false, mangler);
 	}
 
 	@Override

--- a/src/freenet/node/SeedServerPeerNode.java
+++ b/src/freenet/node/SeedServerPeerNode.java
@@ -188,4 +188,9 @@ public class SeedServerPeerNode extends PeerNode {
         return false; // We do not accept announcements from a seednode.
     }
 
+    @Override
+    protected void writePeers() {
+        // Do not write peers, seeds are kept separately.
+    }
+
 }

--- a/src/freenet/node/SeedServerPeerNode.java
+++ b/src/freenet/node/SeedServerPeerNode.java
@@ -22,8 +22,8 @@ import freenet.support.SimpleFieldSet;
  */
 public class SeedServerPeerNode extends PeerNode {
 
-	public SeedServerPeerNode(SimpleFieldSet fs, Node node2, NodeCrypto crypto, boolean fromLocal, OutgoingPacketMangler mangler) throws FSParseException, PeerParseException, ReferenceSignatureVerificationException {
-		super(fs, node2, crypto, fromLocal, mangler);
+	public SeedServerPeerNode(SimpleFieldSet fs, Node node2, NodeCrypto crypto, boolean fromLocal) throws FSParseException, PeerParseException, ReferenceSignatureVerificationException {
+		super(fs, node2, crypto, fromLocal);
 	}
 
 	@Override

--- a/src/freenet/node/SeedServerPeerNode.java
+++ b/src/freenet/node/SeedServerPeerNode.java
@@ -183,4 +183,9 @@ public class SeedServerPeerNode extends PeerNode {
         return true;
     }
 
+    @Override
+    public boolean canAcceptAnnouncements() {
+        return false; // We do not accept announcements from a seednode.
+    }
+
 }

--- a/src/freenet/node/SeedServerPeerNode.java
+++ b/src/freenet/node/SeedServerPeerNode.java
@@ -22,8 +22,8 @@ import freenet.support.SimpleFieldSet;
  */
 public class SeedServerPeerNode extends PeerNode {
 
-	public SeedServerPeerNode(SimpleFieldSet fs, Node node2, NodeCrypto crypto, PeerManager peers, boolean fromLocal, OutgoingPacketMangler mangler) throws FSParseException, PeerParseException, ReferenceSignatureVerificationException {
-		super(fs, node2, crypto, peers, fromLocal, mangler);
+	public SeedServerPeerNode(SimpleFieldSet fs, Node node2, NodeCrypto crypto, boolean fromLocal, OutgoingPacketMangler mangler) throws FSParseException, PeerParseException, ReferenceSignatureVerificationException {
+		super(fs, node2, crypto, fromLocal, mangler);
 	}
 
 	@Override

--- a/src/freenet/node/SeedServerPeerNode.java
+++ b/src/freenet/node/SeedServerPeerNode.java
@@ -23,7 +23,7 @@ import freenet.support.SimpleFieldSet;
 public class SeedServerPeerNode extends PeerNode {
 
 	public SeedServerPeerNode(SimpleFieldSet fs, Node node2, NodeCrypto crypto, PeerManager peers, boolean fromLocal, OutgoingPacketMangler mangler) throws FSParseException, PeerParseException, ReferenceSignatureVerificationException {
-		super(fs, node2, crypto, peers, fromLocal, false, mangler);
+		super(fs, node2, crypto, peers, fromLocal, mangler);
 	}
 
 	@Override

--- a/src/freenet/node/SeedServerPeerNode.java
+++ b/src/freenet/node/SeedServerPeerNode.java
@@ -23,7 +23,7 @@ import freenet.support.SimpleFieldSet;
 public class SeedServerPeerNode extends PeerNode {
 
 	public SeedServerPeerNode(SimpleFieldSet fs, Node node2, NodeCrypto crypto, PeerManager peers, boolean fromLocal, OutgoingPacketMangler mangler) throws FSParseException, PeerParseException, ReferenceSignatureVerificationException {
-		super(fs, node2, crypto, peers, fromLocal, false, mangler, true);
+		super(fs, node2, crypto, peers, fromLocal, false, mangler);
 	}
 
 	@Override
@@ -177,5 +177,10 @@ public class SeedServerPeerNode extends PeerNode {
 	boolean dontKeepFullFieldSet() {
 		return false;
 	}
+
+    @Override
+    public boolean isOpennetForNoderef() {
+        return true;
+    }
 
 }

--- a/src/freenet/node/SeedServerTestPeerNode.java
+++ b/src/freenet/node/SeedServerTestPeerNode.java
@@ -13,8 +13,8 @@ import freenet.support.SimpleFieldSet;
  */
 public class SeedServerTestPeerNode extends SeedServerPeerNode {
 
-	public SeedServerTestPeerNode(SimpleFieldSet fs, Node node2, NodeCrypto crypto, boolean fromLocal, OutgoingPacketMangler mangler) throws FSParseException, PeerParseException, ReferenceSignatureVerificationException {
-		super(fs, node2, crypto, fromLocal, mangler);
+	public SeedServerTestPeerNode(SimpleFieldSet fs, Node node2, NodeCrypto crypto, boolean fromLocal) throws FSParseException, PeerParseException, ReferenceSignatureVerificationException {
+		super(fs, node2, crypto, fromLocal);
 	}
 	
 	@Override

--- a/src/freenet/node/SeedServerTestPeerNode.java
+++ b/src/freenet/node/SeedServerTestPeerNode.java
@@ -13,8 +13,8 @@ import freenet.support.SimpleFieldSet;
  */
 public class SeedServerTestPeerNode extends SeedServerPeerNode {
 
-	public SeedServerTestPeerNode(SimpleFieldSet fs, Node node2, NodeCrypto crypto, PeerManager peers, boolean fromLocal, OutgoingPacketMangler mangler) throws FSParseException, PeerParseException, ReferenceSignatureVerificationException {
-		super(fs, node2, crypto, peers, fromLocal, mangler);
+	public SeedServerTestPeerNode(SimpleFieldSet fs, Node node2, NodeCrypto crypto, boolean fromLocal, OutgoingPacketMangler mangler) throws FSParseException, PeerParseException, ReferenceSignatureVerificationException {
+		super(fs, node2, crypto, fromLocal, mangler);
 	}
 	
 	@Override


### PR DESCRIPTION
Slightly larger cleanups, mostly organised around "PeerNode constructor takes too many arguments". Some minor performance gain on seednodes.