### PR TITLE
Fix legacy UOM (please consider for 1471, urgent!)

### DIFF
--- a/src/freenet/io/comm/DMT.java
+++ b/src/freenet/io/comm/DMT.java
@@ -1542,23 +1542,6 @@ public class DMT {
 		return msg;
 	}
 
-	// Used by old UOM. We need to distinguish them in NodeDispatcher. FIXME remove eventually.
-	public static final MessageType UOMSendingMain = new MessageType("UOMSendingMain", PRIORITY_LOW) {{
-		addField(UID, Long.class);
-		addField(FILE_LENGTH, Long.class);
-		addField(MAIN_JAR_KEY, String.class);
-		addField(MAIN_JAR_VERSION, Integer.class);
-	}};
-	
-	public static Message createUOMSendingMain(long uid, long length, String key, int version) {
-		Message msg = new Message(UOMSendingMain);
-		msg.set(UID, uid);
-		msg.set(FILE_LENGTH, length);
-		msg.set(MAIN_JAR_KEY, key);
-		msg.set(MAIN_JAR_VERSION, version);
-		return msg;
-	}
-	
 	// Used by new UOM. We need to distinguish them in NodeDispatcher.
 	public static final MessageType UOMSendingMainJar = new MessageType("UOMSendingMainJar", PRIORITY_LOW) {{
 		addField(UID, Long.class);
@@ -1573,23 +1556,6 @@ public class DMT {
 		msg.set(FILE_LENGTH, length);
 		msg.set(MAIN_JAR_KEY, key);
 		msg.set(MAIN_JAR_VERSION, version);
-		return msg;
-	}
-	
-	// Used only by legacy UOM. FIXME remove eventually.
-	public static final MessageType UOMSendingExtra = new MessageType("UOMSendingExtra", PRIORITY_LOW) {{
-		addField(UID, Long.class);
-		addField(FILE_LENGTH, Long.class);
-		addField(EXTRA_JAR_KEY, String.class);
-		addField(EXTRA_JAR_VERSION, Integer.class);
-	}};
-	
-	public static Message createUOMSendingExtra(long uid, long length, String key, int version) {
-		Message msg = new Message(UOMSendingExtra);
-		msg.set(UID, uid);
-		msg.set(FILE_LENGTH, length);
-		msg.set(EXTRA_JAR_KEY, key);
-		msg.set(EXTRA_JAR_VERSION, version);
 		return msg;
 	}
 	

--- a/src/freenet/io/comm/DMT.java
+++ b/src/freenet/io/comm/DMT.java
@@ -1505,51 +1505,6 @@ public class DMT {
 		return msg;
 	}
 	
-	// Legacy UOM message. Kept to enable old nodes to UOM to 1421.
-	// After that they can use the modern UOM system. FIXME remove eventually.
-	public static final MessageType UOMAnnounce = new MessageType("UOMAnnounce", PRIORITY_LOW) {{
-		addField(MAIN_JAR_KEY, String.class);
-		addField(EXTRA_JAR_KEY, String.class);
-		addField(REVOCATION_KEY, String.class);
-		addField(HAVE_REVOCATION_KEY, Boolean.class);
-		addField(MAIN_JAR_VERSION, Long.class);
-		addField(EXTRA_JAR_VERSION, Long.class);
-		// Last time (ms ago) we had 3 DNFs in a row on the revocation checker.
-		addField(REVOCATION_KEY_TIME_LAST_TRIED, Long.class);
-		// Number of DNFs so far this time.
-		addField(REVOCATION_KEY_DNF_COUNT, Integer.class);
-		// For convenience, may change
-		addField(REVOCATION_KEY_FILE_LENGTH, Long.class);
-		addField(MAIN_JAR_FILE_LENGTH, Long.class);
-		addField(EXTRA_JAR_FILE_LENGTH, Long.class);
-		addField(PING_TIME, Integer.class);
-		addField(BWLIMIT_DELAY_TIME, Integer.class);
-	}};
-
-	// We need to be able to create these to announce to old nodes.
-	public static Message createUOMAnnounce(String mainKey, String extraKey, String revocationKey,
-			boolean haveRevocation, long mainJarVersion, long extraJarVersion, long timeLastTriedRevocationFetch,
-			int revocationDNFCount, long revocationKeyLength, long mainJarLength, long extraJarLength, int pingTime, int bwlimitDelayTime) {
-		Message msg = new Message(UOMAnnounce);
-		
-		msg.set(MAIN_JAR_KEY, mainKey);
-		msg.set(EXTRA_JAR_KEY, extraKey);
-		msg.set(REVOCATION_KEY, revocationKey);
-		msg.set(HAVE_REVOCATION_KEY, haveRevocation);
-		msg.set(MAIN_JAR_VERSION, mainJarVersion);
-		msg.set(EXTRA_JAR_VERSION, extraJarVersion);
-		msg.set(REVOCATION_KEY_TIME_LAST_TRIED, timeLastTriedRevocationFetch);
-		msg.set(REVOCATION_KEY_DNF_COUNT, revocationDNFCount);
-		msg.set(REVOCATION_KEY_FILE_LENGTH, revocationKeyLength);
-		msg.set(MAIN_JAR_FILE_LENGTH, mainJarLength);
-		msg.set(EXTRA_JAR_FILE_LENGTH, extraJarLength);
-		msg.set(PING_TIME, pingTime);
-		msg.set(BWLIMIT_DELAY_TIME, bwlimitDelayTime);
-		
-		return msg;
-	}
-	
-	// Same for old and new, handled by new UOM.
 	public static final MessageType UOMRequestRevocation = new MessageType("UOMRequestRevocation", PRIORITY_HIGH) {{
 		addField(UID, Long.class);
 	}};
@@ -1560,12 +1515,6 @@ public class DMT {
 		return msg;
 	}
 
-	// Used by old UOM. We need to be able to distinguish it easily for dispatcher.
-	// FIXME remove eventually.
-	public static final MessageType UOMRequestMain = new MessageType("UOMRequestMain", PRIORITY_LOW) {{
-		addField(UID, Long.class);
-	}};
-	
 	// Used by new UOM.
 	public static final MessageType UOMRequestMainJar = new MessageType("UOMRequestMainJar", PRIORITY_LOW) {{
 		addField(UID, Long.class);
@@ -1577,12 +1526,6 @@ public class DMT {
 		return msg;
 	}
 
-	// Used only by legacy UOM. FIXME remove eventually.
-	public static final MessageType UOMRequestExtra = new MessageType("UOMRequestExtra", PRIORITY_LOW) {{
-		addField(UID, Long.class);
-	}};
-	
-	// Used by both old and new UOM.
 	public static final MessageType UOMSendingRevocation = new MessageType("UOMSendingRevocation", PRIORITY_HIGH) {{
 		addField(UID, Long.class);
 		// Probably excessive, but lengths are always long's, and wasting a few bytes here

--- a/src/freenet/node/NodeDispatcher.java
+++ b/src/freenet/node/NodeDispatcher.java
@@ -159,9 +159,6 @@ public class NodeDispatcher implements Dispatcher, Runnable {
 		} else if(spec == DMT.nodeToNodeMessage) {
 			node.receivedNodeToNodeMessage(m, source);
 			return true;
-		} else if(spec == DMT.UOMAnnounce && source.isRealConnection()) {
-			// Treat as a UOMAnnouncement, as it's a strict subset, and new UOM handles revocations.
-			return node.nodeUpdater.uom.handleAnnounce(m, source);
 		} else if(spec == DMT.UOMAnnouncement && source.isRealConnection()) {
 			return node.nodeUpdater.uom.handleAnnounce(m, source);
 		} else if(spec == DMT.UOMRequestRevocation && source.isRealConnection()) {

--- a/src/freenet/node/updater/NodeUpdateManager.java
+++ b/src/freenet/node/updater/NodeUpdateManager.java
@@ -610,20 +610,15 @@ public class NodeUpdateManager {
 	private Message getOldUOMAnnouncement() {
 		boolean mainJarAvailable = transitionMainJarFetcher == null ? false
 				: transitionMainJarFetcher.fetched();
-		boolean extJarAvailable = transitionExtJarFetcher == null ? false
-				: transitionExtJarFetcher.fetched();
-		return DMT.createUOMAnnounce(transitionMainJarURIAsUSK.toString(),
-				transitionExtJarURIAsUSK.toString(),
-				revocationURI.toString(), revocationChecker.hasBlown(),
-				mainJarAvailable ? TRANSITION_VERSION : -1,
-				extJarAvailable ? TRANSITION_VERSION_EXT : -1,
-				revocationChecker.lastSucceededDelta(), revocationChecker
-						.getRevocationDNFCounter(), revocationChecker
-						.getBlobSize(),
-				mainJarAvailable ? transitionMainJarFetcher.getBlobSize() : -1,
-				extJarAvailable ? transitionExtJarFetcher.getBlobSize() : -1,
-				(int) node.nodeStats.getNodeAveragePingTime(),
-				(int) node.nodeStats.getBwlimitDelayTime());
+        return DMT.createUOMAnnouncement(updateURI.toString(), revocationURI
+                .toString(), revocationChecker.hasBlown(), 
+                mainJarAvailable ? TRANSITION_VERSION : -1,
+                revocationChecker.lastSucceededDelta(), revocationChecker
+                .getRevocationDNFCounter(), revocationChecker
+                .getBlobSize(),
+                mainJarAvailable ? transitionMainJarFetcher.getBlobSize() : -1,
+                (int) node.nodeStats.getNodeAveragePingTime(),
+                (int) node.nodeStats.getBwlimitDelayTime());
 	}
 
 	private Message getNewUOMAnnouncement(long blobSize) {

--- a/src/freenet/node/updater/NodeUpdateManager.java
+++ b/src/freenet/node/updater/NodeUpdateManager.java
@@ -587,7 +587,7 @@ public class NodeUpdateManager {
 	private Message getOldUOMAnnouncement() {
 		boolean mainJarAvailable = transitionMainJarFetcher == null ? false
 				: transitionMainJarFetcher.fetched();
-        return DMT.createUOMAnnouncement(updateURI.toString(), revocationURI
+        return DMT.createUOMAnnouncement(transitionMainJarURIAsUSK.toString(), revocationURI
                 .toString(), revocationChecker.hasBlown(), 
                 mainJarAvailable ? TRANSITION_VERSION : -1,
                 revocationChecker.lastSucceededDelta(), revocationChecker

--- a/src/freenet/node/updater/UpdateOverMandatoryManager.java
+++ b/src/freenet/node/updater/UpdateOverMandatoryManager.java
@@ -1185,12 +1185,15 @@ public class UpdateOverMandatoryManager implements RequestClient {
 
 		File data;
 		int version;
+		FreenetURI uri;
 		if(source.isUnroutableOlderVersion()) {
 		    data = updateManager.getTransitionMainBlob();
 		    version = NodeUpdateManager.TRANSITION_VERSION;
+		    uri = NodeUpdateManager.transitionMainJarURIAsUSK;
 		} else {
 		    data = updateManager.getCurrentVersionBlobFile();
 		    version = Version.buildNumber();
+            uri = updateManager.getURI();
 		}
 		
 		if(version != Version.buildNumber()) {
@@ -1240,7 +1243,7 @@ public class UpdateOverMandatoryManager implements RequestClient {
 			}
 			
 			msg =
-				DMT.createUOMSendingMainJar(uid, length, updateManager.getURI().toString(), version);
+				DMT.createUOMSendingMainJar(uid, length, uri.toString(), version);
 			
 		} catch (RuntimeException e) {
 			source.finishedSendingUOMJar(false);

--- a/src/freenet/node/updater/UpdateOverMandatoryManager.java
+++ b/src/freenet/node/updater/UpdateOverMandatoryManager.java
@@ -154,9 +154,6 @@ public class UpdateOverMandatoryManager implements RequestClient {
 	 */
 	public boolean handleAnnounce(Message m, final PeerNode source) {
 		
-		/** If it's a UOMAnnounce, we only care about revocations. */
-		boolean fromOldNode = m.getSpec() == DMT.UOMAnnounce;
-		
 		String mainJarKey = m.getString(DMT.MAIN_JAR_KEY);
 		String revocationKey = m.getString(DMT.REVOCATION_KEY);
 		boolean haveRevocationKey = m.getBoolean(DMT.HAVE_REVOCATION_KEY);
@@ -239,10 +236,6 @@ public class UpdateOverMandatoryManager implements RequestClient {
 		
 		tellFetchers(source);
 		
-		if(fromOldNode)
-			// If it's an old node, we ignore everything except revocations.
-			return true;
-
 		if(updateManager.isBlown())
 			return true; // We already know
 

--- a/src/freenet/node/updater/UpdateOverMandatoryManager.java
+++ b/src/freenet/node/updater/UpdateOverMandatoryManager.java
@@ -1183,8 +1183,15 @@ public class UpdateOverMandatoryManager implements RequestClient {
 		}
 		// Do we have the data?
 
-		File data = updateManager.getCurrentVersionBlobFile();
-		int version = Version.buildNumber();
+		File data;
+		int version;
+		if(source.isUnroutableOlderVersion()) {
+		    data = updateManager.getTransitionMainBlob();
+		    version = NodeUpdateManager.TRANSITION_VERSION;
+		} else {
+		    data = updateManager.getCurrentVersionBlobFile();
+		    version = Version.buildNumber();
+		}
 		
 		if(version != Version.buildNumber()) {
 			Logger.normal(this, "Peer " + source + " asked us for the blob file for the main jar but we are about to update...");


### PR DESCRIPTION
I am surprised that UOM works in your testing. It looks to me like it shouldn't - we announce via the old message, UOMAnnounce, and it looks like UpdateOverMandatoryManager won't fetch a jar if advertised via the old UOM announcement message?

In any case it would be a very good idea to announce using the new UOMAnnouncement message - that is, please consider the first commit even if you don't want the others, if you can test it.

Please test carefully, I haven't tested this yet. I believe you had a script to automate testing.