### PR TITLE
build: make Bouncy Castle path configurable

### DIFF
--- a/build-clean.xml
+++ b/build-clean.xml
@@ -26,6 +26,7 @@ maintainers may prefer to use this instead of build.xml.
 	<path id="lib.path">
 		<fileset dir="${lib.contrib.dir}" includes="${lib.contrib.jars}"/>
 		<fileset dir="${lib.dir}" includes="${lib.jars}"/>
+		<fileset dir="${bcprov.dir}" includes="${bc.jar}"/>
 		<fileset dir="/usr/share/java" includes="${lib.jars}" erroronmissingdir="false"/>
 	</path>
 	<path id="libtest.path">

--- a/build.properties
+++ b/build.properties
@@ -28,6 +28,8 @@ doc.api=javadoc
 # dir for common library jars
 lib.dir = lib
 
+bcprov.dir = ${lib.dir}
+
 # dir for freenet library jars (aka freenet-ext or "contrib" jars)
 lib.contrib.dir = lib/freenet
 ## if you use the git submodule in ./contrib (legacy-27 branch)


### PR DESCRIPTION
Debian Jessie (current stable) packages Bouncy Castle 1.49, but Freenet
requires later versions. The Debian build is configured to search
/usr/share/java for its libraries, but a usable version cannot
practically be there because it is not packaged. Therefore the build
must be able to search another directory.

I'm submitting this because I'm trying to get some work done on the Debian package, and this change is 1) already done 2) easier than finishing the move to Gradle.