### PR TITLE
Fix race condition in MultiMessageCallback

### DIFF
--- a/src/freenet/node/MultiMessageCallback.java
+++ b/src/freenet/node/MultiMessageCallback.java
@@ -6,7 +6,21 @@ import freenet.io.comm.AsyncMessageCallback;
  * You should add messages with make() and then call arm(). sent(boolean)
  * will be called when all the messages have been sent (or failed e.g. 
  * disconnected) and finish(boolean) will be called when all the messages 
- * have been acknowledged (or failed). */
+ * have been acknowledged (or failed). Typical usage:
+ * <pre>Message m1 = ...;
+ * Message m2 = ...;
+ * PeerNode pn = ...;
+ * MultiMessageCallback mcb = new MultiMessageCallback() {
+ *   protected void finish(boolean success) {
+ *     // Messages have finished.
+ *   }
+ *   protected void sent(boolean success) {
+ *     // Messages have been sent.
+ *   }
+ * }
+ * pn.sendAsync(m1, mcb, ctr);
+ * pn.sendAsync(m2, mcb, ctr);
+ * mcb.arm();</pre> */
 public abstract class MultiMessageCallback {
 	
     /** Number of messages that have not yet completed */

--- a/src/freenet/node/MultiMessageCallback.java
+++ b/src/freenet/node/MultiMessageCallback.java
@@ -16,8 +16,8 @@ import freenet.io.comm.AsyncMessageCallback;
  *     // Messages have been sent.
  *   }
  * }
- * pn.sendAsync(m1, mcb, ctr);
- * pn.sendAsync(m2, mcb, ctr);
+ * pn.sendAsync(m1, mcb.make(), ctr);
+ * pn.sendAsync(m2, mcb.make(), ctr);
  * mcb.arm();</pre> */
 public abstract class MultiMessageCallback {
 	

--- a/src/freenet/node/MultiMessageCallback.java
+++ b/src/freenet/node/MultiMessageCallback.java
@@ -2,11 +2,9 @@ package freenet.node;
 
 import freenet.io.comm.AsyncMessageCallback;
 
-/** Waits for multiple asynchronous message sends, then calls finish(). 
- * You should add messages with make() and then call arm(). sent(boolean)
- * will be called when all the messages have been sent (or failed e.g. 
- * disconnected) and finish(boolean) will be called when all the messages 
- * have been acknowledged (or failed). Typical usage:
+/** Groups a set of message sends together so that we get a single sent(boolean)
+ * callback after all the messages have been sent, and then later a finished(boolean).
+ * None of the callbacks will be called until after you call arm(). Typical usage:
  * <pre>Message m1 = ...;
  * Message m2 = ...;
  * PeerNode pn = ...;

--- a/src/freenet/node/MultiMessageCallback.java
+++ b/src/freenet/node/MultiMessageCallback.java
@@ -30,6 +30,7 @@ public abstract class MultiMessageCallback {
 	/** Add another message. You should call arm() after you have added all messages. */
 	public AsyncMessageCallback make() {
 		synchronized(this) {
+		    assert(!armed);
 			AsyncMessageCallback cb = new AsyncMessageCallback() {
 
 				private boolean finished;

--- a/src/freenet/node/MultiMessageCallback.java
+++ b/src/freenet/node/MultiMessageCallback.java
@@ -29,10 +29,11 @@ public abstract class MultiMessageCallback {
 				public void sent() {
 					boolean success;
 					synchronized(MultiMessageCallback.this) {
-						if(finished || sent || !armed) return;
+						if(finished || sent) return;
 						sent = true;
 						waitingForSend--;
 						if(waitingForSend > 0) return;
+                        if(!armed) return;
 						success = !someFailed;
 					}
 					MultiMessageCallback.this.sent(success);


### PR DESCRIPTION
If message.sent() is called before cb.arm(), then we only call cb.sent() after completion. We should call it on arm()ing. This probably only affects simulations, but possibly also very busy nodes.

This is a minor accounting glitch, low priority, but might conceivably caused forced disconnects.