### PR TITLE
Fix JVM version comparison for version >1.9 and build >99

### DIFF
--- a/src/freenet/support/JVMVersion.java
+++ b/src/freenet/support/JVMVersion.java
@@ -1,13 +1,20 @@
 package freenet.support;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 /**
  * JVM version utilities.
  *
  * See documentation: http://www.oracle.com/technetwork/java/javase/versioning-naming-139433.html
  */
 public class JVMVersion {
-
 	public static final String REQUIRED = "1.7";
+
+	/** Regular expression for versions: major.feature[.maintenance[_update]],
+	 * leading zeroes and optional identifier stripped. */
+	private static final Pattern VERSION_PATTERN =
+	    Pattern.compile("^0*(\\d+)\\.0*(\\d+)(?:\\.0*(\\d+)(?:_0*(\\d+))?)?(?:-.*)?$");
 
 	public static boolean isTooOld() {
 		return isTooOld(getCurrent());
@@ -20,7 +27,7 @@ public class JVMVersion {
 	static boolean isTooOld(String version) {
 		if (version == null) return false;
 
-		return version.compareTo(REQUIRED) < 0;
+		return compareVersion(version, REQUIRED) < 0;
 	}
 
 	public static final boolean is32Bit() {
@@ -31,5 +38,46 @@ public class JVMVersion {
 		} else {
 			return is32bitOS;
 		}
+	}
+
+	/**
+	 * Decomposes a version string into major, feature, and optional maintenance and update
+	 * components.
+	 * Missing optional components are set to 0, failed parses return all zeroes.
+	 */
+	static int[] parse(String version) {
+	    int[] parsed = new int[4];
+	    if (version == null) {
+	        return parsed;
+	    }
+	    Matcher m = VERSION_PATTERN.matcher(version);
+	    if (m.matches()) {
+	        for (int i = 0; i < 4; i++) {
+	            String component = m.group(i + 1);
+	            if (component != null) {
+	                parsed[i] = Integer.parseInt(component);
+	            }
+	        }
+	    }
+	    return parsed;
+	}
+
+	/**
+	 * Compares two version strings, ignoring optional identifiers.
+	 * Version strings that cannot be parsed are treated as version 0.0.0_0.
+	 * @return A value < 0 if version1 is less than version2, 0 if they are equal, > 0 otherwise.
+	 */
+	static int compareVersion(String version1, String version2) {
+	    int[] parsed1 = parse(version1);
+	    int[] parsed2 = parse(version2);
+	    for (int i = 0; i < 4; i++) {
+	        if (parsed1[i] < parsed2[i]) {
+	            return -1;
+	        }
+	        if (parsed1[i] > parsed2[i]) {
+	            return 1;
+	        }
+	    }
+	    return 0;
 	}
 }

--- a/test/freenet/support/JVMVersionTest.java
+++ b/test/freenet/support/JVMVersionTest.java
@@ -15,9 +15,42 @@ public class JVMVersionTest extends TestCase {
 		Assert.assertFalse(JVMVersion.isTooOld("1.7.0_65"));
 		Assert.assertFalse(JVMVersion.isTooOld("1.7"));
 		Assert.assertFalse(JVMVersion.isTooOld("1.8.0_9"));
+		Assert.assertFalse(JVMVersion.isTooOld("1.10"));
 	}
 
 	public void testNull() {
 		Assert.assertFalse(JVMVersion.isTooOld(null));
+	}
+
+	public void testCompare() {
+	    String[] orderedVersions = new String[] {
+	        "1.7.bogus", // Bogus versions are treated as 0.0.0_0
+	        "1.5",
+	        "1.6.0",
+	        "1.6.0_32",
+	        "1.7",
+	        "1.7.0_59",
+	        "1.7.0_65",
+	        "1.7.1",
+	        "1.7.1_1",
+	        "1.7.1_09",
+	        "1.7.1_65-rc4",
+	        "1.7.2-ea",
+	        "1.7.3_0",
+	        "1.8-beta",
+	        "1.10",
+	        "1.10.1"
+	    };
+
+	    // Compare all combinations and check correctness of their ordering
+	    for (int i = 0; i < orderedVersions.length; i++) {
+	        String v1 = orderedVersions[i];
+	        for (int j = 0; j < orderedVersions.length; j++) {
+	            String v2 = orderedVersions[j];
+	            int expected = Integer.signum(Integer.compare(i, j));
+	            int actual = Integer.signum(JVMVersion.compareVersion(v1, v2));
+	            assertEquals(expected, actual);
+	        }
+	    }
 	}
 }


### PR DESCRIPTION
We now properly parse JVM version numbers, instead of comparing them
lexicographically.

This resolves bug [6390](https://bugs.freenetproject.org/view.php?id=6390).