### PR TITLE
Fix CSS filter being more generous than it should be in 1471-pre

### DIFF
--- a/src/freenet/client/filter/CSSTokenizerFilter.java
+++ b/src/freenet/client/filter/CSSTokenizerFilter.java
@@ -3650,7 +3650,7 @@ class CSSTokenizerFilter {
 		public final boolean isAngle;      //an
 		public final boolean isColor;      //co
 		public final boolean isURI;        //ur
-		public final boolean isSelector;   //se
+		public final boolean isIDSelector;   //se
 		public final boolean isShape;      //sh
 		public final boolean isString;     //st
 		public final boolean isCounter;    //co
@@ -3707,10 +3707,10 @@ class CSSTokenizerFilter {
 			this.allowCommaDelimiters = allowCommaDelimiters;
 
 			boolean isInteger, isReal, isPercentage, isLength, isAngle, isColor,
-				isSelector, isURI, isShape, isString, isCounter, isIdentifier,
+				isIDSelector, isURI, isShape, isString, isCounter, isIdentifier,
 				isTime, isFrequency, isTransform;
 			isInteger = isReal = isPercentage = isLength = isAngle = isColor = isURI
-				= isShape = isString = isCounter = isIdentifier = isTime = isSelector
+				= isShape = isString = isCounter = isIdentifier = isTime = isIDSelector
 				= isFrequency = isTransform = false;
 			if(possibleValues != null) {
 				for(String possibleValue : possibleValues) {
@@ -3729,7 +3729,7 @@ class CSSTokenizerFilter {
 					else if("ur".equals(possibleValue))
 						isURI=true;	//ur
 					else if ("se".equals(possibleValue)) {
-						isSelector = true; //se
+						isIDSelector = true; //se
 					}
 					else if("sh".equals(possibleValue))
 						isShape=true;	//sh
@@ -3754,7 +3754,7 @@ class CSSTokenizerFilter {
 			this.isAngle = isAngle;
 			this.isColor = isColor;
 			this.isURI = isURI;
-			this.isSelector = isSelector;
+			this.isIDSelector = isIDSelector;
 			this.isShape = isShape;
 			this.isString = isString;
 			this.isCounter = isCounter;
@@ -3967,7 +3967,7 @@ class CSSTokenizerFilter {
 				return true;
 			}
 			
-			if (isSelector) {
+			if (isIDSelector) {
 				String result = HTMLelementVerifier(words[0].original);
 				if (!(result == null || result.equals(""))) {
 					return true;

--- a/src/freenet/client/filter/CSSTokenizerFilter.java
+++ b/src/freenet/client/filter/CSSTokenizerFilter.java
@@ -924,7 +924,7 @@ class CSSTokenizerFilter {
 			//  ] ]
 			auxilaryVerifiers[25]=new CSSPropertyVerifier(null,Arrays.asList("ur"),null,null,true);
 			auxilaryVerifiers[141] = new CSSPropertyVerifier(null, Arrays.asList("in", "re"), null, null, true);
-			auxilaryVerifiers[142] = new CSSPropertyVerifier(null, null, null, Arrays.asList("25 141<0,1> 141<0,1>"), true, true);
+			auxilaryVerifiers[142] = new CSSPropertyVerifier(null, null, null, Arrays.asList("25 141 141", "25"), true, true);
 			auxilaryVerifiers[26] = new CSSPropertyVerifier(
 			Arrays.asList("auto", "default", "none",
 					"context-menu", "help", "pointer", "progress", "wait",

--- a/src/freenet/client/filter/CSSTokenizerFilter.java
+++ b/src/freenet/client/filter/CSSTokenizerFilter.java
@@ -3976,6 +3976,13 @@ class CSSTokenizerFilter {
 			}
 			
 			if (isIDSelector) {
+			    // In accordance with spec for e.g. nav-*, we only allow ID selectors.
+			    // See http://www.w3.org/TR/css3-ui/
+			    // REDFLAG If we allow more general selectors (which some browsers may accept) we 
+			    // have two new problems:
+			    // 1) They may occupy more than one word, which greatly complicates parsing here,
+			    // 2) We should sanitize the selectors, not just pass them on. Which in turn may 
+			    // cause them to take up more than one word!
 				String result = HTMLelementVerifier(words[0].original, true);
 				if (!(result == null || result.equals(""))) {
 					return true;

--- a/src/freenet/client/filter/CSSTokenizerFilter.java
+++ b/src/freenet/client/filter/CSSTokenizerFilter.java
@@ -4215,6 +4215,7 @@ class CSSTokenizerFilter {
 		}
 		/**
 		 * Takes b expressions and evaluates them.<br/>
+		 * "&&" means all of the expressions must occur in any order.<br/>
 		 * CSS Grammar <code>list-item && [ block | nonsense ] && [ more ]?</code><br/>
 		 * Will accept the following inputs as valid:<br/>
 		 * <code>list-item block</code><br/>
@@ -4224,12 +4225,9 @@ class CSSTokenizerFilter {
 		 * @param expression the expression, explained above
 		 * @param words tokens to parse
 		 * @param cb
-		 * @return true if all the words were consumed false otherwise.
+		 * @return true if all the verifiers and all the words were consumed, false otherwise.
 		 */
 		public boolean doubleAmpersandVerifier(String expression, ParsedWord[] words, FilterCallback cb) {
-			if(words==null || words.length == 0)
-				return true;
-
 			String ignoredParts="";
 			String firstPart = "";
 			int lastB = -1;

--- a/test/freenet/client/filter/CSSParserTest.java
+++ b/test/freenet/client/filter/CSSParserTest.java
@@ -876,7 +876,7 @@ public class CSSParserTest extends TestCase {
 		propertyTests.put("body { nav-down: auto; }",  "body { nav-down: auto; }");
 		propertyTests.put("body { nav-down: h2#java current; }",  "body { nav-down: h2#java current; }");
 		propertyTests.put("body { nav-up: #java root; }",  "body { nav-up: #java root; }");
-		propertyTests.put("body { nav-left: div.bold '<target-name>'; }",  "body { nav-left: div.bold '<target-name>'; }");
+		propertyTests.put("body { nav-left: div.bold '<target-name>'; }",  "body { }");
 		propertyTests.put("button#foo { nav-left: #bar \"sidebar\"; }", "button#foo { nav-left: #bar \"sidebar\"; }");
 		propertyTests.put("button#foo { nav-left: invalidSelector \"sidebar\"; }", "button#foo { }");
 	}

--- a/test/freenet/client/filter/CSSParserTest.java
+++ b/test/freenet/client/filter/CSSParserTest.java
@@ -783,6 +783,7 @@ public class CSSParserTest extends TestCase {
 		propertyTests.put(":link,:visited { cursor: url(example.svg#linkcursor) url(hyper.cur) pointer }", ":link { cursor: url(\"example.svg#linkcursor\") url(\"hyper.cur\") pointer }");
 		propertyTests.put(":link,:visited { cursor: url(example.svg#linkcursor), url(hyper.cur), pointer }", ":link { cursor: url(\"example.svg#linkcursor\"), url(\"hyper.cur\"), pointer }");
 		propertyTests.put(":link,:visited { cursor: url(example.svg#linkcursor) 2 5, url(hyper.cur), pointer }", ":link { cursor: url(\"example.svg#linkcursor\") 2 5, url(\"hyper.cur\"), pointer }");
+        propertyTests.put(":link,:visited { cursor: url(example.svg#linkcursor) 2, url(hyper.cur), pointer }", ":link { }");
 
 		// UI colors
 		propertyTests.put("p { color: WindowText; background-color: Window }", "p { color: WindowText; background-color: Window }");


### PR DESCRIPTION
next is too generous with CSS selectors in nav-*. I doubt that this is exploitable but we should not allow more than the spec unless there is a good reason. Also, we don't sanitize/rebuild the selectors here (which we do in other cases), which might make any possible exploit easier.

To be clear, this should be considered for 1471 since it's a possible (but unlikely) security regression in next/pre-1471 relative to 1470.