### PR TITLE
Disallow blank bookmark names

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 next ():
 
 - add a NEWS file
+- Fix problems with blank bookmark names. Thanks to _xiaoyu for the report!
 
 1470 (2015-08-15):
 

--- a/src/freenet/clients/http/BookmarkEditorToadlet.java
+++ b/src/freenet/clients/http/BookmarkEditorToadlet.java
@@ -398,15 +398,13 @@ public class BookmarkEditorToadlet extends Toadlet {
 						 * - values as "on", "true", "yes" should be accepted.
 						 */
 						boolean hasAnActivelink = req.isPartSet("hasAnActivelink");
-						if (name.contains("/")) {
-							pageMaker.getInfobox("infobox-error", NodeL10n.getBase().getString("BookmarkEditorToadlet.invalidNameTitle"), content, "bookmark-error", false).
-								addChild("#", NodeL10n.getBase().getString("BookmarkEditorToadlet.invalidName"));
+						if (!isValidName(name)) {
+              addNameError(pageMaker, content);
 						} else
 							newBookmark = new BookmarkItem(key, name, req.getPartAsStringFailsafe("descB", MAX_KEY_LENGTH), req.getPartAsStringFailsafe("explain", MAX_EXPLANATION_LENGTH), hasAnActivelink, ctx.getAlertManager());
 					} else
-						if (name.contains("/")) {
-							pageMaker.getInfobox("infobox-error", NodeL10n.getBase().getString("BookmarkEditorToadlet.invalidNameTitle"), content, "bookmark-error", false).
-								addChild("#", NodeL10n.getBase().getString("BookmarkEditorToadlet.invalidName"));
+						if (!isValidName(name)) {
+              addNameError(pageMaker, content);
 						} else
 							newBookmark = new BookmarkCategory(name);
 					
@@ -441,4 +439,15 @@ public class BookmarkEditorToadlet extends Toadlet {
 	public String path() {
 		return "/bookmarkEditor/";
 	}
+
+  private boolean isValidName(String name) {
+    return !name.contains("/");
+  }
+
+  private void addNameError(PageMaker pageMaker, HTMLNode parent) {
+    HTMLNode errorBox = pageMaker.getInfobox(
+            "infobox-error", NodeL10n.getBase().getString("BookmarkEditorToadlet.invalidNameTitle"),
+            parent, "bookmark-error", false);
+    errorBox.addChild("#", NodeL10n.getBase().getString("BookmarkEditorToadlet.invalidName"));
+  }
 }

--- a/src/freenet/clients/http/BookmarkEditorToadlet.java
+++ b/src/freenet/clients/http/BookmarkEditorToadlet.java
@@ -441,7 +441,7 @@ public class BookmarkEditorToadlet extends Toadlet {
 	}
 
   private boolean isValidName(String name) {
-    return !name.contains("/");
+    return !name.isEmpty() && !name.contains("/");
   }
 
   private void addNameError(PageMaker pageMaker, HTMLNode parent) {

--- a/src/freenet/clients/http/bookmark/BookmarkItem.java
+++ b/src/freenet/clients/http/bookmark/BookmarkItem.java
@@ -57,7 +57,7 @@ public class BookmarkItem extends Bookmark {
     
     public BookmarkItem(SimpleFieldSet sfs, UserAlertManager uam) throws FSParseException, MalformedURLException {
         this.name = sfs.get("Name");
-        if(name == null) name = "";
+        if(name == null || name.isEmpty()) name = l10n("unnamedBookmark");
         this.desc = sfs.get("Description");
         if(desc == null) desc = "";
         this.shortDescription = sfs.get("ShortDescription");
@@ -184,7 +184,7 @@ public class BookmarkItem extends Bookmark {
 
     @Override
 	public String getName() {
-        return ("".equals(name) ? l10n("unnamedBookmark") : name);
+        return name;
     }
 
     @Override


### PR DESCRIPTION
_xiaoyu on IRC reported problems using blank bookmark names. When a bookmark with a blank name was added, it could not be navigated to but did not cause other problems. After restart when parsing the blank name the bookmark state became malformed somehow and prevented any operations on the list of bookmarks. These changes do two main things:

* Disallow new bookmarks with blank names to prevent the problem from occurring anew.
* Load bookmarks with blank names as "Unnamed Bookmark" to fix the problem where it was already occurring.

I'm not certain this is the best way to go about it because [existing code](https://github.com/freenet/fred/blob/caba7734a583aafc55ebe229a270f3a70eed1876/src/freenet/clients/http/bookmark/BookmarkItem.java#L60) seems like it was at least intended to [do that already](https://github.com/freenet/fred/blob/caba7734a583aafc55ebe229a270f3a70eed1876/src/freenet/clients/http/bookmark/BookmarkItem.java#L187). I didn't try diagnosing it.