### PR TITLE
switch the default theme to sky static.

### DIFF
--- a/src/freenet/clients/http/PageMaker.java
+++ b/src/freenet/clients/http/PageMaker.java
@@ -110,7 +110,7 @@ public final class PageMaker {
 		}
 
 		public static THEME getDefault() {
-			return THEME.CLEAN;
+			return THEME.SKY_STATIC;
 		}
 	}	
 	


### PR DESCRIPTION
That’s the cleanest theme I found. It still looks like 1990,
but like the good 1990, not the ugly 1990.