### PR TITLE
Revocation checker reduction

### DIFF
--- a/src/freenet/node/updater/NodeUpdateManager.java
+++ b/src/freenet/node/updater/NodeUpdateManager.java
@@ -509,6 +509,7 @@ public class NodeUpdateManager {
 
 		node.clientCore.alerts.register(alert);
 		
+		revocationChecker.checkForBlobOnDisk();
 		enable(wasEnabledOnStartup);
 
 		// Fetch 3 files, each to a file in the runDir.

--- a/src/freenet/node/updater/NodeUpdateManager.java
+++ b/src/freenet/node/updater/NodeUpdateManager.java
@@ -682,13 +682,6 @@ public class NodeUpdateManager {
 		// }
 		NodeUpdater main = null;
 		Map<String, PluginJarUpdater> oldPluginUpdaters = null;
-		// We need to run the revocation checker even if auto-update is
-		// disabled.
-		// Two reasons:
-		// 1. For the benefit of other nodes, and because even if auto-update is
-		// off, it's something the user should probably know about.
-		// 2. When the key is blown, we turn off auto-update!!!!
-		revocationChecker.start(false);
 		synchronized (this) {
 			boolean enabled = (mainUpdater != null);
 			if (enabled == enable)
@@ -722,7 +715,10 @@ public class NodeUpdateManager {
 			stopPluginUpdaters(oldPluginUpdaters);
 			transitionMainJarFetcher.stop();
 			transitionExtJarFetcher.stop();
+			revocationChecker.kill();
 		} else {
+		    revocationChecker.start(false);
+
 			// FIXME copy it, dodgy locking.
 			try {
 				// Must be run before starting everything else as it cleans up tempfiles too.

--- a/src/freenet/node/updater/RevocationChecker.java
+++ b/src/freenet/node/updater/RevocationChecker.java
@@ -85,7 +85,6 @@ public class RevocationChecker implements ClientGetCallback, RequestClient {
 
 	public void start(boolean aggressive) {
 		start(aggressive, true);
-		checkForBlobOnDisk();
 	}
 	
 	public void checkForBlobOnDisk() {

--- a/src/freenet/node/updater/RevocationChecker.java
+++ b/src/freenet/node/updater/RevocationChecker.java
@@ -85,6 +85,10 @@ public class RevocationChecker implements ClientGetCallback, RequestClient {
 
 	public void start(boolean aggressive) {
 		start(aggressive, true);
+		checkForBlobOnDisk();
+	}
+	
+	public void checkForBlobOnDisk() {
 		if(blobFile.exists()) {
 			ArrayBucket bucket = new ArrayBucket();
 			try {

--- a/src/freenet/node/updater/RevocationChecker.java
+++ b/src/freenet/node/updater/RevocationChecker.java
@@ -93,7 +93,7 @@ public class RevocationChecker implements ClientGetCallback, RequestClient {
 			try {
 				BucketTools.copy(new FileBucket(blobFile, true, false, false, true), bucket);
 				// Allow to free if bogus.
-				manager.uom.processRevocationBlob(bucket, "disk", true);
+				manager.uom.processRevocationBlob(bucket, "disk", true, true);
 			} catch (IOException e) {
 				Logger.error(this, "Failed to read old revocation blob: "+e, e);
 				System.err.println("We may have downloaded an old revocation blob before restarting but it cannot be read: "+e);

--- a/src/freenet/node/updater/UpdateOverMandatoryManager.java
+++ b/src/freenet/node/updater/UpdateOverMandatoryManager.java
@@ -64,6 +64,7 @@ import freenet.support.Logger;
 import freenet.support.ShortBuffer;
 import freenet.support.SizeUtil;
 import freenet.support.TimeUtil;
+import freenet.support.Waiter;
 import freenet.support.WeakHashSet;
 import freenet.support.api.Bucket;
 import freenet.support.api.RandomAccessBucket;
@@ -973,14 +974,16 @@ public class UpdateOverMandatoryManager implements RequestClient {
 	}
 
 	void processRevocationBlob(final File temp, PeerNode source) {
-		processRevocationBlob(new FileBucket(temp, true, false, false, true), source.userToString(), false);
+		processRevocationBlob(new FileBucket(temp, true, false, false, true), 
+		        source.userToString(), false, false);
 	}
 	
 	/**
 	 * Process a binary blob for a revocation certificate (the revocation key).
 	 * @param temp The file it was written to.
 	 */
-	void processRevocationBlob(final Bucket temp, final String source, final boolean fromDisk) {
+	void processRevocationBlob(final Bucket temp, final String source, final boolean fromDisk, 
+	        boolean synchronous) {
 
 		SimpleBlockSet blocks = new SimpleBlockSet();
 
@@ -1035,11 +1038,14 @@ public class UpdateOverMandatoryManager implements RequestClient {
 		tempContext.localRequestOnly = true;
 
 		final ArrayBucket cleanedBlob = new ArrayBucket();
+		
+		final Waiter w = new Waiter();
 
 		ClientGetCallback myCallback = new ClientGetCallback() {
 
 			@Override
 			public void onFailure(FetchException e, ClientGetter state) {
+			    try {
 				if(e.mode == FetchExceptionMode.CANCELLED) {
 					// Eh?
 					Logger.error(this, "Cancelled fetch from store/blob of revocation certificate from " + source);
@@ -1069,15 +1075,22 @@ public class UpdateOverMandatoryManager implements RequestClient {
 					temp.free();
 					cleanedBlob.free();
 				}
+			    } finally {
+			        w.complete();
+			    }
 			}
 
 			@Override
 			public void onSuccess(FetchResult result, ClientGetter state) {
+			    try {
 				System.err.println("Got revocation certificate from " + source);
 				updateManager.revocationChecker.onSuccess(result, state, cleanedBlob);
 				if(!fromDisk)
 					temp.free();
 				insertBlob(updateManager.revocationChecker.getBlobBucket(), "revocation", RequestStarter.INTERACTIVE_PRIORITY_CLASS);
+			    } finally {
+			        w.complete();
+			    }
 			}
 			
             @Override
@@ -1096,13 +1109,16 @@ public class UpdateOverMandatoryManager implements RequestClient {
 
 		try {
 			updateManager.node.clientCore.clientContext.start(cg);
+			if(synchronous) w.waitForCompletion();
 		} catch(FetchException e1) {
 			System.err.println("Failed to decode UOM blob: " + e1);
 			e1.printStackTrace();
 			myCallback.onFailure(e1, cg);
 		} catch (PersistenceDisabledException e) {
 			// Impossible
-		}
+		} catch (InterruptedException e) {
+		    // Shutting down?
+        }
 
 	}
 

--- a/src/freenet/support/Waiter.java
+++ b/src/freenet/support/Waiter.java
@@ -1,0 +1,23 @@
+package freenet.support;
+
+/** Waits for some other thread to signal to proceed. */
+public class Waiter {
+    
+    private boolean completed;
+    
+    public Waiter() {
+        completed = false;
+    }
+
+    public synchronized void complete() {
+        completed = true;
+        notifyAll();
+    }
+
+    public synchronized void waitForCompletion() throws InterruptedException {
+        while(!completed) {
+            wait();
+        }
+    }
+    
+}


### PR DESCRIPTION
I need this for my simulations: Don't request the revocation key if auto-update is turned off.

Low priority, careful testing needed. In particular, it's essential that after the revocation certificate is found, we still show the useralert even after restarting.

This is really a partial solution. The full solution is to only do any of the checks, including the blob file, if auto-update is enabled. But in that case, we need blowing the revocation key to *not turn off auto-update* (for purposes of configuration). In which case, we need to change isEnabled()... That would need more careful testing, although the code changes should be small.