### PR TITLE
<link> to CSS dependencies

### DIFF
--- a/src/freenet/clients/http/staticfiles/base.css
+++ b/src/freenet/clients/http/staticfiles/base.css
@@ -1,13 +1,13 @@
 /* default color scheme */
-@import url(/static/color.css);
+/* @import url(/static/color.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */
 
 /* FIXME these includes should be incorporated into this file */
 
 /* Bookmarks & bookmark editor */
-@import url(/static/bookmark.css);
+/* @import url(/static/bookmark.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */
 
 /* Status bar style & colors */
-@import url(/static/statusbar.css);
+/* @import url(/static/statusbar.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */
 
 /* 
  * Overall Settings

--- a/src/freenet/clients/http/staticfiles/behavior-classic.css
+++ b/src/freenet/clients/http/staticfiles/behavior-classic.css
@@ -3,7 +3,7 @@
  */
 
 /* Basic CSS functions */
-@import url(/static/base.css);
+/* @import url(/static/base.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */
 
 /* code */
 

--- a/src/freenet/clients/http/staticfiles/behavior-dropdown.css
+++ b/src/freenet/clients/http/staticfiles/behavior-dropdown.css
@@ -4,7 +4,7 @@
 */
 
 /* Basic CSS functions */
-@import url(/static/base.css);
+/* @import url(/static/base.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */
 
 /* code */
 

--- a/src/freenet/clients/http/staticfiles/behavior-dynamic.css
+++ b/src/freenet/clients/http/staticfiles/behavior-dynamic.css
@@ -3,7 +3,7 @@
  */
 
 /* Basic CSS functions */
-@import url(/static/base.css);
+/* @import url(/static/base.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */
 
 /* code */
 

--- a/src/freenet/clients/http/staticfiles/behavior-static.css
+++ b/src/freenet/clients/http/staticfiles/behavior-static.css
@@ -3,7 +3,7 @@
  */
 
 /* Basic CSS functions */
-@import url(/static/base.css);
+/* @import url(/static/base.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */
 
 /* code */
 

--- a/src/freenet/clients/http/staticfiles/behavior-top.css
+++ b/src/freenet/clients/http/staticfiles/behavior-top.css
@@ -4,7 +4,7 @@
 */
 
 /* Basic CSS functions */
-@import url(/static/base.css);
+/* @import url(/static/base.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */
 
 /* code */
 

--- a/src/freenet/clients/http/staticfiles/clean-dropdown-old.css
+++ b/src/freenet/clients/http/staticfiles/clean-dropdown-old.css
@@ -1,13 +1,13 @@
 /* clean-dropdown */
 
 /* Basic CSS functions */
-@import url(/static/base-old.css);
+/* @import url(/static/base-old.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */
 
 /* Bookmarks & bookmark editor */
-@import url(/static/bookmark.css);
+/* @import url(/static/bookmark.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */
 
 /* Base theme */
-@import url(/static/clean-old.css);
+/* @import url(/static/clean-old.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */
 
 div#content {
 	position: inherit;

--- a/src/freenet/clients/http/staticfiles/clean-old.css
+++ b/src/freenet/clients/http/staticfiles/clean-old.css
@@ -1,13 +1,13 @@
 /* clean */
 
 /* Basic CSS functions */
-@import url(/static/base-old.css);
+/* @import url(/static/base-old.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */
 
 /* Bookmarks & bookmark editor */
-@import url(/static/bookmark.css);
+/* @import url(/static/bookmark.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */
 
 /* Status bar style & colors */
-@import url(/static/statusbar.css);
+/* @import url(/static/statusbar.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */
 
 /* clean overall settings */
 

--- a/src/freenet/clients/http/staticfiles/themes/boxed-classic/theme.css
+++ b/src/freenet/clients/http/staticfiles/themes/boxed-classic/theme.css
@@ -1,10 +1,10 @@
 /* boxed-classic theme */
 
 /* navigation behavior */
-@import url(/static/behavior-classic.css);
+/* @import url(/static/behavior-classic.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */
 
 /* layout */
-@import url(/static/themes/boxed/layout.css);
+/* @import url(/static/themes/boxed/layout.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */
 
 /* color scheme */
-@import url(/static/themes/boxed/color.css);
+/* @import url(/static/themes/boxed/color.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */

--- a/src/freenet/clients/http/staticfiles/themes/boxed-dropdown/theme.css
+++ b/src/freenet/clients/http/staticfiles/themes/boxed-dropdown/theme.css
@@ -1,10 +1,10 @@
 /* boxed-dropdown theme */
 
 /* navigation behavior */
-@import url(/static/behavior-dropdown.css);
+/* @import url(/static/behavior-dropdown.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */
 
 /* layout */
-@import url(/static/themes/boxed/layout.css);
+/* @import url(/static/themes/boxed/layout.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */
 
 /* color scheme */
-@import url(/static/themes/boxed/color.css);
+/* @import url(/static/themes/boxed/color.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */

--- a/src/freenet/clients/http/staticfiles/themes/boxed-dynamic/theme.css
+++ b/src/freenet/clients/http/staticfiles/themes/boxed-dynamic/theme.css
@@ -1,10 +1,10 @@
 /* boxed theme */
 
 /* navigation behavior */
-@import url(/static/behavior-dynamic.css);
+/* @import url(/static/behavior-dynamic.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */
 
 /* layout */
-@import url(/static/themes/boxed/layout.css);
+/* @import url(/static/themes/boxed/layout.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */
 
 /* color scheme */
-@import url(/static/themes/boxed/color.css);
+/* @import url(/static/themes/boxed/color.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */

--- a/src/freenet/clients/http/staticfiles/themes/boxed-static/theme.css
+++ b/src/freenet/clients/http/staticfiles/themes/boxed-static/theme.css
@@ -1,10 +1,10 @@
 /* boxed-static theme */
 
 /* navigation behavior */
-@import url(/static/behavior-static.css);
+/* @import url(/static/behavior-static.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */
 
 /* layout */
-@import url(/static/themes/boxed/layout.css);
+/* @import url(/static/themes/boxed/layout.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */
 
 /* color scheme */
-@import url(/static/themes/boxed/color.css);
+/* @import url(/static/themes/boxed/color.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */

--- a/src/freenet/clients/http/staticfiles/themes/boxed/theme.css
+++ b/src/freenet/clients/http/staticfiles/themes/boxed/theme.css
@@ -1,10 +1,10 @@
 /* boxed top */
 
 /* navigation behavior */
-@import url(/static/behavior-top.css);
+/* @import url(/static/behavior-top.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */
 
 /* layout */
-@import url(/static/themes/boxed/layout.css);
+/* @import url(/static/themes/boxed/layout.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */
 
 /* color scheme */
-@import url(/static/themes/boxed/color.css);
+/* @import url(/static/themes/boxed/color.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */

--- a/src/freenet/clients/http/staticfiles/themes/clean-classic/theme.css
+++ b/src/freenet/clients/http/staticfiles/themes/clean-classic/theme.css
@@ -1,10 +1,10 @@
 ﻿/* clean-classic theme */
 
 /* navigation behavior */
-@import url(/static/behavior-classic.css);
+/* @import url(/static/behavior-classic.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */
 
 /* layout */
-@import url(/static/themes/clean/layout.css);
+/* @import url(/static/themes/clean/layout.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */
 
 /* color scheme */
-@import url(/static/themes/clean/color.css);
+/* @import url(/static/themes/clean/color.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */

--- a/src/freenet/clients/http/staticfiles/themes/clean-dropdown/theme.css
+++ b/src/freenet/clients/http/staticfiles/themes/clean-dropdown/theme.css
@@ -1,10 +1,10 @@
 ﻿/* clean-dropdown theme */
 
 /* navigation behavior */
-@import url(/static/behavior-dropdown.css);
+/* @import url(/static/behavior-dropdown.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */
 
 /* layout */
-@import url(/static/themes/clean/layout.css);
+/* @import url(/static/themes/clean/layout.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */
 
 /* color scheme */
-@import url(/static/themes/clean/color.css);
+/* @import url(/static/themes/clean/color.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */

--- a/src/freenet/clients/http/staticfiles/themes/clean-static/theme.css
+++ b/src/freenet/clients/http/staticfiles/themes/clean-static/theme.css
@@ -1,10 +1,10 @@
 ﻿/* clean-static theme */
 
 /* navigation behavior */
-@import url(/static/behavior-static.css);
+/* @import url(/static/behavior-static.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */
 
 /* layout */
-@import url(/static/themes/clean/layout.css);
+/* @import url(/static/themes/clean/layout.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */
 
 /* color scheme */
-@import url(/static/themes/clean/color.css);
+/* @import url(/static/themes/clean/color.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */

--- a/src/freenet/clients/http/staticfiles/themes/clean-top/theme.css
+++ b/src/freenet/clients/http/staticfiles/themes/clean-top/theme.css
@@ -1,10 +1,10 @@
 /* clean-top theme */
 
 /* navigation behavior */
-@import url(/static/behavior-top.css);
+/* @import url(/static/behavior-top.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */
 
 /* layout */
-@import url(/static/themes/clean/layout.css);
+/* @import url(/static/themes/clean/layout.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */
 
 /* color scheme */
-@import url(/static/themes/clean/color.css);
+/* @import url(/static/themes/clean/color.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */

--- a/src/freenet/clients/http/staticfiles/themes/clean/theme.css
+++ b/src/freenet/clients/http/staticfiles/themes/clean/theme.css
@@ -1,10 +1,10 @@
 ﻿/* clean theme */
 
 /* navigation behavior */
-@import url(/static/behavior-dynamic.css);
+/* @import url(/static/behavior-dynamic.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */
 
 /* layout */
-@import url(/static/themes/clean/layout.css);
+/* @import url(/static/themes/clean/layout.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */
 
 /* color scheme */
-@import url(/static/themes/clean/color.css);
+/* @import url(/static/themes/clean/color.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */

--- a/src/freenet/clients/http/staticfiles/themes/grayandblue-dropdown/theme.css
+++ b/src/freenet/clients/http/staticfiles/themes/grayandblue-dropdown/theme.css
@@ -1,10 +1,10 @@
 ﻿/* grayandblue-dropdown theme */
 
 /* navigation behavior */
-@import url(/static/behavior-dropdown.css);
+/* @import url(/static/behavior-dropdown.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */
 
 /* layout */
-@import url(/static/themes/grayandblue/layout.css);
+/* @import url(/static/themes/grayandblue/layout.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */
 
 /* color scheme */
-@import url(/static/themes/grayandblue/color.css);
+/* @import url(/static/themes/grayandblue/color.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */

--- a/src/freenet/clients/http/staticfiles/themes/grayandblue-dynamic/theme.css
+++ b/src/freenet/clients/http/staticfiles/themes/grayandblue-dynamic/theme.css
@@ -1,10 +1,10 @@
 ﻿/* grayandblue theme */
 
 /* navigation behavior */
-@import url(/static/behavior-dynamic.css);
+/* @import url(/static/behavior-dynamic.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */
  
 /* layout */
-@import url(/static/themes/grayandblue/layout.css);
+/* @import url(/static/themes/grayandblue/layout.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */
 
 /* color scheme */
-@import url(/static/themes/grayandblue/color.css);
+/* @import url(/static/themes/grayandblue/color.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */

--- a/src/freenet/clients/http/staticfiles/themes/grayandblue-static/theme.css
+++ b/src/freenet/clients/http/staticfiles/themes/grayandblue-static/theme.css
@@ -1,10 +1,10 @@
 ﻿/* grayandblue-static theme */
 
 /* navigation behavior */
-@import url(/static/behavior-static.css);
+/* @import url(/static/behavior-static.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */
  
 /* layout */
-@import url(/static/themes/grayandblue/layout.css);
+/* @import url(/static/themes/grayandblue/layout.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */
 
 /* color scheme */
-@import url(/static/themes/grayandblue/color.css);
+/* @import url(/static/themes/grayandblue/color.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */

--- a/src/freenet/clients/http/staticfiles/themes/grayandblue-top/theme.css
+++ b/src/freenet/clients/http/staticfiles/themes/grayandblue-top/theme.css
@@ -1,10 +1,10 @@
 /* grayandblue-top theme */
 
 /* navigation behavior */
-@import url(/static/behavior-top.css);
+/* @import url(/static/behavior-top.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */
  
 /* layout */
-@import url(/static/themes/grayandblue/layout.css);
+/* @import url(/static/themes/grayandblue/layout.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */
 
 /* color scheme */
-@import url(/static/themes/grayandblue/color.css);
+/* @import url(/static/themes/grayandblue/color.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */

--- a/src/freenet/clients/http/staticfiles/themes/grayandblue/theme.css
+++ b/src/freenet/clients/http/staticfiles/themes/grayandblue/theme.css
@@ -1,10 +1,10 @@
 ﻿/* grayandblue-classic theme */
 
 /* navigation behavior */
-@import url(/static/behavior-classic.css);
+/* @import url(/static/behavior-classic.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */
 
 /* layout */
-@import url(/static/themes/grayandblue/layout.css);
+/* @import url(/static/themes/grayandblue/layout.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */
 
 /* color scheme */
-@import url(/static/themes/grayandblue/color.css);
+/* @import url(/static/themes/grayandblue/color.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */

--- a/src/freenet/clients/http/staticfiles/themes/minimalblue/theme.css
+++ b/src/freenet/clients/http/staticfiles/themes/minimalblue/theme.css
@@ -1,13 +1,13 @@
 ﻿/* minimalblue */
 
 /* Basic CSS functions */
-@import url(/static/base-old.css);
+/* @import url(/static/base-old.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */
 
 /* Bookmarks & bookmark editor */
-@import url(/static/bookmark.css);
+/* @import url(/static/bookmark.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */
 
 /* Status bar style & colors */
-@import url(/static/statusbar.css);
+/* @import url(/static/statusbar.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */
 
 /* minimal blue overall settings */
 

--- a/src/freenet/clients/http/staticfiles/themes/minimalist/theme.css
+++ b/src/freenet/clients/http/staticfiles/themes/minimalist/theme.css
@@ -1,10 +1,10 @@
 ﻿/* minimalist */
 
 /* Base theme */
-@import url(/static/clean-dropdown-old.css);
+/* @import url(/static/clean-dropdown-old.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */
 
 /* Default pictures won't render nice with this theme */
-@import url(/static/picturesnullifier.css);
+/* @import url(/static/picturesnullifier.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */
 
 /* minimalist overall settings */
 

--- a/src/freenet/clients/http/staticfiles/themes/rabbit-hole/theme.css
+++ b/src/freenet/clients/http/staticfiles/themes/rabbit-hole/theme.css
@@ -1,14 +1,14 @@
 ﻿/* rabbit-hole */
 
 /* Basic CSS functions */
-@import url(/static/base-old.css);
+/* @import url(/static/base-old.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */
 
 /* Bookmarks & bookmark editor */
-@import url(/static/bookmark.css);
+/* @import url(/static/bookmark.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */
 
 /* Base theme; commented out, since it is not really compatible. TODO: Get everything therein to here and integrate it. */
 /* First: Progress bars */
-/* @import url(/static/themes/clean/theme.css); */
+/*/*  @import url(/static/themes/clean/theme.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */ */
 
 /* rabbit-hole overall settings */
 

--- a/src/freenet/clients/http/staticfiles/themes/sky-classic/theme.css
+++ b/src/freenet/clients/http/staticfiles/themes/sky-classic/theme.css
@@ -1,10 +1,10 @@
 /* sky-classic theme */
 
 /* navigation behavior */
-@import url(/static/behavior-classic.css);
+/* @import url(/static/behavior-classic.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */
 
 /* layout */
-@import url(/static/themes/sky/layout.css);
+/* @import url(/static/themes/sky/layout.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */
 
 /* color scheme */
-@import url(/static/themes/sky/color.css);
+/* @import url(/static/themes/sky/color.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */

--- a/src/freenet/clients/http/staticfiles/themes/sky-dropdown/theme.css
+++ b/src/freenet/clients/http/staticfiles/themes/sky-dropdown/theme.css
@@ -1,10 +1,10 @@
 /* sky-dropdown theme */
 
 /* navigation behavior */
-@import url(/static/behavior-dropdown.css);
+/* @import url(/static/behavior-dropdown.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */
 
 /* layout */
-@import url(/static/themes/sky/layout.css);
+/* @import url(/static/themes/sky/layout.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */
 
 /* color scheme */
-@import url(/static/themes/sky/color.css);
+/* @import url(/static/themes/sky/color.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */

--- a/src/freenet/clients/http/staticfiles/themes/sky-dynamic/theme.css
+++ b/src/freenet/clients/http/staticfiles/themes/sky-dynamic/theme.css
@@ -1,10 +1,10 @@
 ﻿/* sky theme */
 
 /* navigation behavior */
-@import url(/static/behavior-dynamic.css);
+/* @import url(/static/behavior-dynamic.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */
 
 /* layout */
-@import url(/static/themes/sky/layout.css);
+/* @import url(/static/themes/sky/layout.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */
 
 /* color scheme */
-@import url(/static/themes/sky/color.css);
+/* @import url(/static/themes/sky/color.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */

--- a/src/freenet/clients/http/staticfiles/themes/sky-static/theme.css
+++ b/src/freenet/clients/http/staticfiles/themes/sky-static/theme.css
@@ -1,10 +1,10 @@
 /* sky-static theme */
 
 /* navigation behavior */
-@import url(/static/behavior-static.css);
+/* @import url(/static/behavior-static.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */
 
 /* layout */
-@import url(/static/themes/sky/layout.css);
+/* @import url(/static/themes/sky/layout.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */
 
 /* color scheme */
-@import url(/static/themes/sky/color.css);
+/* @import url(/static/themes/sky/color.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */

--- a/src/freenet/clients/http/staticfiles/themes/sky/theme.css
+++ b/src/freenet/clients/http/staticfiles/themes/sky/theme.css
@@ -1,10 +1,10 @@
 ﻿/* sky theme */
 
 /* navigation behavior */
-@import url(/static/behavior-top.css);
+/* @import url(/static/behavior-top.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */
 
 /* layout */
-@import url(/static/themes/sky/layout.css);
+/* @import url(/static/themes/sky/layout.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */
 
 /* color scheme */
-@import url(/static/themes/sky/color.css);
+/* @import url(/static/themes/sky/color.css); replaced by freenet.clients.http.PageMaker.ThemeCSS */


### PR DESCRIPTION
This replaces the CSS `@import` declarations with top-level `<link>` declarations of unique includes in the HTML in the correct order of appearance. To be able to do this, we could either parse/modify the CSS (which is doable but hard), or hard-code the dependency graph in Java. Since themes are hard-coded in `PageMaker` anyhow, I opted for the latter approach.

The original `@import` statements have been omitted from the CSS files accordingly, and replaced by a comment explaining where the import has gone.

This can be seen as another approach to #423.