### PR TITLE
Add warning message about leftover plugin files

### DIFF
--- a/src/freenet/clients/http/PproxyToadlet.java
+++ b/src/freenet/clients/http/PproxyToadlet.java
@@ -198,6 +198,9 @@ public class PproxyToadlet extends Toadlet {
 				HTMLNode infoboxContent = infobox.addChild("div", "class", "infobox-content");
 				infoboxContent.addChild("#", l10n("pluginUnloadedWithName", "name", pluginThreadName));
 				infoboxContent.addChild("br");
+                infoboxContent.addChild("#", l10n("pluginFilesWarning"));
+                infoboxContent.addChild("br");
+                infoboxContent.addChild("br");
 				infoboxContent.addChild("a", "href", "/plugins/", l10n("returnToPluginPage"));
 				writeHTMLReply(ctx, 200, "OK", pageNode.generate());
 				return;

--- a/src/freenet/l10n/freenet.l10n.en.properties
+++ b/src/freenet/l10n/freenet.l10n.en.properties
@@ -1502,6 +1502,7 @@ PproxyToadlet.pluginSourceHTTPS=Fetch over the web from our central servers.
 PproxyToadlet.pluginSourceHTTPSWarning=WARNING: This will give away the fact that you are running Freenet, and won't work if our website is blocked! It may even be possible for a wiretapper to tell what you are trying to load, and thus connect it with when e.g. a Freemail identity was created.
 PproxyToadlet.pluginUnloaded=Plugin unloaded
 PproxyToadlet.pluginUnloadedWithName=The plugin ${name} has been unloaded.
+PproxyToadlet.pluginFilesWarning=WARNING: If this plugin stored files on disk, they have NOT been deleted.
 PproxyToadlet.plugins=Plugins
 PproxyToadlet.reloadOnStartupShort=Reload on Startup
 PproxyToadlet.reload=Reload


### PR DESCRIPTION
Added a warning that files stored by a plugin are not removed when the plugin is unloaded, as requested in bug 6558. I didn't add the FredPluginWithUninstallation interface, because it doesn't make sense until we have functionality for it.