### PR TITLE
Test node blobs

### DIFF
--- a/src/freenet/node/NodeStarter.java
+++ b/src/freenet/node/NodeStarter.java
@@ -411,7 +411,7 @@ public class NodeStarter implements WrapperListener {
         public int dropProb;
         public RandomSource random;
         public Executor executor;
-        public int threadLimit;
+        public int threadLimit = 500;
         public long storeSize;
         public boolean ramStore;
         public boolean enableSwapping;

--- a/test/freenet/node/NodeAndClientLayerBlobTest.java
+++ b/test/freenet/node/NodeAndClientLayerBlobTest.java
@@ -1,0 +1,102 @@
+package freenet.node;
+
+import static org.junit.Assert.*;
+
+import java.io.BufferedInputStream;
+import java.io.DataInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+
+import org.junit.Test;
+
+import freenet.client.FetchContext;
+import freenet.client.FetchException;
+import freenet.client.FetchResult;
+import freenet.client.FetchWaiter;
+import freenet.client.HighLevelSimpleClient;
+import freenet.client.InsertBlock;
+import freenet.client.InsertContext;
+import freenet.client.InsertException;
+import freenet.client.async.BinaryBlob;
+import freenet.client.async.BinaryBlobFormatException;
+import freenet.client.async.BinaryBlobWriter;
+import freenet.client.async.ClientGetter;
+import freenet.client.async.SimpleBlockSet;
+import freenet.crypt.DummyRandomSource;
+import freenet.keys.FreenetURI;
+import freenet.node.NodeStarter.TestNodeParameters;
+import freenet.support.Executor;
+import freenet.support.Logger;
+import freenet.support.PooledExecutor;
+import freenet.support.LoggerHook.InvalidThresholdException;
+import freenet.support.api.Bucket;
+import freenet.support.io.BucketTools;
+import freenet.support.io.FileUtil;
+
+public class NodeAndClientLayerBlobTest extends NodeAndClientLayerTestBase {
+
+    @Test
+    public void testFetchPullBlobSingleNode() throws InvalidThresholdException, NodeInitException, InsertException, FetchException, IOException, BinaryBlobFormatException {
+        DummyRandomSource random = new DummyRandomSource(25312);
+        final Executor executor = new PooledExecutor();
+        File dir = new File("test-fetch-pull-blob-single-node");
+        FileUtil.removeAll(dir);
+        dir.mkdir();
+        NodeStarter.globalTestInit(dir, false, 
+                Logger.LogLevel.ERROR, "", true, random);
+        TestNodeParameters params = new TestNodeParameters();
+        params.random = new DummyRandomSource(253121);
+        params.ramStore = true;
+        params.storeSize = FILE_SIZE * 3;
+        params.baseDirectory = dir;
+        params.executor = executor;
+        Node node = NodeStarter.createTestNode(params);
+        node.start(false);
+        HighLevelSimpleClient client = 
+                node.clientCore.makeClient((short)0, false, false);
+        // First do an ordinary insert.
+        InsertContext ictx = client.getInsertContext(true);
+        ictx.localRequestOnly = true;
+        InsertBlock block = generateBlock(random);
+        FreenetURI uri = 
+                client.insert(block, "", (short)0, ictx);
+        assertEquals(uri.getKeyType(), "SSK");
+        FetchContext ctx = client.getFetchContext(FILE_SIZE*2);
+        ctx.localRequestOnly = true;
+        FetchWaiter fw = new FetchWaiter(rc);
+        client.fetch(uri, FILE_SIZE*2, fw, ctx, (short)0);
+        FetchResult result = fw.waitForCompletion();
+        assertTrue(BucketTools.equalBuckets(result.asBucket(), block.getData()));
+        // Now fetch the blob...
+        fw = new FetchWaiter(rc);
+        Bucket blobBucket = node.clientCore.tempBucketFactory.makeBucket(FILE_SIZE*3);
+        BinaryBlobWriter bbw = new BinaryBlobWriter(blobBucket);
+        ClientGetter getter = new ClientGetter(fw, uri, ctx, (short) 0, null, bbw, false, null, null);
+        getter.start(node.clientCore.clientContext);
+        fw.waitForCompletion();
+        assertTrue(blobBucket.size() > 0);
+        // Now bootstrap a second node, and fetch using the blob on that node.
+        params = new TestNodeParameters();
+        params.random = new DummyRandomSource(253121);
+        params.ramStore = true;
+        params.storeSize = FILE_SIZE * 3;
+        params.baseDirectory = new File(dir, "fetchNode");
+        params.baseDirectory.mkdir();
+        params.executor = executor;
+        Node node2 = NodeStarter.createTestNode(params);
+        node2.start(false);
+        HighLevelSimpleClient client2 = 
+                node.clientCore.makeClient((short)0, false, false);
+        FetchContext ctx2 = client.getFetchContext(FILE_SIZE*2);
+        SimpleBlockSet blocks = new SimpleBlockSet();
+        DataInputStream dis = new DataInputStream(blobBucket.getInputStream());
+        BinaryBlob.readBinaryBlob(dis, blocks, true);
+        ctx2 = new FetchContext(ctx2, FetchContext.IDENTICAL_MASK, true, blocks);
+        fw = new FetchWaiter(rc);
+        getter = client2.fetch(uri, FILE_SIZE*2, fw, ctx2, (short)0);
+        result = fw.waitForCompletion();
+        assertTrue(BucketTools.equalBuckets(result.asBucket(), block.getData()));
+    }
+    
+}

--- a/test/freenet/node/NodeAndClientLayerBlobTest.java
+++ b/test/freenet/node/NodeAndClientLayerBlobTest.java
@@ -33,11 +33,13 @@ import freenet.support.LoggerHook.InvalidThresholdException;
 import freenet.support.api.Bucket;
 import freenet.support.io.BucketTools;
 import freenet.support.io.FileUtil;
+import freenet.support.TestProperty;
 
 public class NodeAndClientLayerBlobTest extends NodeAndClientLayerTestBase {
 
     @Test
     public void testFetchPullBlobSingleNode() throws InvalidThresholdException, NodeInitException, InsertException, FetchException, IOException, BinaryBlobFormatException {
+        if(!TestProperty.EXTENSIVE) return;
         DummyRandomSource random = new DummyRandomSource(25312);
         final Executor executor = new PooledExecutor();
         File dir = new File("test-fetch-pull-blob-single-node");

--- a/test/freenet/node/NodeAndClientLayerBlobTest.java
+++ b/test/freenet/node/NodeAndClientLayerBlobTest.java
@@ -1,13 +1,13 @@
 package freenet.node;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
-import java.io.BufferedInputStream;
 import java.io.DataInputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 
+import org.junit.After;
 import org.junit.Test;
 
 import freenet.client.FetchContext;
@@ -28,21 +28,22 @@ import freenet.keys.FreenetURI;
 import freenet.node.NodeStarter.TestNodeParameters;
 import freenet.support.Executor;
 import freenet.support.Logger;
-import freenet.support.PooledExecutor;
 import freenet.support.LoggerHook.InvalidThresholdException;
+import freenet.support.PooledExecutor;
+import freenet.support.TestProperty;
 import freenet.support.api.Bucket;
 import freenet.support.io.BucketTools;
 import freenet.support.io.FileUtil;
-import freenet.support.TestProperty;
 
 public class NodeAndClientLayerBlobTest extends NodeAndClientLayerTestBase {
 
+    private static final File dir = new File("test-fetch-pull-blob-single-node");
+    
     @Test
     public void testFetchPullBlobSingleNode() throws InvalidThresholdException, NodeInitException, InsertException, FetchException, IOException, BinaryBlobFormatException {
         if(!TestProperty.EXTENSIVE) return;
         DummyRandomSource random = new DummyRandomSource(25312);
         final Executor executor = new PooledExecutor();
-        File dir = new File("test-fetch-pull-blob-single-node");
         FileUtil.removeAll(dir);
         dir.mkdir();
         NodeStarter.globalTestInit(dir, false, 
@@ -99,6 +100,11 @@ public class NodeAndClientLayerBlobTest extends NodeAndClientLayerTestBase {
         getter = client2.fetch(uri, FILE_SIZE*2, fw, ctx2, (short)0);
         result = fw.waitForCompletion();
         assertTrue(BucketTools.equalBuckets(result.asBucket(), block.getData()));
+    }
+    
+    @After
+    public void cleanUp() {
+        FileUtil.removeAll(dir);
     }
     
 }

--- a/test/freenet/node/NodeAndClientLayerTest.java
+++ b/test/freenet/node/NodeAndClientLayerTest.java
@@ -1,0 +1,93 @@
+package freenet.node;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+
+import org.junit.Test;
+
+import freenet.client.ClientMetadata;
+import freenet.client.FetchContext;
+import freenet.client.FetchException;
+import freenet.client.FetchResult;
+import freenet.client.FetchWaiter;
+import freenet.client.HighLevelSimpleClient;
+import freenet.client.InsertBlock;
+import freenet.client.InsertContext;
+import freenet.client.InsertException;
+import freenet.crypt.DummyRandomSource;
+import freenet.keys.FreenetURI;
+import freenet.keys.InsertableClientSSK;
+import freenet.node.NodeStarter.TestNodeParameters;
+import freenet.support.Executor;
+import freenet.support.Logger;
+import freenet.support.LoggerHook.InvalidThresholdException;
+import freenet.support.PooledExecutor;
+import freenet.support.SimpleReadOnlyArrayBucket;
+import freenet.support.api.RandomAccessBucket;
+import freenet.support.io.BucketTools;
+import freenet.support.io.FileUtil;
+
+public class NodeAndClientLayerTest {
+
+    static final int PORT = 2048;
+    static final int FILE_SIZE = 1024*1024;
+    
+    static RequestClient rc = new RequestClient() {
+
+        @Override
+        public boolean persistent() {
+            return false;
+        }
+
+        @Override
+        public boolean realTimeFlag() {
+            return false;
+        }
+        
+    };
+    
+    @Test
+    public void testFetchPullSingleNode() throws InvalidThresholdException, NodeInitException, InsertException, FetchException, IOException {
+        DummyRandomSource random = new DummyRandomSource(25312);
+        final Executor executor = new PooledExecutor();
+        File dir = new File("test-fetch-pull-single-node");
+        FileUtil.removeAll(dir);
+        dir.mkdir();
+        NodeStarter.globalTestInit(dir, false, 
+                Logger.LogLevel.ERROR, "", true, random);
+        TestNodeParameters params = new TestNodeParameters();
+        params.random = new DummyRandomSource(253121);
+        params.ramStore = true;
+        params.storeSize = FILE_SIZE * 2;
+        params.baseDirectory = dir;
+        params.executor = executor;
+        Node node = NodeStarter.createTestNode(params);
+        node.start(false);
+        HighLevelSimpleClient client = 
+                node.clientCore.makeClient((short)0, false, false);
+        InsertContext ictx = client.getInsertContext(true);
+        ictx.localRequestOnly = true;
+        InsertBlock block = generateBlock(random);
+        FreenetURI uri = 
+                client.insert(block, "", (short)0, ictx);
+        assertEquals(uri.getKeyType(), "SSK");
+        FetchContext ctx = client.getFetchContext(FILE_SIZE*2);
+        ctx.localRequestOnly = true;
+        FetchWaiter fw = new FetchWaiter(rc);
+        client.fetch(uri, FILE_SIZE*2, fw, ctx, (short)0);
+        FetchResult result = fw.waitForCompletion();
+        assertTrue(BucketTools.equalBuckets(result.asBucket(), block.getData()));
+    }
+    
+    private InsertBlock generateBlock(DummyRandomSource random) throws MalformedURLException {
+        byte[] data = new byte[FILE_SIZE];
+        random.nextBytes(data);
+        RandomAccessBucket bucket = new SimpleReadOnlyArrayBucket(data);
+        FreenetURI uri = InsertableClientSSK.createRandom(random, "test").getInsertURI();
+        return new InsertBlock(bucket, new ClientMetadata(null), uri);
+    }
+
+}

--- a/test/freenet/node/NodeAndClientLayerTest.java
+++ b/test/freenet/node/NodeAndClientLayerTest.java
@@ -17,6 +17,8 @@ import freenet.client.HighLevelSimpleClient;
 import freenet.client.InsertBlock;
 import freenet.client.InsertContext;
 import freenet.client.InsertException;
+import freenet.client.async.BinaryBlobWriter;
+import freenet.client.async.ClientGetter;
 import freenet.crypt.DummyRandomSource;
 import freenet.keys.FreenetURI;
 import freenet.keys.InsertableClientSSK;
@@ -26,29 +28,18 @@ import freenet.support.Logger;
 import freenet.support.LoggerHook.InvalidThresholdException;
 import freenet.support.PooledExecutor;
 import freenet.support.SimpleReadOnlyArrayBucket;
+import freenet.support.api.Bucket;
 import freenet.support.api.RandomAccessBucket;
 import freenet.support.io.BucketTools;
 import freenet.support.io.FileUtil;
 
-public class NodeAndClientLayerTest {
+/** Creates a node, inserts data to it, and fetches the data back.
+ * Note that we need one JUnit class per node because we need to actually exit the JVM
+ * to get rid of all the node threads.
+ * @author toad
+ */
+public class NodeAndClientLayerTest extends NodeAndClientLayerTestBase {
 
-    static final int PORT = 2048;
-    static final int FILE_SIZE = 1024*1024;
-    
-    static RequestClient rc = new RequestClient() {
-
-        @Override
-        public boolean persistent() {
-            return false;
-        }
-
-        @Override
-        public boolean realTimeFlag() {
-            return false;
-        }
-        
-    };
-    
     @Test
     public void testFetchPullSingleNode() throws InvalidThresholdException, NodeInitException, InsertException, FetchException, IOException {
         DummyRandomSource random = new DummyRandomSource(25312);
@@ -82,12 +73,4 @@ public class NodeAndClientLayerTest {
         assertTrue(BucketTools.equalBuckets(result.asBucket(), block.getData()));
     }
     
-    private InsertBlock generateBlock(DummyRandomSource random) throws MalformedURLException {
-        byte[] data = new byte[FILE_SIZE];
-        random.nextBytes(data);
-        RandomAccessBucket bucket = new SimpleReadOnlyArrayBucket(data);
-        FreenetURI uri = InsertableClientSSK.createRandom(random, "test").getInsertURI();
-        return new InsertBlock(bucket, new ClientMetadata(null), uri);
-    }
-
 }

--- a/test/freenet/node/NodeAndClientLayerTest.java
+++ b/test/freenet/node/NodeAndClientLayerTest.java
@@ -61,7 +61,7 @@ public class NodeAndClientLayerTest {
         TestNodeParameters params = new TestNodeParameters();
         params.random = new DummyRandomSource(253121);
         params.ramStore = true;
-        params.storeSize = FILE_SIZE * 2;
+        params.storeSize = FILE_SIZE * 3;
         params.baseDirectory = dir;
         params.executor = executor;
         Node node = NodeStarter.createTestNode(params);

--- a/test/freenet/node/NodeAndClientLayerTest.java
+++ b/test/freenet/node/NodeAndClientLayerTest.java
@@ -25,6 +25,7 @@ import freenet.keys.InsertableClientSSK;
 import freenet.node.NodeStarter.TestNodeParameters;
 import freenet.support.Executor;
 import freenet.support.Logger;
+import freenet.support.TestProperty;
 import freenet.support.LoggerHook.InvalidThresholdException;
 import freenet.support.PooledExecutor;
 import freenet.support.SimpleReadOnlyArrayBucket;
@@ -42,6 +43,7 @@ public class NodeAndClientLayerTest extends NodeAndClientLayerTestBase {
 
     @Test
     public void testFetchPullSingleNode() throws InvalidThresholdException, NodeInitException, InsertException, FetchException, IOException {
+        if(!TestProperty.EXTENSIVE) return;
         DummyRandomSource random = new DummyRandomSource(25312);
         final Executor executor = new PooledExecutor();
         File dir = new File("test-fetch-pull-single-node");

--- a/test/freenet/node/NodeAndClientLayerTest.java
+++ b/test/freenet/node/NodeAndClientLayerTest.java
@@ -6,6 +6,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 
+import org.junit.After;
 import org.junit.Test;
 
 import freenet.client.ClientMetadata;
@@ -41,12 +42,13 @@ import freenet.support.io.FileUtil;
  */
 public class NodeAndClientLayerTest extends NodeAndClientLayerTestBase {
 
+    private static final File dir = new File("test-fetch-pull-single-node");
+    
     @Test
     public void testFetchPullSingleNode() throws InvalidThresholdException, NodeInitException, InsertException, FetchException, IOException {
         if(!TestProperty.EXTENSIVE) return;
         DummyRandomSource random = new DummyRandomSource(25312);
         final Executor executor = new PooledExecutor();
-        File dir = new File("test-fetch-pull-single-node");
         FileUtil.removeAll(dir);
         dir.mkdir();
         NodeStarter.globalTestInit(dir, false, 
@@ -73,6 +75,11 @@ public class NodeAndClientLayerTest extends NodeAndClientLayerTestBase {
         client.fetch(uri, FILE_SIZE*2, fw, ctx, (short)0);
         FetchResult result = fw.waitForCompletion();
         assertTrue(BucketTools.equalBuckets(result.asBucket(), block.getData()));
+    }
+    
+    @After
+    public void cleanUp() {
+        FileUtil.removeAll(dir);
     }
     
 }

--- a/test/freenet/node/NodeAndClientLayerTestBase.java
+++ b/test/freenet/node/NodeAndClientLayerTestBase.java
@@ -1,0 +1,40 @@
+package freenet.node;
+
+import java.net.MalformedURLException;
+
+import freenet.client.ClientMetadata;
+import freenet.client.InsertBlock;
+import freenet.crypt.DummyRandomSource;
+import freenet.keys.FreenetURI;
+import freenet.keys.InsertableClientSSK;
+import freenet.support.SimpleReadOnlyArrayBucket;
+import freenet.support.api.RandomAccessBucket;
+
+public class NodeAndClientLayerTestBase {
+
+    static final int PORT = 2048;
+    static final int FILE_SIZE = 1024*1024;
+    
+    static RequestClient rc = new RequestClient() {
+
+        @Override
+        public boolean persistent() {
+            return false;
+        }
+
+        @Override
+        public boolean realTimeFlag() {
+            return false;
+        }
+        
+    };
+    
+    protected InsertBlock generateBlock(DummyRandomSource random) throws MalformedURLException {
+        byte[] data = new byte[FILE_SIZE];
+        random.nextBytes(data);
+        RandomAccessBucket bucket = new SimpleReadOnlyArrayBucket(data);
+        FreenetURI uri = InsertableClientSSK.createRandom(random, "test").getInsertURI();
+        return new InsertBlock(bucket, new ClientMetadata(null), uri);
+    }
+    
+}


### PR DESCRIPTION
Adds basic unit tests for the client layer when run on a single node (i.e. insert/request to datastore), including binary blobs (the data is fetched on a second node using the blob). These tests only run when -Dtest.extensive=true.