### PR TITLE
Eclipe classpath: Fix sourcepath of contrib to match repository name

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -3,7 +3,7 @@
 	<classpathentry excluding="freenet/node/*Test.java|plugins/JSTUN/**|test/**" kind="src" output="build/main" path="src"/>
 	<classpathentry including="freenet/|org/" kind="src" output="build/test" path="test"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-	<classpathentry exported="true" kind="lib" path="lib/freenet/freenet-ext.jar" sourcepath="/Contrib/db4o/src/db4oj"/>
+	<classpathentry exported="true" kind="lib" path="lib/freenet/freenet-ext.jar" sourcepath="/contrib/db4o/src/db4oj"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
 	<classpathentry kind="lib" path="lib/bcprov-jdk15on-152.jar"/>
 	<classpathentry kind="output" path="build/main/"/>


### PR DESCRIPTION
The previous sourcepath was uppercase, while our contrib repository uses a lowercase name:
    https://github.com/freenet/contrib
If people clone it, they will get a "contrib" directory, not "Contrib" as the previous sourcepath used.

This commit changes the sourcepath to be lowercase just like the repository name.

This fixes Eclipse to find the db4o source code automatically as long as people clone "fred" and "contrib" into the root directory of their workspace. This is useful for Web of Trust and Freetalk developers: Eclipse will be able to display db4o JavaDoc now.