### PR TITLE
Remove direct calls to SubConfig constructor

### DIFF
--- a/src/freenet/clients/fcp/FCPServer.java
+++ b/src/freenet/clients/fcp/FCPServer.java
@@ -421,7 +421,7 @@ public class FCPServer implements Runnable, DownloadCache {
 
 
 	public static FCPServer maybeCreate(Node node, NodeClientCore core, Config config, PersistentRequestRoot root) throws IOException, InvalidConfigValueException {
-		SubConfig fcpConfig = new SubConfig("fcp", config);
+		SubConfig fcpConfig = config.createSubConfig("fcp");
 		short sortOrder = 0;
 		fcpConfig.register("enabled", true, sortOrder++, true, false, "FcpServer.isEnabled", "FcpServer.isEnabledLong", new FCPEnabledCallback(core));
 		fcpConfig.register("ssl", false, sortOrder++, true, true, "FcpServer.ssl", "FcpServer.sslLong", new FCPSSLCallback());

--- a/src/freenet/clients/http/SymlinkerToadlet.java
+++ b/src/freenet/clients/http/SymlinkerToadlet.java
@@ -28,7 +28,7 @@ public class SymlinkerToadlet extends Toadlet {
 	public SymlinkerToadlet(HighLevelSimpleClient client,final Node node) {
 		super(client);
 		this.node = node;
-		tslconfig = new SubConfig("toadletsymlinker", node.config);
+		tslconfig = node.config.createSubConfig("toadletsymlinker");
 		tslconfig.register("symlinks", null, 9, true, false, "SymlinkerToadlet.symlinks", "SymlinkerToadlet.symlinksLong", 
         		new StringArrCallback() {
 			@Override

--- a/src/freenet/config/Config.java
+++ b/src/freenet/config/Config.java
@@ -61,4 +61,10 @@ public class Config {
 	public synchronized SubConfig get(String subConfig){
 		return configsByPrefix.get(subConfig);
 	}
+
+	@SuppressWarnings("deprecation")
+	public SubConfig createSubConfig(String subConfig) {
+		return new SubConfig(subConfig, this);
+	}
+
 }

--- a/src/freenet/config/SubConfig.java
+++ b/src/freenet/config/SubConfig.java
@@ -38,6 +38,10 @@ public class SubConfig implements Comparable<SubConfig> {
 		});
 	}
 
+	/**
+	 * @deprecated Use {@link Config#createSubConfig(String)} instead
+	 */
+	@Deprecated
 	public SubConfig(String prefix, Config config) {
 		this.config = config;
 		this.prefix = prefix;

--- a/src/freenet/node/Node.java
+++ b/src/freenet/node/Node.java
@@ -990,8 +990,8 @@ public class Node implements TimeSkewDetectorCallback {
 		startupTime = System.currentTimeMillis();
 		SimpleFieldSet oldConfig = config.getSimpleFieldSet();
 		// Setup node-specific configuration
-		final SubConfig nodeConfig = new SubConfig("node", config);
-		final SubConfig installConfig = new SubConfig("node.install", config);
+		final SubConfig nodeConfig = config.createSubConfig("node");
+		final SubConfig installConfig = config.createSubConfig("node.install");
 
 		int sortOrder = 0;
 
@@ -1024,7 +1024,7 @@ public class Node implements TimeSkewDetectorCallback {
 		}
 
 		// FProxy config needs to be here too
-		SubConfig fproxyConfig = new SubConfig("fproxy", config);
+		SubConfig fproxyConfig = config.createSubConfig("fproxy");
 		try {
 			toadlets = new SimpleToadletServer(fproxyConfig, new ArrayBucketFactory(), executor, this);
 			fproxyConfig.finishedInitialization();
@@ -1661,7 +1661,7 @@ public class Node implements TimeSkewDetectorCallback {
 
 		failureTable = new FailureTable(this);
 
-		nodeStats = new NodeStats(this, sortOrder, new SubConfig("node.load", config), obwLimit, ibwLimit, lastVersion);
+		nodeStats = new NodeStats(this, sortOrder, config.createSubConfig("node.load"), obwLimit, ibwLimit, lastVersion);
 
 		// clientCore needs new load management and other settings from stats.
 		clientCore = new NodeClientCore(this, config, nodeConfig, installConfig, getDarknetPortNumber(), sortOrder, oldConfig, fproxyConfig, toadlets, nodeDBHandle, databaseKey, db, persistentSecret);
@@ -1686,7 +1686,7 @@ public class Node implements TimeSkewDetectorCallback {
 
 		// Opennet
 
-		final SubConfig opennetConfig = new SubConfig("node.opennet", config);
+		final SubConfig opennetConfig = config.createSubConfig("node.opennet");
 		opennetConfig.register("connectToSeednodes", true, 0, true, false, "Node.withAnnouncement", "Node.withAnnouncementLong", new BooleanCallback() {
 			@Override
 			public Boolean get() {

--- a/src/freenet/node/NodeStarter.java
+++ b/src/freenet/node/NodeStarter.java
@@ -135,7 +135,7 @@ public class NodeStarter implements WrapperListener {
 		}
 
 		// First, set up logging. It is global, and may be shared between several nodes.
-		SubConfig loggingConfig = new SubConfig("logger", cfg);
+		SubConfig loggingConfig = cfg.createSubConfig("logger");
 
 		PooledExecutor executor = new PooledExecutor();
 
@@ -187,7 +187,7 @@ public class NodeStarter implements WrapperListener {
 		plug.start();
 
 		// Initialize SSL
-		SubConfig sslConfig = new SubConfig("ssl", cfg);
+		SubConfig sslConfig = cfg.createSubConfig("ssl");
 		SSL.init(sslConfig);
 
 		try {

--- a/src/freenet/node/RequestStarterGroup.java
+++ b/src/freenet/node/RequestStarterGroup.java
@@ -69,7 +69,7 @@ public class RequestStarterGroup {
 
 	private final NodeStats stats;
 	RequestStarterGroup(Node node, NodeClientCore core, int portNumber, RandomSource random, Config config, SimpleFieldSet fs, ClientContext ctx, long dbHandle) throws InvalidConfigValueException {
-		SubConfig schedulerConfig = new SubConfig("node.scheduler", config);
+		SubConfig schedulerConfig = config.createSubConfig("node.scheduler");
 		this.stats = core.nodeStats;
 		
 		throttleWindowBulk = new ThrottleWindowManager(2.0, fs == null ? null : fs.subset("ThrottleWindow"), node);

--- a/src/freenet/node/SecurityLevels.java
+++ b/src/freenet/node/SecurityLevels.java
@@ -67,7 +67,7 @@ public class SecurityLevels {
 	
 	public SecurityLevels(Node node, PersistentConfig config) {
 		this.node = node;
-		SubConfig myConfig = new SubConfig("security-levels", config);
+		SubConfig myConfig = config.createSubConfig("security-levels");
 		int sortOrder = 0;
 		networkThreatLevelCallback = new MyCallback<NETWORK_THREAT_LEVEL>() {
 

--- a/src/freenet/node/TextModeClientInterfaceServer.java
+++ b/src/freenet/node/TextModeClientInterfaceServer.java
@@ -64,7 +64,7 @@ public class TextModeClientInterfaceServer implements Runnable {
 
 		TextModeClientInterfaceServer server = null;
 
-		SubConfig TMCIConfig = new SubConfig("console", config);
+		SubConfig TMCIConfig = config.createSubConfig("console");
 
 		TMCIConfig.register("enabled", false, 1, true, true /* FIXME only because can't be changed on the fly */, "TextModeClientInterfaceServer.enabled", "TextModeClientInterfaceServer.enabledLong", new TMCIEnabledCallback(core));
 		TMCIConfig.register("ssl", false, 1, true, true , "TextModeClientInterfaceServer.ssl", "TextModeClientInterfaceServer.sslLong", new TMCISSLCallback());

--- a/src/freenet/node/updater/NodeUpdateManager.java
+++ b/src/freenet/node/updater/NodeUpdateManager.java
@@ -223,7 +223,7 @@ public class NodeUpdateManager {
 		this.alert = new UpdatedVersionAvailableUserAlert(this);
 		alert.isValid(false);
 
-		SubConfig updaterConfig = new SubConfig("node.updater", config);
+		SubConfig updaterConfig = config.createSubConfig("node.updater");
 
 		updaterConfig.register("enabled", true, 1, false, false,
 				"NodeUpdateManager.enabled", "NodeUpdateManager.enabledLong",

--- a/src/freenet/pluginmanager/PluginInfoWrapper.java
+++ b/src/freenet/pluginmanager/PluginInfoWrapper.java
@@ -78,7 +78,7 @@ public class PluginInfoWrapper implements Comparable<PluginInfoWrapper> {
 		if(isConfigurablePlugin) {
 			config = FilePersistentConfig.constructFilePersistentConfig(new File(node.getCfgDir(), "plugin-"+getPluginClassName()+".ini"),
 			             "config options for plugin: "+getPluginClassName());
-			subconfig = new SubConfig(getPluginClassName(), config);
+			subconfig = config.createSubConfig(getPluginClassName());
 			((FredPluginConfigurable)plug).setupConfig(subconfig);
 			config.finishedInit();
 			configToadlet = new ConfigToadlet(pr.getHLSimpleClient(), config, subconfig, node, node.clientCore, (FredPluginConfigurable)plug);

--- a/src/freenet/pluginmanager/PluginManager.java
+++ b/src/freenet/pluginmanager/PluginManager.java
@@ -127,7 +127,7 @@ public class PluginManager {
 		executor = new SerialExecutor(NativeThread.NORM_PRIORITY);
 		executor.start(node.executor, "PM callback executor");
 
-		pmconfig = new SubConfig("pluginmanager", node.config);
+		pmconfig = node.config.createSubConfig("pluginmanager");
 //		pmconfig.register("configfile", "fplugins.ini", 9, true, true, "PluginConfig.configFile", "PluginConfig.configFileLong",
 //				new StringCallback() {
 //			public String get() {

--- a/test/freenet/config/ConfigTest.java
+++ b/test/freenet/config/ConfigTest.java
@@ -35,7 +35,7 @@ public class ConfigTest extends TestCase {
 	protected void setUp() throws Exception {
 		super.setUp();
 		conf = new Config();
-		sc = new SubConfig("testing", conf);
+		sc = conf.createSubConfig("testing");
 	}
 	
 	public void testConfig() {
@@ -49,8 +49,8 @@ public class ConfigTest extends TestCase {
 			sb.append(UTFUtil.PRINTABLE_ASCII[i]);
 		for(int i=0; i< UTFUtil.STRESSED_UTF.length; i++)
 			sb.append(UTFUtil.STRESSED_UTF[i]);
-		assertNotNull(new SubConfig(sb.toString(), conf));
-		
+		assertNotNull(conf.createSubConfig(sb.toString()));
+
 		/* test if it prevents multiple registrations */
 		try{
 			conf.register(sc);


### PR DESCRIPTION
This makes it easier to mock configs and subconfigs once we
get around to unit testing.