### PR TITLE
test: fix resource path on Java 6

### DIFF
--- a/test/freenet/l10n/BaseL10nTest.java
+++ b/test/freenet/l10n/BaseL10nTest.java
@@ -215,9 +215,9 @@ public class BaseL10nTest extends TestCase {
     
     private BaseL10n createTestL10n(LANGUAGE lang) {
         String testL10nPath = new File(TEST_PATH, L10N_PATH).getPath();
-        URL classLoaderUrl = getClass().getClassLoader().getResource(".");
+        URL classLoaderUrl = getClass().getResource(".");
         File classLoaderDir = new File(classLoaderUrl.getPath());
-        File overrideFile = new File(new File(classLoaderDir, testL10nPath),
+        File overrideFile = new File(new File(classLoaderDir, "/../../../" + testL10nPath),
                 "freenet.l10n.${lang}.override.properties");
         return new BaseL10n(testL10nPath, "freenet.l10n.${lang}.properties",
                 overrideFile.getPath(), lang);


### PR DESCRIPTION
On Java 6 the classloader path may return multiple colon-delimited paths, which makes using the classloader path not work as intended. Using the class path requires more backing out of the build directory.

In my testing this allows the tests from #421 to pass under Java 6, but I really hope there's a more idiomatic / less fragile way to do this.