### PR TITLE
Avoid claiming of unrejected messages by NodeDispatcher

### DIFF
--- a/src/freenet/node/NodeDispatcher.java
+++ b/src/freenet/node/NodeDispatcher.java
@@ -234,6 +234,8 @@ public class NodeDispatcher implements Dispatcher, Runnable {
 				rejectRequest(m, node.nodeStats.sskInsertCtr);
 			} else if(spec == DMT.FNPGetOfferedKey) {
 				rejectRequest(m, node.failureTable.senderCounter);
+			} else {
+				return false;
 			}
 			return true;
 		}


### PR DESCRIPTION
As a result of [commit f3e3be4](https://github.com/freenet/fred/commit/f3e3be45698272db462ae45f784ff4049c692e92), messages received from an unroutable source may be claimed as matched although they actually weren't rejected or otherwise processed. This behavior led to the failure of noderef-transmissions from seed nodes to a new opennet node, if the first transfer message arrived before the corresponding receiver thread started. This commit ensures that unhandled messages are kept marked as unmatched.