### PR TITLE
Re-check the stores list periodically

### DIFF
--- a/src/freenet/store/caching/CachingFreenetStoreTracker.java
+++ b/src/freenet/store/caching/CachingFreenetStoreTracker.java
@@ -130,11 +130,12 @@ public class CachingFreenetStoreTracker {
 	
 	private void pushAllCachingStores() {
 		CachingFreenetStore<?>[] cachingStoresSnapshot = null;
-		synchronized (cachingStores) {
-			cachingStoresSnapshot = this.cachingStores.toArray(new CachingFreenetStore[cachingStores.size()]);
-		}
 		
 		while(true) {
+		    // Need to re-check occasionally in case new stores have been added.
+	        synchronized (cachingStores) {
+	            cachingStoresSnapshot = this.cachingStores.toArray(new CachingFreenetStore[cachingStores.size()]);
+	        }
 			for(CachingFreenetStore<?> cfs : cachingStoresSnapshot) {
 				int k=0;
 				while(k < numberOfKeysToWrite) {

--- a/src/freenet/store/caching/CachingFreenetStoreTracker.java
+++ b/src/freenet/store/caching/CachingFreenetStoreTracker.java
@@ -127,13 +127,13 @@ public class CachingFreenetStoreTracker {
 			return true;
 		}
 	}
-	
+    
 	private void pushAllCachingStores() {
 		while(true) {
-		    // Need to re-check occasionally in case new stores have been added.
-	        CachingFreenetStore<?>[] cachingStoresSnapshot = null;
-	        synchronized (cachingStores) {
-	            cachingStoresSnapshot = this.cachingStores.toArray(new CachingFreenetStore[cachingStores.size()]);
+            // Need to re-check occasionally in case new stores have been added.
+            CachingFreenetStore<?>[] cachingStoresSnapshot = null;
+            synchronized (cachingStores) {
+                cachingStoresSnapshot = this.cachingStores.toArray(new CachingFreenetStore[cachingStores.size()]);
 	        }
 			for(CachingFreenetStore<?> cfs : cachingStoresSnapshot) {
 				int k=0;

--- a/src/freenet/store/caching/CachingFreenetStoreTracker.java
+++ b/src/freenet/store/caching/CachingFreenetStoreTracker.java
@@ -129,10 +129,9 @@ public class CachingFreenetStoreTracker {
 	}
 	
 	private void pushAllCachingStores() {
-		CachingFreenetStore<?>[] cachingStoresSnapshot = null;
-		
 		while(true) {
 		    // Need to re-check occasionally in case new stores have been added.
+	        CachingFreenetStore<?>[] cachingStoresSnapshot = null;
 	        synchronized (cachingStores) {
 	            cachingStoresSnapshot = this.cachingStores.toArray(new CachingFreenetStore[cachingStores.size()]);
 	        }


### PR DESCRIPTION
Fixes a nasty race condition which could happen with late initialisation
of the client-cache (e.g. due to password encryption), would cause an
infinite loop.

Please consider for 1471 (as this fixes a regression in next).