### PR TITLE
HTMLFilter: fix processing of reset input element

### DIFF
--- a/src/freenet/client/filter/HTMLFilter.java
+++ b/src/freenet/client/filter/HTMLFilter.java
@@ -2722,7 +2722,7 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
 			"checkbox",
 			"radio",
 			"submit",
-			"reset,",
+			"reset",
 			// no ! file
 			"hidden",
 			"image",


### PR DESCRIPTION
This fixes an obvious typo in HTMLFilter that prevented `<input type="reset">`-style form elements from passing the filter.