### PR TITLE
Added missing assigment for the target location of a forwarded Opennet announce request

### DIFF
--- a/src/freenet/node/AnnounceSender.java
+++ b/src/freenet/node/AnnounceSender.java
@@ -47,7 +47,7 @@ public class AnnounceSender implements PrioRunnable, ByteCounter {
 	private final int paddedLength;
 	private byte[] noderefBuf;
 	private short htl;
-	private double target;
+	private final double target;
 	private final AnnouncementCallback cb;
 	private final PeerNode onlyNode;
 	private int forwardedRefs;
@@ -62,6 +62,7 @@ public class AnnounceSender implements PrioRunnable, ByteCounter {
 		this.xferUID = xferUID;
 		this.paddedLength = paddedLength;
 		this.noderefLength = noderefLength;
+		this.target = target;
 		this.cb = cb;
 	}
 


### PR DESCRIPTION
While working with Freenet, I discovered that whenever a seed node received an 
OpennetAnnounceRequest-message for a target location X, it forwards the 
request to another opennet peer node, but always for target location 0.0 
instead.  This behavior results from the fact that the constructor of the 
AnnounceSender class does not copy the given target location 
into the "target" member variable, which will be fixed by this commit.