### PR TITLE
Much less recentlyfailed

### DIFF
--- a/src/freenet/node/PeerManager.java
+++ b/src/freenet/node/PeerManager.java
@@ -1160,7 +1160,7 @@ public class PeerManager {
 		
 		if(recentlyFailed != null && logMINOR)
 			Logger.minor(this, "Count waiting: "+countWaiting);
-		int maxCountWaiting = maxCountWaiting();
+		int maxCountWaiting = maxCountWaiting(peers);
 		if(recentlyFailed != null && countWaiting >= maxCountWaiting && 
 				node.enableULPRDataPropagation /* dangerous to do RecentlyFailed if we won't track/propagate offers */) {
 			// Recently failed is possible.
@@ -1247,11 +1247,12 @@ public class PeerManager {
 	}
 
 	/**
+	 * @param peers 
 	 * @return The minimum number of peers which are waiting for timeouts due to RecentlyFailed or 
 	 * DNF's for which we will terminate the request with a RecentlyFailed of our own.
 	 */
-	private int maxCountWaiting() {
-		int count = countConnectedPeers();
+	private int maxCountWaiting(PeerNode[] peers) {
+		int count = countConnectedPeers(peers);
 		return Math.max(3, count / 2);
 	}
 
@@ -2082,10 +2083,13 @@ public class PeerManager {
 		if(logMINOR) Logger.minor(this, "countConnectedDarknetPeers() returning "+count);
 		return count;
 	}
-
+	
 	public int countConnectedPeers() {
+		return countConnectedPeers(myPeers());
+	}
+
+	private int countConnectedPeers(PeerNode[] peers) {
 		int count = 0;
-		PeerNode[] peers = myPeers();
 		for(PeerNode peer: peers) {
 			if(peer == null)
 				continue;

--- a/src/freenet/node/PeerManager.java
+++ b/src/freenet/node/PeerManager.java
@@ -1253,7 +1253,7 @@ public class PeerManager {
 	 */
 	private int maxCountWaiting(PeerNode[] peers) {
 		int count = countConnectedPeers(peers);
-		return Math.max(3, count / 2);
+		return Math.max(3, count / 4);
 	}
 
 	static final int MIN_DELTA = 2000;

--- a/src/freenet/node/PeerManager.java
+++ b/src/freenet/node/PeerManager.java
@@ -1251,7 +1251,8 @@ public class PeerManager {
 	 * DNF's for which we will terminate the request with a RecentlyFailed of our own.
 	 */
 	private int maxCountWaiting() {
-		return 3;
+		int count = countConnectedPeers();
+		return Math.max(3, count / 2);
 	}
 
 	static final int MIN_DELTA = 2000;

--- a/src/freenet/node/PeerManager.java
+++ b/src/freenet/node/PeerManager.java
@@ -1253,7 +1253,7 @@ public class PeerManager {
 	 */
 	private int maxCountWaiting(PeerNode[] peers) {
 		int count = countConnectedPeers(peers);
-		return Math.max(3, count / 4);
+		return Math.min(10, Math.max(3, count / 4));
 	}
 
 	static final int MIN_DELTA = 2000;

--- a/src/freenet/node/PeerManager.java
+++ b/src/freenet/node/PeerManager.java
@@ -1160,7 +1160,8 @@ public class PeerManager {
 		
 		if(recentlyFailed != null && logMINOR)
 			Logger.minor(this, "Count waiting: "+countWaiting);
-		if(recentlyFailed != null && countWaiting >= 3 && 
+		int maxCountWaiting = maxCountWaiting();
+		if(recentlyFailed != null && countWaiting >= maxCountWaiting && 
 				node.enableULPRDataPropagation /* dangerous to do RecentlyFailed if we won't track/propagate offers */) {
 			// Recently failed is possible.
 			// Route twice, each time ignoring timeout.
@@ -1182,7 +1183,7 @@ public class PeerManager {
 							// This is the sooner of the two top nodes' timeouts.
 							// We also take into account the sooner of any timed out node, IF there are exactly 3 nodes waiting.
 							long until = Math.min(secondTime, firstTime);
-							if(countWaiting == 3) {
+							if(countWaiting == maxCountWaiting) {
 								// Count the others as well if there are only 3.
 								// If there are more than that they won't matter.
 								until = Math.min(until, soonestTimeoutWakeup);
@@ -1243,6 +1244,14 @@ public class PeerManager {
 		}
 		
 		return best;
+	}
+
+	/**
+	 * @return The minimum number of peers which are waiting for timeouts due to RecentlyFailed or 
+	 * DNF's for which we will terminate the request with a RecentlyFailed of our own.
+	 */
+	private int maxCountWaiting() {
+		return 3;
 	}
 
 	static final int MIN_DELTA = 2000;


### PR DESCRIPTION
Recently failed is one of the great annoyances when using Freenet, so I think it would be great to merge and use this.

The change likely makes it cheaper to create load by firing requests which never finish, but given that recently failed hits me at least once a week, I think this change should go in (I checked the diff and it looks sane).
