### PR TITLE
FNP fixes post 440

### DIFF
--- a/src/freenet/node/FNPPacketMangler.java
+++ b/src/freenet/node/FNPPacketMangler.java
@@ -1713,7 +1713,7 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
 		 * It is assumed to be non-message recovering
 		 */
 		// save parameters so that we can verify message4
-		byte[] toSign = assembleDHParams(nonceInitiatorHashed, nonceResponder, ourExponential, hisExponential, pn.getIdentity(negType), data);
+		byte[] toSign = assembleDHParams(nonceInitiatorHashed, nonceResponder, ourExponential, hisExponential, pn.getPubKeyHash(), data);
 		pn.setJFKBuffer(toSign);
 		byte[] sig = crypto.ecdsaSign(toSign);
 
@@ -1874,7 +1874,7 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
 		ptr += myRef.length;
 		System.arraycopy(hisRef, 0, data, ptr, hisRef.length);
 
-		byte[] params = assembleDHParams(nonceInitiatorHashed, nonceResponder, initiatorExponential, responderExponential, pn.getIdentity(negType), data);
+		byte[] params = assembleDHParams(nonceInitiatorHashed, nonceResponder, initiatorExponential, responderExponential, pn.getPubKeyHash(), data);
 		if(logMINOR)
 			Logger.minor(this, "Message length "+params.length+" myRef: "+myRef.length+" hash "+Fields.hashCode(myRef)+" hisRef: "+hisRef.length+" hash "+Fields.hashCode(hisRef)+" boot ID "+node.bootID);
 		byte[] sig = crypto.ecdsaSign(params);

--- a/src/freenet/node/PeerManager.java
+++ b/src/freenet/node/PeerManager.java
@@ -2012,7 +2012,7 @@ public class PeerManager {
 		PeerNode[] peers = pn.isOpennet() ? getOpennetAndSeedServerPeers() : getDarknetPeers();
 
 		for(PeerNode peer: peers)
-			if(Arrays.equals(pn.getIdentity(), peer.getIdentity()))
+			if(Arrays.equals(pn.getPubKeyHash(), peer.getPubKeyHash()))
 				return peer;
 
 		return null;

--- a/src/freenet/node/PeerManager.java
+++ b/src/freenet/node/PeerManager.java
@@ -1906,6 +1906,9 @@ public class PeerManager {
 		return v.toArray(new DarknetPeerNode[v.size()]);
 	}
 
+	/** Get the currently connected seednodes.
+	 * @param exclude Set of peer public keys to exclude.
+	 */
 	public List<SeedServerPeerNode> getConnectedSeedServerPeersVector(HashSet<ByteArrayWrapper> exclude) {
 		PeerNode[] peers = myPeers();
 		// FIXME optimise! Maybe maintain as a separate list?
@@ -1913,7 +1916,7 @@ public class PeerManager {
 		for(PeerNode p : peers) {
 			if(p instanceof SeedServerPeerNode) {
 				SeedServerPeerNode sspn = (SeedServerPeerNode) p;
-				if(exclude != null && exclude.contains(new ByteArrayWrapper(sspn.getIdentity()))) {
+				if(exclude != null && exclude.contains(new ByteArrayWrapper(sspn.getPubKeyHash()))) {
 					if(logMINOR)
 						Logger.minor(this, "Not including in getConnectedSeedServerPeersVector() as in exclude set: " + sspn.userToString());
 					continue;

--- a/src/freenet/node/PeerNode.java
+++ b/src/freenet/node/PeerNode.java
@@ -5833,7 +5833,7 @@ public abstract class PeerNode implements USKRetrieverCallback, BasePeerNode, Pe
 	    return identity;
 	}
 	
-	protected final byte[] getIdentity(int negType) {
-	        return peerECDSAPubKeyHash;
+	protected final byte[] getPubKeyHash() {
+	    return peerECDSAPubKeyHash;
 	}
 }

--- a/src/freenet/node/PeerNode.java
+++ b/src/freenet/node/PeerNode.java
@@ -5829,10 +5829,6 @@ public abstract class PeerNode implements USKRetrieverCallback, BasePeerNode, Pe
         return !failed;
 	}
 	
-	protected byte[] getIdentity() {
-	    return identity;
-	}
-	
 	protected final byte[] getPubKeyHash() {
 	    return peerECDSAPubKeyHash;
 	}


### PR DESCRIPTION
Fixes a bug nextgens missed in #440 and cleans up slightly. 

**Please consider for 1471** because the bug affected announcement performance: Checking for peers we had already announced to failed because we were putting ECDSA pubkey hashes into the exclude set, but then comparing them against obfuscation keys (PeerNode.identity).