### PR TITLE
Opennet RequestSender cleanup

### DIFF
--- a/src/freenet/node/RequestHandler.java
+++ b/src/freenet/node/RequestHandler.java
@@ -939,6 +939,7 @@ public class RequestHandler implements PrioRunnable, ByteCounter, RequestSenderL
 						try {
 						    rs.relayOpennetRef(newNoderef, dataSource, RequestHandler.this);
                             // Does not wait for an acknowledgement.
+						    return;
 						} catch(NotConnectedException e) {
 							// How sad
 						}

--- a/src/freenet/node/RequestHandler.java
+++ b/src/freenet/node/RequestHandler.java
@@ -777,7 +777,7 @@ public class RequestHandler implements PrioRunnable, ByteCounter, RequestSenderL
 			noderef = rs.waitForOpennetNoderef();
 		} catch (WaitedTooLongForOpennetNoderefException e) {
 			sendTerminal(DMT.createFNPOpennetCompletedTimeout(uid));
-			rs.ackOpennet(rs.successFrom());
+			// RequestSender will have already acknowledged.
 			return;
 		}
 		if(noderef == null) {

--- a/src/freenet/node/RequestHandler.java
+++ b/src/freenet/node/RequestHandler.java
@@ -937,29 +937,13 @@ public class RequestHandler implements PrioRunnable, ByteCounter, RequestSenderL
 					
 					if(OpennetManager.validateNoderef(newNoderef, 0, newNoderef.length, source, false) != null) {
 						try {
-							if(logMINOR) Logger.minor(this, "Relaying noderef from source to data source for "+RequestHandler.this);
-							om.sendOpennetRef(true, uid, dataSource, newNoderef, RequestHandler.this, new AllSentCallback() {
-
-								@Override
-								public void allSent(
-										BulkTransmitter bulkTransmitter,
-										boolean anyFailed) {
-									// As soon as the originator receives the three blocks, he can reuse the slot.
-									tag.finishedWaitingForOpennet(dataSource);
-									tag.unlockHandler();
-									applyByteCounts();
-									// Note that sendOpennetRef() does not wait for an acknowledgement or even for the blocks to have been sent!
-									// So this will be called well after gotNoderef() exits.
-								}
-								
-							});
+						    rs.relayOpennetRef(newNoderef, dataSource, RequestHandler.this);
+                            // Does not wait for an acknowledgement.
 						} catch(NotConnectedException e) {
 							// How sad
 						}
 					}
-					tag.finishedWaitingForOpennet(dataSource);
-					tag.unlockHandler();
-					applyByteCounts();
+					finishAfterRelaying(dataSource);
 				}
 			}
 
@@ -985,7 +969,14 @@ public class RequestHandler implements PrioRunnable, ByteCounter, RequestSenderL
 		}, node);
 
 	}
-	private int sentBytes;
+	
+	protected void finishAfterRelaying(PeerNode dataSource) {
+        tag.finishedWaitingForOpennet(dataSource);
+        tag.unlockHandler();
+        applyByteCounts();
+    }
+	
+    private int sentBytes;
 	private int receivedBytes;
 	private volatile Object bytesSync = new Object();
 

--- a/src/freenet/node/RequestSender.java
+++ b/src/freenet/node/RequestSender.java
@@ -1664,6 +1664,14 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
 	/** Acknowledge the opennet path folding attempt without sending a reference. Once
 	 * the send completes (asynchronously), unlock everything. */
 	void ackOpennet(final PeerNode next) {
+	    synchronized(this) {
+	        if(opennetFinishedRelaying) {
+	            Logger.error(this, "Already relayed in ackOpennet on "+this+" to "+next, 
+	                    new Exception("debug"));
+                opennetFinishedRelaying = true;
+	            return;
+	        }
+	    }
 		Message msg = DMT.createFNPOpennetCompletedAck(uid);
 		// We probably should set opennetFinished after the send completes.
 		try {
@@ -1783,6 +1791,9 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
     
     /** Have we finished waiting for an opennet noderef? */
     private boolean opennetFinished;
+
+    /** Have we sent an acknowledgement or opennet noderef? */
+    private boolean opennetFinishedRelaying;
     
     /** Did we timeout waiting for opennet noderef? */
     private boolean opennetTimedOut;

--- a/src/freenet/node/RequestSender.java
+++ b/src/freenet/node/RequestSender.java
@@ -1711,11 +1711,13 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
     }
 
     /**
-     * Do path folding, maybe.
-     * Wait for either a CompletedAck or a ConnectDestination.
-     * If the former, exit.
-     * If we want a connection, reply with a ConnectReply, otherwise send a ConnectRejected and exit.
-     * Add the peer.
+     * Do path folding, maybe:
+     * Wait for either a CompletedAck or a ConnectDestination. If the former, exit.
+     * If we want a connection, reply with a ConnectReply and our noderef and add the
+     * peer. If there is no previous peer, acknowledge it immediately and exit.
+     * Otherwise pass it on to RequestHandler, which is responsible for relaying it
+     * to the requestor, waiting for a response and calling either ackOpennet() or
+     * relayOpennetRef().
      * @return True only if there was a fatal timeout and the caller should not unlock.
      */
     private boolean finishOpennet(PeerNode next) {

--- a/src/freenet/node/RequestSender.java
+++ b/src/freenet/node/RequestSender.java
@@ -1752,7 +1752,8 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
 				synchronized(this) {
 					opennetNoderef = noderef;
 				}
-				// RequestHandler will send a noderef back up, eventually, and will unlockHandler() after that point.
+				// RequestHandler will send a noderef back up, eventually, and will 
+				// unlockHandler() after that point.
 				// But if this is a local request, we need to send the ack now.
 				// Serious race condition not possible here as we set it.
 				if(source == null)

--- a/src/freenet/node/RequestSender.java
+++ b/src/freenet/node/RequestSender.java
@@ -1781,7 +1781,7 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
 
     // Opennet stuff
     
-    /** Have we finished all opennet-related activities? */
+    /** Have we finished waiting for an opennet noderef? */
     private boolean opennetFinished;
     
     /** Did we timeout waiting for opennet noderef? */

--- a/src/freenet/node/RequestSender.java
+++ b/src/freenet/node/RequestSender.java
@@ -1670,9 +1670,9 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
 	        if(opennetFinishedRelaying) {
 	            Logger.error(this, "Already relayed in ackOpennet on "+this+" to "+next, 
 	                    new Exception("debug"));
-                opennetFinishedRelaying = true;
 	            return;
 	        }
+            opennetFinishedRelaying = true;
 	    }
 		Message msg = DMT.createFNPOpennetCompletedAck(uid);
 		// We probably should set opennetFinished after the send completes.
@@ -1689,9 +1689,9 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
             if(opennetFinishedRelaying) {
                 Logger.error(this, "Already relayed in relayOpennetRef on "+this+" to "+next, 
                         new Exception("debug"));
-                opennetFinishedRelaying = true;
                 return;
             }
+            opennetFinishedRelaying = true;
         }
         if(logMINOR) Logger.minor(this, "Relaying noderef from source to data source for "+this);
         OpennetManager om = node.getOpennet();

--- a/src/freenet/node/RequestSender.java
+++ b/src/freenet/node/RequestSender.java
@@ -22,8 +22,10 @@ import freenet.io.comm.ReferenceSignatureVerificationException;
 import freenet.io.comm.RetrievalException;
 import freenet.io.comm.SlowAsyncMessageFilterCallback;
 import freenet.io.xfer.BlockReceiver;
+import freenet.io.xfer.BulkTransmitter;
 import freenet.io.xfer.BlockReceiver.BlockReceiverCompletion;
 import freenet.io.xfer.BlockReceiver.BlockReceiverTimeoutHandler;
+import freenet.io.xfer.BulkTransmitter.AllSentCallback;
 import freenet.io.xfer.PartiallyReceivedBlock;
 import freenet.keys.CHKBlock;
 import freenet.keys.Key;
@@ -1680,8 +1682,24 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
 			// Ignore.
 		}
 	}
+	
+    public void relayOpennetRef(byte[] newNoderef, final PeerNode next, 
+            final RequestHandler handler) throws NotConnectedException {
+        if(logMINOR) Logger.minor(this, "Relaying noderef from source to data source for "+this);
+        OpennetManager om = node.getOpennet();
+        om.sendOpennetRef(true, uid, next, newNoderef, this, new AllSentCallback() {
 
-	/**
+            @Override
+            public void allSent(
+                    BulkTransmitter bulkTransmitter,
+                    boolean anyFailed) {
+                handler.finishAfterRelaying(next);
+            }
+            
+        });
+    }
+
+    /**
      * Do path folding, maybe.
      * Wait for either a CompletedAck or a ConnectDestination.
      * If the former, exit.

--- a/src/freenet/node/RequestSender.java
+++ b/src/freenet/node/RequestSender.java
@@ -1685,13 +1685,16 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
 	
     public void relayOpennetRef(byte[] newNoderef, final PeerNode next, 
             final RequestHandler handler) throws NotConnectedException {
+        boolean duplicate = false;
         synchronized(this) {
-            if(opennetFinishedRelaying) {
-                Logger.error(this, "Already relayed in relayOpennetRef on "+this+" to "+next, 
-                        new Exception("debug"));
-                return;
-            }
+            duplicate = opennetFinishedRelaying;
             opennetFinishedRelaying = true;
+        }
+        if(duplicate) {
+            Logger.error(this, "Already relayed in relayOpennetRef on "+this+" to "+next, 
+                    new Exception("debug"));
+            handler.finishAfterRelaying(next);
+            return;
         }
         if(logMINOR) Logger.minor(this, "Relaying noderef from source to data source for "+this);
         OpennetManager om = node.getOpennet();

--- a/src/freenet/node/RequestSender.java
+++ b/src/freenet/node/RequestSender.java
@@ -1685,6 +1685,14 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
 	
     public void relayOpennetRef(byte[] newNoderef, final PeerNode next, 
             final RequestHandler handler) throws NotConnectedException {
+        synchronized(this) {
+            if(opennetFinishedRelaying) {
+                Logger.error(this, "Already relayed in relayOpennetRef on "+this+" to "+next, 
+                        new Exception("debug"));
+                opennetFinishedRelaying = true;
+                return;
+            }
+        }
         if(logMINOR) Logger.minor(this, "Relaying noderef from source to data source for "+this);
         OpennetManager om = node.getOpennet();
         om.sendOpennetRef(true, uid, next, newNoderef, this, new AllSentCallback() {


### PR DESCRIPTION
This makes RequestSender responsible for actually sending node references (and acknowledgements) to the data source. It should make opennet behave more consistently. It needs careful testing.