### PR TITLE
Random delay for opennet ack when not path folding (locally)

### DIFF
--- a/src/freenet/node/RequestSender.java
+++ b/src/freenet/node/RequestSender.java
@@ -1735,7 +1735,7 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
 				// Serious race condition not possible here as we set it.
 				if(source == null) {
 				    long delay = randomDelayFinishOpennetLocal();
-				    if(logMINOR) Logger.minor(this, "Delaying opennet completion for "+TimeUtil.formatTime(delay, 2));
+				    if(logMINOR) Logger.minor(this, "Delaying opennet completion for "+TimeUtil.formatTime(delay, 2, true));
 				    node.ticker.queueTimedJob(new Runnable() {
 
                         @Override

--- a/src/freenet/node/RequestSender.java
+++ b/src/freenet/node/RequestSender.java
@@ -1681,7 +1681,8 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
 	
 	private long randomDelayFinishOpennetLocal() {
 	    double pingTime = 
-	            Math.max(node.nodeStats.getBwlimitDelayTime(),
+	            // Noderefs are sent as real-time
+	            Math.max(node.nodeStats.getBwlimitDelayTimeRT(),
 	                    node.nodeStats.nodePinger.averagePingTime());
 	    pingTime = Math.min(pingTime, MAX_PING_TIME);
 	    double delay = 

--- a/src/freenet/node/RequestSender.java
+++ b/src/freenet/node/RequestSender.java
@@ -1735,7 +1735,7 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
 				// Serious race condition not possible here as we set it.
 				if(source == null) {
 				    long delay = randomDelayFinishOpennetLocal();
-				    if(logMINOR) Logger.minor(this, "Delaying opennet completion for "+TimeUtil.formatTime(delay));
+				    if(logMINOR) Logger.minor(this, "Delaying opennet completion for "+TimeUtil.formatTime(delay, 2));
 				    node.ticker.queueTimedJob(new Runnable() {
 
                         @Override

--- a/src/freenet/node/RequestSender.java
+++ b/src/freenet/node/RequestSender.java
@@ -1682,8 +1682,8 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
 	private long randomDelayFinishOpennetLocal() {
 	    double pingTime = 
 	            // Noderefs are sent as real-time
-	            Math.max(node.nodeStats.getBwlimitDelayTimeRT(),
-	                    node.nodeStats.nodePinger.averagePingTime());
+	            node.nodeStats.getBwlimitDelayTimeRT() +
+	            node.nodeStats.nodePinger.averagePingTime();
 	    pingTime = Math.min(pingTime, MAX_PING_TIME);
 	    double delay = 
 	            ((node.random.nextGaussian() * PINGS_STDDEV) + PINGS) * pingTime;

--- a/src/freenet/node/RequestSender.java
+++ b/src/freenet/node/RequestSender.java
@@ -1673,6 +1673,22 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
 		}
 	}
 
+	/** Number of ping times to simulate */
+	static final double PINGS = 5.0;
+	/** Standard deviation in ping times */
+	static final double PINGS_STDDEV = PINGS / 6.0;
+	static final double MAX_PING_TIME = RequestSender.OPENNET_TIMEOUT / 10;
+	
+	private long randomDelayFinishOpennetLocal() {
+	    double pingTime = node.nodeStats.getBwlimitDelayTime() +
+	            node.nodeStats.nodePinger.averagePingTime();
+	    pingTime = Math.min(pingTime, MAX_PING_TIME);
+	    double delay = 
+	            ((node.random.nextGaussian() * PINGS_STDDEV) + PINGS) * pingTime;
+	    if(delay < 0) delay = 0;
+	    return (long) delay;
+	}
+	
 	/**
      * Do path folding, maybe.
      * Wait for either a CompletedAck or a ConnectDestination.
@@ -1681,7 +1697,7 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
      * Add the peer.
      * @return True only if there was a fatal timeout and the caller should not unlock.
      */
-    private boolean finishOpennet(PeerNode next) {
+    private boolean finishOpennet(final PeerNode next) {
     	
     	OpennetManager om;
     	
@@ -1716,9 +1732,18 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
 				// RequestHandler will send a noderef back up, eventually, and will unlockHandler() after that point.
 				// But if this is a local request, we need to send the ack now.
 				// Serious race condition not possible here as we set it.
-				if(source == null)
-					ackOpennet(next);
-				else if(origTag.shouldStop()) {
+				if(source == null) {
+				    long delay = randomDelayFinishOpennetLocal();
+				    if(logMINOR) Logger.minor(this, "Delaying opennet completion for "+TimeUtil.formatTime(delay));
+				    node.ticker.queueTimedJob(new Runnable() {
+
+                        @Override
+                        public void run() {
+                            ackOpennet(next);
+                        }
+				        
+				    }, delay);
+				} else if(origTag.shouldStop()) {
 					// Can't pass it on.
 					origTag.finishedWaitingForOpennet(next);
 				}

--- a/src/freenet/node/RequestSender.java
+++ b/src/freenet/node/RequestSender.java
@@ -1680,8 +1680,9 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
 	static final double MAX_PING_TIME = RequestSender.OPENNET_TIMEOUT / 10;
 	
 	private long randomDelayFinishOpennetLocal() {
-	    double pingTime = node.nodeStats.getBwlimitDelayTime() +
-	            node.nodeStats.nodePinger.averagePingTime();
+	    double pingTime = 
+	            Math.max(node.nodeStats.getBwlimitDelayTime(),
+	                    node.nodeStats.nodePinger.averagePingTime());
 	    pingTime = Math.min(pingTime, MAX_PING_TIME);
 	    double delay = 
 	            ((node.random.nextGaussian() * PINGS_STDDEV) + PINGS) * pingTime;

--- a/src/freenet/node/RequestSender.java
+++ b/src/freenet/node/RequestSender.java
@@ -1674,7 +1674,7 @@ public final class RequestSender extends BaseSender implements PrioRunnable {
 	}
 
 	/** Number of ping times to simulate */
-	static final double PINGS = 5.0;
+	static final double PINGS = 3.0;
 	/** Standard deviation in ping times */
 	static final double PINGS_STDDEV = PINGS / 6.0;
 	static final double MAX_PING_TIME = RequestSender.OPENNET_TIMEOUT / 10;


### PR DESCRIPTION
This should improve protection against local attackers. I would like it to be considered for 1472 if not earlier. The performance impact should be marginal: Path folding does not block returning the data, although maybe we might end up running slightly fewer requests as a result. If so increasing the limits (BANDWIDTH_LIABILITY_*) in NodeStats would be a simple solution.