### PR TITLE
Travis CI: Enable extensive unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ cache:
 before_install:
   - mkdir -p lib/freenet/ && cd lib/ && if [ ! -e bcprov-jdk15on-154.jar ]; then wget -c https://bouncycastle.org/download/bcprov-jdk15on-154.jar; fi ; cd ..
 
-script: ant -Dlib.contrib.get=true
+script: ant -Dlib.contrib.get=true -Dtest.extensive=true
 
 jdk:
   - oraclejdk8

--- a/test/freenet/support/TestProperty.java
+++ b/test/freenet/support/TestProperty.java
@@ -3,6 +3,8 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.support;
 
+import org.junit.Test;
+
 /**
 ** Unified class for getting java properties to control unit test behaviour.
 **
@@ -10,10 +12,17 @@ package freenet.support;
 */
 final public class TestProperty {
 
-	private TestProperty() { }
+	public TestProperty() { }
 
 	final public static boolean BENCHMARK = Boolean.getBoolean("test.benchmark");
 	final public static boolean VERBOSE = Boolean.getBoolean("test.verbose");
 	final public static boolean EXTENSIVE = Boolean.getBoolean("test.extensive");
 
+	/** Useful to check whether things such as Travis CI properly pass properties */
+	@Test
+	public void printProperties() {
+		System.out.println("test.benchmark=" + BENCHMARK);
+		System.out.println("test.verbose=" + VERBOSE);
+		System.out.println("test.extensive=" + EXTENSIVE);
+	}
 }


### PR DESCRIPTION
As Travis is a dedicated server for running tests, it is just the right place for running tests which take longer, so let's enable them.

NOTICE: You check whether this works by searching the stdout on Travis for "test.extensive".
Please do not only check the Ant command line, but also the actual output of the tests: They will print the content of the environment variables they have received, as implemented by commit https://github.com/xor-freenet/fred-staging/commit/1a5731c39d5b6e08c2a525d1b176ae90cd8952f0