### PR TITLE
Fix wrapped FCP message

### DIFF
--- a/src/freenet/clients/fcp/FCPMessage.java
+++ b/src/freenet/clients/fcp/FCPMessage.java
@@ -184,6 +184,16 @@ public abstract class FCPMessage {
 		}
 		return new FCPMessage() {
 			@Override
+			public void send(OutputStream os) throws IOException {
+				fcpMessage.send(os);
+			}
+
+			@Override
+			String getEndString() {
+				return fcpMessage.getEndString();
+			}
+
+			@Override
 			public SimpleFieldSet getFieldSet() {
 				SimpleFieldSet fieldSet = fcpMessage.getFieldSet();
 				fieldSet.putSingle("ListRequestIdentifier", listRequestIdentifier);

--- a/src/freenet/clients/fcp/FCPMessage.java
+++ b/src/freenet/clients/fcp/FCPMessage.java
@@ -196,7 +196,7 @@ public abstract class FCPMessage {
 			@Override
 			public SimpleFieldSet getFieldSet() {
 				SimpleFieldSet fieldSet = fcpMessage.getFieldSet();
-				fieldSet.putSingle("ListRequestIdentifier", listRequestIdentifier);
+				fieldSet.putOverwrite("ListRequestIdentifier", listRequestIdentifier);
 				return fieldSet;
 			}
 

--- a/src/freenet/clients/fcp/FCPMessage.java
+++ b/src/freenet/clients/fcp/FCPMessage.java
@@ -179,7 +179,7 @@ public abstract class FCPMessage {
 	 * @return The new FCP message
 	 */
 	public static FCPMessage withListRequestIdentifier(final FCPMessage fcpMessage, final String listRequestIdentifier) {
-		if (listRequestIdentifier == null) {
+		if ((listRequestIdentifier == null) || (fcpMessage == null)) {
 			return fcpMessage;
 		}
 		return new FCPMessage() {

--- a/test/freenet/clients/fcp/FCPMessageTest.java
+++ b/test/freenet/clients/fcp/FCPMessageTest.java
@@ -2,6 +2,7 @@ package freenet.clients.fcp;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -28,6 +29,11 @@ public class FCPMessageTest {
     private static final String END_STRING = "End";
 
     private final FCPMessage originalMessage = mock(FCPMessage.class);
+
+    @Test
+    public void wrappingNullReturnsNull() {
+        assertThat(FCPMessage.withListRequestIdentifier(null, LIST_REQUEST_IDENTIFIER), nullValue());
+    }
 
     @Test
     public void wrappingMessageAddsIdentifier() {

--- a/test/freenet/clients/fcp/FCPMessageTest.java
+++ b/test/freenet/clients/fcp/FCPMessageTest.java
@@ -1,0 +1,77 @@
+package freenet.clients.fcp;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+import freenet.node.Node;
+import freenet.support.SimpleFieldSet;
+
+import org.junit.Test;
+
+/**
+ * Unit test for {@link FCPMessage}.
+ *
+ * @author <a href="mailto:david.roden@bietr.de">David Roden</a>
+ */
+public class FCPMessageTest {
+
+    private static final String LIST_REQUEST_IDENTIFIER = "ListRequestIdentifier";
+    private static final String IDENTIFIER = "identifier";
+    private static final String MESSAGE_NAME = "SomeMessage";
+    private static final String END_STRING = "End";
+
+    private final FCPMessage originalMessage = mock(FCPMessage.class);
+
+    @Test
+    public void wrappingMessageAddsIdentifier() {
+        when(originalMessage.getFieldSet()).thenReturn(new SimpleFieldSet(true));
+        FCPMessage wrappedMessage = FCPMessage.withListRequestIdentifier(originalMessage, IDENTIFIER);
+        assertThat(wrappedMessage.getFieldSet().get(LIST_REQUEST_IDENTIFIER), is(IDENTIFIER));
+    }
+
+    @Test
+    public void messageIsNotWrappedIfListRequestIdentifierIsNull() {
+        assertThat(FCPMessage.withListRequestIdentifier(originalMessage, null), sameInstance(originalMessage));
+    }
+
+    @Test
+    public void wrappedMessageDelegatesName() {
+        when(originalMessage.getName()).thenReturn(MESSAGE_NAME);
+        FCPMessage wrappedMessage = FCPMessage.withListRequestIdentifier(originalMessage, IDENTIFIER);
+        assertThat(wrappedMessage.getName(), is(MESSAGE_NAME));
+        verify(originalMessage).getName();
+    }
+
+    @Test
+    public void wrappedMessageDelegatesRun() throws MessageInvalidException {
+        FCPMessage wrappedMessage = FCPMessage.withListRequestIdentifier(originalMessage, IDENTIFIER);
+        FCPConnectionHandler connectionHandler = mock(FCPConnectionHandler.class);
+        Node node = mock(Node.class);
+        wrappedMessage.run(connectionHandler, node);
+        verify(originalMessage).run(connectionHandler, node);
+    }
+
+    @Test
+    public void wrappedMessageDelegatesEndString() {
+        FCPMessage wrappedMessage = FCPMessage.withListRequestIdentifier(originalMessage, IDENTIFIER);
+        when(originalMessage.getEndString()).thenReturn(END_STRING);
+        assertThat(wrappedMessage.getEndString(), is(END_STRING));
+        verify(originalMessage).getEndString();
+    }
+
+    @Test
+    public void wrappedMessageDelegatesSend() throws IOException {
+        FCPMessage wrappedMessage = FCPMessage.withListRequestIdentifier(originalMessage, IDENTIFIER);
+        OutputStream outputStream = mock(OutputStream.class);
+        wrappedMessage.send(outputStream);
+        verify(originalMessage).send(outputStream);
+    }
+
+}


### PR DESCRIPTION
This fixes `AllData` and all other data-carrying messages that are sent as a response to `ListPersistentRequests`.