### PR TITLE
Fix leaking a message when rejecting because not routable

### DIFF
--- a/src/freenet/node/NodeDispatcher.java
+++ b/src/freenet/node/NodeDispatcher.java
@@ -241,7 +241,7 @@ public class NodeDispatcher implements Dispatcher, Runnable {
 			} else if(spec == DMT.FNPGetOfferedKey) {
 				rejectRequest(m, node.failureTable.senderCounter);
 			}
-			return false;
+			return true;
 		}
 
 		if(spec == DMT.FNPSwapRequest) {


### PR DESCRIPTION
We send a rejection, so clearly we do claim the message. We don't want it to be reconsidered later. The message is "leaked" into the unmatched messages buffer, thus wasting both memory and CPU (but it will eventually be dropped due to limits). Low priority but trivial fix.