### PR TITLE
pass the isOfficial flag to the plugin(api)

### DIFF
--- a/src/freenet/pluginmanager/PluginRespirator.java
+++ b/src/freenet/pluginmanager/PluginRespirator.java
@@ -332,4 +332,8 @@ public class PluginRespirator {
 	public void storeConfig() {
 		pi.getConfig().store();
 	}
+
+	public boolean isOfficialPlugin() {
+	    return pi.isOfficialPlugin();
+	}
 }


### PR DESCRIPTION
pass the isOfficial flag to the plugin so the official plugin can point to mantis as bugtracker and stuff.