### PR TITLE
Implement test for packet encryption

### DIFF
--- a/test/freenet/node/NullBasePeerNode.java
+++ b/test/freenet/node/NullBasePeerNode.java
@@ -1,6 +1,7 @@
 package freenet.node;
 
 import java.lang.ref.WeakReference;
+import java.util.ArrayList;
 import java.util.Random;
 
 import freenet.io.comm.AsyncMessageCallback;
@@ -113,7 +114,8 @@ public class NullBasePeerNode implements BasePeerNode {
 
 	@Override
 	public void verified(SessionKey s) {
-		throw new UnsupportedOperationException();
+	    if(decryptedMessages == null)
+	        throw new UnsupportedOperationException(); // Not expecting messages.
 	}
 
 	@Override
@@ -135,10 +137,16 @@ public class NullBasePeerNode implements BasePeerNode {
 	public void reportOutgoingBytes(int length) {
 		// Ignore
 	}
+	
+	protected ArrayList<byte[]> decryptedMessages;
 
 	protected void processDecryptedMessage(byte[] data, int offset, int length,
 			int overhead) {
-		throw new UnsupportedOperationException();
+	    if(decryptedMessages == null)
+	        throw new UnsupportedOperationException();
+	    else {
+	        decryptedMessages.add(java.util.Arrays.copyOfRange(data, offset, offset+length));
+	    }
 	}
 
 	@Override
@@ -161,9 +169,11 @@ public class NullBasePeerNode implements BasePeerNode {
 		return 1280;
 	}
 
+    public PeerMessageQueue messageQueue;
+	
 	@Override
 	public PeerMessageQueue getMessageQueue() {
-		return null;
+		return messageQueue;
 	}
 
 	@Override
@@ -171,9 +181,11 @@ public class NullBasePeerNode implements BasePeerNode {
 		return false;
 	}
 
+	byte[] sentEncryptedPacket;
+	
 	@Override
 	public void sendEncryptedPacket(byte[] data) throws LocalAddressException {
-		// Do nothing
+	    sentEncryptedPacket = data;
 	}
 
 	@Override


### PR DESCRIPTION
This fails on next. It passes with fix-hash-regression. It is no more ugly and timing-sensitive than any other test in the same file, and works for me. Also note that it is single-threaded; while there are sleep()'s, it should at least be close to deterministic.