### PR TITLE
Change default in test.haltonfailure to false

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -74,7 +74,7 @@ test.verbose=false
 test.benchmark=false
 test.extensive=false
 test.xml_output=true
-test.haltonfailure=yes
+test.haltonfailure=false
 
 # select a single test to run
 #test.class=


### PR DESCRIPTION
When building fred, continue the junit tests once a failure is encountered by default.