### PR TITLE
CSS parser expression fixes

### DIFF
--- a/src/freenet/client/filter/CSSTokenizerFilter.java
+++ b/src/freenet/client/filter/CSSTokenizerFilter.java
@@ -3650,7 +3650,7 @@ class CSSTokenizerFilter {
 		public final boolean isAngle;      //an
 		public final boolean isColor;      //co
 		public final boolean isURI;        //ur
-		public final boolean isSelector;   //se
+		public final boolean isIDSelector;   //se
 		public final boolean isShape;      //sh
 		public final boolean isString;     //st
 		public final boolean isCounter;    //co
@@ -3707,10 +3707,10 @@ class CSSTokenizerFilter {
 			this.allowCommaDelimiters = allowCommaDelimiters;
 
 			boolean isInteger, isReal, isPercentage, isLength, isAngle, isColor,
-				isSelector, isURI, isShape, isString, isCounter, isIdentifier,
+				isIDSelector, isURI, isShape, isString, isCounter, isIdentifier,
 				isTime, isFrequency, isTransform;
 			isInteger = isReal = isPercentage = isLength = isAngle = isColor = isURI
-				= isShape = isString = isCounter = isIdentifier = isTime = isSelector
+				= isShape = isString = isCounter = isIdentifier = isTime = isIDSelector
 				= isFrequency = isTransform = false;
 			if(possibleValues != null) {
 				for(String possibleValue : possibleValues) {
@@ -3729,7 +3729,7 @@ class CSSTokenizerFilter {
 					else if("ur".equals(possibleValue))
 						isURI=true;	//ur
 					else if ("se".equals(possibleValue)) {
-						isSelector = true; //se
+						isIDSelector = true; //se
 					}
 					else if("sh".equals(possibleValue))
 						isShape=true;	//sh
@@ -3754,7 +3754,7 @@ class CSSTokenizerFilter {
 			this.isAngle = isAngle;
 			this.isColor = isColor;
 			this.isURI = isURI;
-			this.isSelector = isSelector;
+			this.isIDSelector = isIDSelector;
 			this.isShape = isShape;
 			this.isString = isString;
 			this.isCounter = isCounter;
@@ -3967,7 +3967,7 @@ class CSSTokenizerFilter {
 				return true;
 			}
 			
-			if (isSelector) {
+			if (isIDSelector) {
 				String result = HTMLelementVerifier(words[0].original);
 				if (!(result == null || result.equals(""))) {
 					return true;

--- a/src/freenet/client/filter/CSSTokenizerFilter.java
+++ b/src/freenet/client/filter/CSSTokenizerFilter.java
@@ -4001,12 +4001,14 @@ class CSSTokenizerFilter {
 
 			/*
 			 * Parser expressions
+			 * Original syntax: http://www.w3.org/TR/CSS2/about.html#value-defs
+			 * We encode it a bit differently...
 			 * 1 || 2 => 1a2
 			 * [1][2] =>1 2
+			 * 1 && 2 => 1b2
 			 * 1<1,4> => 1<1,4>
 			 * 1* => 1<0,65536>
 			 * 1? => 1o
-			 *
 			 */
 			/*
 			 * For each parserExpression, recursiveParserExpressionVerifier() would be called with parserExpression and value.

--- a/src/freenet/client/filter/CSSTokenizerFilter.java
+++ b/src/freenet/client/filter/CSSTokenizerFilter.java
@@ -924,7 +924,7 @@ class CSSTokenizerFilter {
 			//  ] ]
 			auxilaryVerifiers[25]=new CSSPropertyVerifier(null,Arrays.asList("ur"),null,null,true);
 			auxilaryVerifiers[141] = new CSSPropertyVerifier(null, Arrays.asList("in", "re"), null, null, true);
-			auxilaryVerifiers[142] = new CSSPropertyVerifier(null, null, null, Arrays.asList("25 141<0,1> 141<0,1>"), true, true);
+			auxilaryVerifiers[142] = new CSSPropertyVerifier(null, null, null, Arrays.asList("25 141 141", "25"), true, true);
 			auxilaryVerifiers[26] = new CSSPropertyVerifier(
 			Arrays.asList("auto", "default", "none",
 					"context-menu", "help", "pointer", "progress", "wait",

--- a/src/freenet/client/filter/CSSTokenizerFilter.java
+++ b/src/freenet/client/filter/CSSTokenizerFilter.java
@@ -4009,6 +4009,11 @@ class CSSTokenizerFilter {
 			 * 1<1,4> => 1<1,4>
 			 * 1* => 1<0,65536>
 			 * 1? => 1o
+			 * 
+			 * Note that we do not (correctly) implement operator precedence. Brackets must be
+			 * implemented using auxiliary expression verifiers. && may only join numbered 
+			 * expressions, but || and space may join anything. There is no support for the single
+			 * bar, again we use multiple alternative numbered patterns for this.
 			 */
 			/*
 			 * For each parserExpression, recursiveParserExpressionVerifier() would be called with parserExpression and value.

--- a/src/freenet/client/filter/CSSTokenizerFilter.java
+++ b/src/freenet/client/filter/CSSTokenizerFilter.java
@@ -3976,6 +3976,13 @@ class CSSTokenizerFilter {
 			}
 			
 			if (isIDSelector) {
+			    // In accordance with spec for e.g. nav-*, we only allow ID selectors.
+			    // See http://www.w3.org/TR/css3-ui/
+			    // REDFLAG If we allow more general selectors (which some browsers may accept) we 
+			    // have two new problems:
+			    // 1) They may occupy more than one word, which greatly complicates parsing here,
+			    // 2) We should sanitize the selectors, not just pass them on. Which in turn may 
+			    // cause them to take up more than one word!
 				String result = HTMLelementVerifier(words[0].original, true);
 				if (!(result == null || result.equals(""))) {
 					return true;

--- a/src/freenet/client/filter/CSSTokenizerFilter.java
+++ b/src/freenet/client/filter/CSSTokenizerFilter.java
@@ -4008,7 +4008,7 @@ class CSSTokenizerFilter {
 			 * 1 && 2 => 1b2
 			 * 1<1,4> => 1<1,4>
 			 * 1* => 1<0,65536>
-			 * 1? => 1o
+			 * 1? => 1?
 			 * 
 			 * Note that we do not (correctly) implement operator precedence. Brackets must be
 			 * implemented using auxiliary expression verifiers. && may only join numbered 
@@ -4031,7 +4031,7 @@ class CSSTokenizerFilter {
 		 * [1][2] => 1 2
 		 * 1<1,4> => 1<1,4>
 		 * 1* => 1<0,65536>
-		 * 1? => 1o
+		 * 1? => 1?
 		 * 1+ => 1<1,65536>
 		 * 1&&2 => 1b2   (see doubleAmpersandVerifier())
 		 * Additional expressions that can be passed to the function

--- a/src/freenet/client/filter/CSSTokenizerFilter.java
+++ b/src/freenet/client/filter/CSSTokenizerFilter.java
@@ -4108,8 +4108,10 @@ class CSSTokenizerFilter {
 				} else if (expression.charAt(i) == 'b') {
 					// detecting b which is the && operator
 					int endIndex = expression.length();
+                    // Find the end of a chain of 1b2b3...
 					for (int j = 0; j < expression.length(); j++) {
-						if (expression.charAt(j)=='?' || expression.charAt(j)=='<' || expression.charAt(j)=='>' || expression.charAt(j)==' ') {
+					    char c = expression.charAt(j);
+					    if(!(c == 'b' || '0' <= c && '9' >= c)) {
 							endIndex=j;
 							break;
 						}

--- a/src/freenet/client/filter/CSSTokenizerFilter.java
+++ b/src/freenet/client/filter/CSSTokenizerFilter.java
@@ -4011,9 +4011,9 @@ class CSSTokenizerFilter {
 			 * 1? => 1?
 			 * 
 			 * Note that we do not (correctly) implement operator precedence. Brackets must be
-			 * implemented using auxiliary expression verifiers. && may only join numbered 
-			 * expressions, but || and space may join anything. There is no support for the single
-			 * bar, again we use multiple alternative numbered patterns for this.
+			 * implemented using auxiliary expression verifiers. && and || may only join numbered 
+			 * expressions. There is no support for the single bar, again we use multiple 
+			 * alternative numbered patterns for this.
 			 */
 			/*
 			 * For each parserExpression, recursiveParserExpressionVerifier() would be called with parserExpression and value.
@@ -4075,14 +4075,13 @@ class CSSTokenizerFilter {
 					//Detecting the other end
 					for(int j=0;j<expression.length();j++)
 					{
-						if(expression.charAt(j)=='?' || expression.charAt(j)=='<' || expression.charAt(j)=='>' || expression.charAt(j)==' ')
-						{
+					    char c = expression.charAt(j);
+					    if(c == 'a') {
+                            noOfa++;
+					    } else if(!('0' <= c && '9' >= c)) {
 							endIndex=j;
 							break;
 						}
-						else if(expression.charAt(j)=='a')
-							noOfa++;
-
 					}
 					String firstPart=expression.substring(0,endIndex);
 					String secondPart="";

--- a/src/freenet/client/filter/CSSTokenizerFilter.java
+++ b/src/freenet/client/filter/CSSTokenizerFilter.java
@@ -4215,6 +4215,7 @@ class CSSTokenizerFilter {
 		}
 		/**
 		 * Takes b expressions and evaluates them.<br/>
+		 * "&&" means all of the expressions must occur in any order.<br/>
 		 * CSS Grammar <code>list-item && [ block | nonsense ] && [ more ]?</code><br/>
 		 * Will accept the following inputs as valid:<br/>
 		 * <code>list-item block</code><br/>
@@ -4224,12 +4225,9 @@ class CSSTokenizerFilter {
 		 * @param expression the expression, explained above
 		 * @param words tokens to parse
 		 * @param cb
-		 * @return true if all the words were consumed false otherwise.
+		 * @return true if all the verifiers and all the words were consumed, false otherwise.
 		 */
 		public boolean doubleAmpersandVerifier(String expression, ParsedWord[] words, FilterCallback cb) {
-			if(words==null || words.length == 0)
-				return true;
-
 			String ignoredParts="";
 			String firstPart = "";
 			int lastB = -1;

--- a/test/freenet/client/filter/CSSParserTest.java
+++ b/test/freenet/client/filter/CSSParserTest.java
@@ -876,7 +876,7 @@ public class CSSParserTest extends TestCase {
 		propertyTests.put("body { nav-down: auto; }",  "body { nav-down: auto; }");
 		propertyTests.put("body { nav-down: h2#java current; }",  "body { nav-down: h2#java current; }");
 		propertyTests.put("body { nav-up: #java root; }",  "body { nav-up: #java root; }");
-		propertyTests.put("body { nav-left: div.bold '<target-name>'; }",  "body { nav-left: div.bold '<target-name>'; }");
+		propertyTests.put("body { nav-left: div.bold '<target-name>'; }",  "body { }");
 		propertyTests.put("button#foo { nav-left: #bar \"sidebar\"; }", "button#foo { nav-left: #bar \"sidebar\"; }");
 		propertyTests.put("button#foo { nav-left: invalidSelector \"sidebar\"; }", "button#foo { }");
 	}

--- a/test/freenet/client/filter/CSSParserTest.java
+++ b/test/freenet/client/filter/CSSParserTest.java
@@ -783,6 +783,7 @@ public class CSSParserTest extends TestCase {
 		propertyTests.put(":link,:visited { cursor: url(example.svg#linkcursor) url(hyper.cur) pointer }", ":link { cursor: url(\"example.svg#linkcursor\") url(\"hyper.cur\") pointer }");
 		propertyTests.put(":link,:visited { cursor: url(example.svg#linkcursor), url(hyper.cur), pointer }", ":link { cursor: url(\"example.svg#linkcursor\"), url(\"hyper.cur\"), pointer }");
 		propertyTests.put(":link,:visited { cursor: url(example.svg#linkcursor) 2 5, url(hyper.cur), pointer }", ":link { cursor: url(\"example.svg#linkcursor\") 2 5, url(\"hyper.cur\"), pointer }");
+        propertyTests.put(":link,:visited { cursor: url(example.svg#linkcursor) 2, url(hyper.cur), pointer }", ":link { }");
 
 		// UI colors
 		propertyTests.put("p { color: WindowText; background-color: Window }", "p { color: WindowText; background-color: Window }");


### PR DESCRIPTION
This goes a bit further than #445. It documents the syntax and limitations and also fixes some potentially confusing bugs in future parsing rules. It is not urgent. CSS tests pass.