### PR TITLE
HMAC: replace our implementation by the JCA's

### DIFF
--- a/src/freenet/crypt/HMAC.java
+++ b/src/freenet/crypt/HMAC.java
@@ -3,152 +3,54 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.crypt;
 
-import java.io.UnsupportedEncodingException;
+import java.security.InvalidKeyException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
-import freenet.support.HexUtil;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
 
 /**
- * Implements the HMAC Keyed Message Authentication function, as described
- * in the draft FIPS standard.
+ * Implements the HMAC Keyed Message Authentication function, as described in the draft FIPS
+ * standard.
  */
-public class HMAC {
+public enum HMAC {
+  SHA2_256("HMac-SHA256", 32),
+  SHA3_256("HMac-KECCAK256", 32);
 
-	protected static final int B = 64;
-	protected static byte[] ipad = new byte[B];
-	protected static byte[] opad = new byte[B];
+  final String algo;
+  final int digestSize;
 
-	static {
-		for(int i = 0; i < B; i++) {
-			ipad[i] = (byte) 0x36;
-			opad[i] = (byte) 0x5c;
-		}
-	}
-	protected MessageDigest d;
+  HMAC(String name, int size) {
+    this.algo = name;
+    this.digestSize = size;
+  }
 
-	public HMAC(MessageDigest md) {
-		this.d = md;
-	}
-	
-	public boolean verify(byte[] K, byte[] text, byte[] mac) {
-		byte[] mac2 = mac(K, text, mac.length);
-		
-		// this is constant-time; DO NOT 'optimize'
-		return MessageDigest.isEqual(mac, mac2);
-	}
+  public static byte[] mac(HMAC hash, byte[] key, byte[] data) {
+    SecretKeySpec signingKey = new SecretKeySpec(key, hash.algo);
+    Mac mac = null;
+    try {
+      mac = Mac.getInstance(hash.algo);
+    } catch (NoSuchAlgorithmException e) {
+      e.printStackTrace();
+    }
+    try {
+      mac.init(signingKey);
+    } catch (InvalidKeyException e) {
+      e.printStackTrace();
+    }
+    return mac.doFinal(data);
+  }
 
-	public byte[] mac(byte[] K, byte[] text, int macbytes) {
-		byte[] K0 = null;
+  public static boolean verify(HMAC hash, byte[] key, byte[] data, byte[] mac) {
+    return MessageDigest.isEqual(mac, mac(hash, key, data));
+  }
 
-		if(K.length == B) // Step 1
-			K0 = K;
-		else {
-			// Step 2
-			if(K.length > B)
-				K0 = K = Util.hashBytes(d, K);
+  public static byte[] macWithSHA256(byte[] K, byte[] text) {
+    return mac(HMAC.SHA2_256, K, text);
+  }
 
-			if(K.length < B) { // Step 3
-				K0 = new byte[B];
-				System.arraycopy(K, 0, K0, 0, K.length);
-			}
-		}
-
-		// Step 4
-		byte[] IS1 = Util.xor(K0, ipad);
-
-		// Step 5/6
-		d.update(IS1);
-		d.update(text);
-		IS1 = d.digest();
-
-		// Step 7
-		byte[] IS2 = Util.xor(K0, opad);
-
-		// Step 8/9
-		d.update(IS2);
-		d.update(IS1);
-		IS1 = d.digest();
-
-		// Step 10
-		if(macbytes == IS1.length)
-			return IS1;
-		else {
-			byte[] rv = new byte[macbytes];
-			System.arraycopy(IS1, 0, rv, 0, Math.min(rv.length, IS1.length));
-			return rv;
-		}
-	}
-
-	public static void main(String[] args) throws UnsupportedEncodingException {
-		HMAC s = null;
-		try {
-			s = new HMAC(MessageDigest.getInstance("SHA1"));
-		} catch(NoSuchAlgorithmException e) {
-			throw new RuntimeException(e);
-		}
-		byte[] key = new byte[20];
-		System.err.println("20x0b, 'Hi There':");
-		byte[] text;
-		text = "Hi There".getBytes("UTF-8");
-
-		for(int i = 0; i < key.length; i++)
-			key[i] = (byte) 0x0b;
-
-		byte[] mv = s.mac(key, text, 20);
-		System.out.println(HexUtil.bytesToHex(mv, 0, mv.length));
-
-		System.err.println("20xaa, 50xdd:");
-		for(int i = 0; i < key.length; i++)
-			key[i] = (byte) 0xaa;
-		text = new byte[50];
-		for(int i = 0; i < text.length; i++)
-			text[i] = (byte) 0xdd;
-		mv = s.mac(key, text, 20);
-		System.out.println(HexUtil.bytesToHex(mv, 0, mv.length));
-
-		key = new byte[25];
-		System.err.println("25x[i+1], 50xcd:");
-		for(int i = 0; i < key.length; i++)
-			key[i] = (byte) (i + 1);
-		for(int i = 0; i < text.length; i++)
-			text[i] = (byte) 0xcd;
-		mv = s.mac(key, text, 20);
-		System.out.println(HexUtil.bytesToHex(mv, 0, mv.length));
-
-		key = new byte[20];
-		System.err.println("20x0c, 'Test With Truncation':");
-		for(int i = 0; i < key.length; i++)
-			key[i] = (byte) 0x0c;
-		text = "Test With Truncation".getBytes("UTF-8");
-		mv = s.mac(key, text, 20);
-		System.out.println(HexUtil.bytesToHex(mv, 0, mv.length));
-		mv = s.mac(key, text, 12);
-		System.out.println(HexUtil.bytesToHex(mv, 0, mv.length));
-
-	}
-
-	public static byte[] macWithSHA256(byte[] K, byte[] text, int macbytes) {
-		MessageDigest sha256 = null;
-		try {
-			sha256 = SHA256.getMessageDigest();
-			HMAC hash = new HMAC(sha256);
-			return hash.mac(K, text, macbytes);
-		} finally {
-			if(sha256 != null)
-				SHA256.returnMessageDigest(sha256);
-		}
-	}
-
-	public static boolean verifyWithSHA256(byte[] K, byte[] text, byte[] mac) {
-		MessageDigest sha256 = null;
-		try {
-			sha256 = SHA256.getMessageDigest();
-			HMAC hash = new HMAC(sha256);
-			return hash.verify(K, text, mac);
-		} finally {
-			if(sha256 != null)
-				SHA256.returnMessageDigest(sha256);
-		}
-	}
+  public static boolean verifyWithSHA256(byte[] K, byte[] text, byte[] mac) {
+    return verify(HMAC.SHA2_256, K, text, mac);
+  }
 }	

--- a/src/freenet/node/DatabaseKey.java
+++ b/src/freenet/node/DatabaseKey.java
@@ -1,11 +1,11 @@
 package freenet.node;
 
-import java.io.UnsupportedEncodingException;
-import java.util.Random;
+import com.db4o.io.IoAdapter;
 
 import org.bouncycastle.util.Arrays;
 
-import com.db4o.io.IoAdapter;
+import java.io.UnsupportedEncodingException;
+import java.util.Random;
 
 import freenet.crypt.AEADCryptBucket;
 import freenet.crypt.EncryptingIoAdapter;
@@ -52,7 +52,7 @@ public class DatabaseKey {
             System.arraycopy(PLUGIN, 0, full, x, PLUGIN.length);
             x += PLUGIN.length;
             System.arraycopy(id, 0, full, x, id.length);
-            return HMAC.macWithSHA256(databaseKey, full, 32);
+            return HMAC.macWithSHA256(databaseKey, full);
         } catch (UnsupportedEncodingException e) {
             throw new Error(e);
         }
@@ -68,7 +68,7 @@ public class DatabaseKey {
         System.arraycopy(databaseKey, 0, full, 0, databaseKey.length);
         x += databaseKey.length;
         System.arraycopy(CLIENT_LAYER, 0, full, x, CLIENT_LAYER.length);
-        return HMAC.macWithSHA256(databaseKey, full, 32);
+        return HMAC.macWithSHA256(databaseKey, full);
     }
     
     private static final byte[] PLUGIN;

--- a/src/freenet/node/FNPPacketMangler.java
+++ b/src/freenet/node/FNPPacketMangler.java
@@ -948,7 +948,7 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
 		byte[] sig = ctx.ecdsaSig;
 	    if(sig.length != getSignatureLength(negType))
 	        throw new IllegalStateException("This shouldn't happen: please report! We are attempting to send "+sig.length+" bytes of signature in JFK2! "+pn.getPeer());
-	    byte[] authenticator = HMAC.macWithSHA256(getTransientKey(),assembleJFKAuthenticator(myExponential, hisExponential, myNonce, nonceInitator, replyTo.getAddress().getAddress()), HASH_LENGTH);
+	    byte[] authenticator = HMAC.macWithSHA256(getTransientKey(),assembleJFKAuthenticator(myExponential, hisExponential, myNonce, nonceInitator, replyTo.getAddress().getAddress()));
 		if(logDEBUG) Logger.debug(this, "We are using the following HMAC : " + HexUtil.bytesToHex(authenticator));
         if(logDEBUG) Logger.debug(this, "We have Ni' : " + HexUtil.bytesToHex(nonceInitator));
 		byte[] message2 = new byte[nonceInitator.length + nonceSize+modulusLength+
@@ -1777,7 +1777,7 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
 		pcfb.blockEncipher(cleartext, cleartextToEncypherOffset, cleartext.length-cleartextToEncypherOffset);
 
 		// We compute the HMAC of (prefix + cyphertext) Includes the IV!
-		byte[] hmac = HMAC.macWithSHA256(pn.jfkKa, cleartext, HASH_LENGTH);
+		byte[] hmac = HMAC.macWithSHA256(pn.jfkKa, cleartext);
 
 		// copy stuffs back to the message
 		System.arraycopy(hmac, 0, message3, offset, HASH_LENGTH);
@@ -1900,7 +1900,7 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
 		pk.blockEncipher(cyphertext, cleartextToEncypherOffset, cyphertext.length - cleartextToEncypherOffset);
 
 		// We compute the HMAC of (prefix + iv + signature)
-		byte[] hmac = HMAC.macWithSHA256(Ka, cyphertext, HASH_LENGTH);
+		byte[] hmac = HMAC.macWithSHA256(Ka, cyphertext);
 
 		// Message4 = hmac + IV + encryptedSignature
 		byte[] message4 = new byte[HASH_LENGTH + ivLength + (cyphertext.length - cleartextToEncypherOffset)];
@@ -2284,7 +2284,7 @@ public class FNPPacketMangler implements OutgoingPacketMangler {
 		offset += nR.length;
 		System.arraycopy(number, 0, toHash, offset, number.length);
 
-		return HMAC.macWithSHA256(exponential, toHash, HASH_LENGTH);
+		return HMAC.macWithSHA256(exponential, toHash);
 	}
 
 	private long timeLastReset = -1;

--- a/src/freenet/node/NewPacketFormat.java
+++ b/src/freenet/node/NewPacketFormat.java
@@ -3,8 +3,6 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.node;
 
-import static java.util.concurrent.TimeUnit.MINUTES;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -26,6 +24,8 @@ import freenet.support.LogThresholdCallback;
 import freenet.support.Logger;
 import freenet.support.Logger.LogLevel;
 import freenet.support.SparseBitmap;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
 
 public class NewPacketFormat implements PacketFormat {
 
@@ -507,7 +507,7 @@ public class NewPacketFormat implements PacketFormat {
 		byte[] text = new byte[paddedLen - hmacLength];
 		System.arraycopy(data, hmacLength, text, 0, text.length);
 
-		byte[] hash = HMAC.macWithSHA256(sessionKey.hmacKey, text, hmacLength);
+		byte[] hash = HMAC.macWithSHA256(sessionKey.hmacKey, text);
 
 		System.arraycopy(hash, 0, data, 0, hmacLength);
 

--- a/src/freenet/node/PeerNode.java
+++ b/src/freenet/node/PeerNode.java
@@ -1,11 +1,5 @@
 package freenet.node;
 
-import static java.util.concurrent.TimeUnit.DAYS;
-import static java.util.concurrent.TimeUnit.HOURS;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static java.util.concurrent.TimeUnit.MINUTES;
-import static java.util.concurrent.TimeUnit.SECONDS;
-
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -13,7 +7,6 @@ import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
 import java.io.Writer;
 import java.lang.ref.WeakReference;
-import java.math.BigInteger;
 import java.net.InetAddress;
 import java.net.MalformedURLException;
 import java.net.UnknownHostException;
@@ -88,6 +81,12 @@ import freenet.support.math.SimpleRunningAverage;
 import freenet.support.math.TimeDecayingRunningAverage;
 import freenet.support.transport.ip.HostnameSyntaxException;
 import freenet.support.transport.ip.IPUtil;
+
+import static java.util.concurrent.TimeUnit.DAYS;
+import static java.util.concurrent.TimeUnit.HOURS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
  * @author amphibian
@@ -3751,7 +3750,7 @@ public abstract class PeerNode implements USKRetrieverCallback, BasePeerNode, Pe
 	public void offer(Key key) {
 		byte[] keyBytes = key.getFullKey();
 		// FIXME maybe the authenticator should be shorter than 32 bytes to save memory?
-		byte[] authenticator = HMAC.macWithSHA256(node.failureTable.offerAuthenticatorKey, keyBytes, 32);
+		byte[] authenticator = HMAC.macWithSHA256(node.failureTable.offerAuthenticatorKey, keyBytes);
 		Message msg = DMT.createFNPOfferKey(key, authenticator);
 		try {
 			sendAsync(msg, null, node.nodeStats.sendOffersCtr);


### PR DESCRIPTION
It turns out that we're never truncating the output anyways...so we can simplify the API

This hasn't been tested! I can't seem to bootstrap an opennet node with it atm