### PR TITLE
SSK inserts: commit before reply and collisions

### DIFF
--- a/src/freenet/node/SSKInsertHandler.java
+++ b/src/freenet/node/SSKInsertHandler.java
@@ -70,6 +70,7 @@ public class SSKInsertHandler implements PrioRunnable, ByteCounter {
         this.preferInsert = preferInsert;
         this.ignoreLowBackoff = ignoreLowBackoff;
         this.realTimeFlag = realTimeFlag;
+        if(data != null && headers != null) collided = true;
     }
     
     @Override
@@ -204,6 +205,7 @@ public class SSKInsertHandler implements PrioRunnable, ByteCounter {
             block = storedBlock;
             data = block.getRawData();
             headers = block.getRawHeaders();
+            collided = true;
 		    sendCollision();
 		}
 		

--- a/src/freenet/store/KeyCollisionException.java
+++ b/src/freenet/store/KeyCollisionException.java
@@ -6,6 +6,12 @@ package freenet.store;
 import freenet.support.LightweightException;
 import freenet.support.Logger;
 
+/** Unfortunately this can't carry the actual colliding block because 
+ * FreenetStore.put() may not be able to reconstruct it (because it may need to fetch
+ * the public key from elsewhere). FIXME When we remove the pubkey store, add a 
+ * StorableBlock here.
+ * @author toad
+ */
 public class KeyCollisionException extends LightweightException {
 	private static final long serialVersionUID = -1;
     private static volatile boolean logDEBUG;


### PR DESCRIPTION
For review and careful testing. Two changes:
1) Always commit before sending InsertReply, just like we do in CHKInsertHandler (this is IMHO needed for consistency but it's also relevant to bug #3338, see the big comment).
2) Fix collisions not working correctly in some corner cases / race conditions.