### PR TITLE
Wait for running transfers to complete when a FNPRouteNotFound-message arrived in the meantime

### DIFF
--- a/src/freenet/node/AnnounceSender.java
+++ b/src/freenet/node/AnnounceSender.java
@@ -483,16 +483,18 @@ public class AnnounceSender implements PrioRunnable, ByteCounter {
 		if(cb != null) cb.nodeFailed(next, "timed out");
 	}
 
+        private synchronized void waitForRunningTransfers() {
+           while(waitingForTransfers > 0) {
+              try {
+                 wait();
+              } catch (InterruptedException e) {
+                 // Ignore.
+              }
+           }
+        }
+
 	private void rnf(PeerNode next) {
-		synchronized(this) {
-			while(waitingForTransfers > 0) {
-				try {
-					wait();
-				} catch (InterruptedException e) {
-					// Ignore.
-				}
-			}
-		}
+		waitForRunningTransfers();
 		Message msg = DMT.createFNPRouteNotFound(uid, htl);
 		if(source != null) {
 			try {
@@ -508,15 +510,7 @@ public class AnnounceSender implements PrioRunnable, ByteCounter {
 	}
 
 	private void complete() {
-		synchronized(this) {
-			while(waitingForTransfers > 0) {
-				try {
-					wait();
-				} catch (InterruptedException e) {
-					// Ignore.
-				}
-			}
-		}
+		waitForRunningTransfers();
 		Message msg = DMT.createFNPOpennetAnnounceCompleted(uid);
 		if(source != null) {
 			try {

--- a/src/freenet/node/AnnounceSender.java
+++ b/src/freenet/node/AnnounceSender.java
@@ -484,6 +484,15 @@ public class AnnounceSender implements PrioRunnable, ByteCounter {
 	}
 
 	private void rnf(PeerNode next) {
+		synchronized(this) {
+			while(waitingForTransfers > 0) {
+				try {
+					wait();
+				} catch (InterruptedException e) {
+					// Ignore.
+				}
+			}
+		}
 		Message msg = DMT.createFNPRouteNotFound(uid, htl);
 		if(source != null) {
 			try {


### PR DESCRIPTION
I encountered this problem while running Freenet in an isolated local testbed, where each opennet announcement ran into a dead end quite quickly. Although latter is not a problem, it resulted in the propagation of a FNPRouteNotFound-message while the transmission of the noderef from a replying node was still running. This commit keeps running noderef-transfers from being aborted in such cases.