### PR TITLE
Store updated seednodes.fref in nodeDir, not userDir

### DIFF
--- a/src/freenet/clients/http/ConnectionsToadlet.java
+++ b/src/freenet/clients/http/ConnectionsToadlet.java
@@ -32,6 +32,7 @@ import freenet.node.DarknetPeerNode.FRIEND_TRUST;
 import freenet.node.FSParseException;
 import freenet.node.Node;
 import freenet.node.NodeClientCore;
+import freenet.node.NodeFile;
 import freenet.node.NodeStats;
 import freenet.node.PeerManager;
 import freenet.node.PeerNode;
@@ -989,7 +990,7 @@ public abstract class ConnectionsToadlet extends Toadlet {
 		}
 		HTMLNode addressRow = peerRow.addChild("td", "class", "peer-address");
 		// Ip to country + Flags
-		IPConverter ipc = IPConverter.getInstance(node.runDir().file(NodeUpdateManager.IPV4_TO_COUNTRY_FILENAME));
+		IPConverter ipc = IPConverter.getInstance(NodeFile.IPv4ToCountry.getFile(node));
 		byte[] addr = peerNodeStatus.getPeerAddressBytes();
 
 		Country country = ipc.locateIP(addr);

--- a/src/freenet/clients/http/DarknetAddRefToadlet.java
+++ b/src/freenet/clients/http/DarknetAddRefToadlet.java
@@ -7,6 +7,7 @@ import java.net.URI;
 import freenet.client.HighLevelSimpleClient;
 import freenet.l10n.NodeL10n;
 import freenet.node.Node;
+import freenet.node.NodeFile;
 import freenet.node.updater.NodeUpdateManager;
 import freenet.support.HTMLNode;
 import freenet.support.SimpleFieldSet;
@@ -29,7 +30,7 @@ public class DarknetAddRefToadlet extends Toadlet {
             return;
 		
 		String path = uri.getPath();
-		if(path.endsWith(NodeUpdateManager.WINDOWS_FILENAME)) {
+		if(path.endsWith(NodeFile.InstallerWindows.getFilename())) {
 			File installer = node.nodeUpdater.getInstallerWindows();
 			if(installer != null) {
 				FileBucket bucket = new FileBucket(installer, true, false, false, false);
@@ -38,7 +39,7 @@ public class DarknetAddRefToadlet extends Toadlet {
 			}
 		}
 		
-		if(path.endsWith(NodeUpdateManager.NON_WINDOWS_FILENAME)) {
+		if(path.endsWith(NodeFile.InstallerNonWindows.getFilename())) {
 			File installer = node.nodeUpdater.getInstallerNonWindows();
 			if(installer != null) {
 				FileBucket bucket = new FileBucket(installer, true, false, false, false);
@@ -60,7 +61,7 @@ public class DarknetAddRefToadlet extends Toadlet {
 		boxContent.addChild("p", l10n("explainBox2"));
 				
 		File installer = node.nodeUpdater.getInstallerWindows();
-		String shortFilename = NodeUpdateManager.WINDOWS_FILENAME;
+		String shortFilename = NodeFile.InstallerWindows.getFilename();
 		
 		HTMLNode p = boxContent.addChild("p");
 		
@@ -71,7 +72,7 @@ public class DarknetAddRefToadlet extends Toadlet {
 			NodeL10n.getBase().addL10nSubstitution(p, "DarknetAddRefToadlet.explainInstallerWindowsNotYet", new String[] { "link" }, new HTMLNode[] { HTMLNode.link("/"+node.nodeUpdater.getInstallerWindowsURI().toString()) });
 		
 		installer = node.nodeUpdater.getInstallerNonWindows();
-		shortFilename = NodeUpdateManager.NON_WINDOWS_FILENAME;
+		shortFilename = NodeFile.InstallerNonWindows.getFilename();
 		
 		boxContent.addChild("#", " ");
 		

--- a/src/freenet/node/Announcer.java
+++ b/src/freenet/node/Announcer.java
@@ -65,7 +65,6 @@ public class Announcer {
 	/** Do not announce if there are more than this many opennet peers connected */
 	private static final int MIN_OPENNET_CONNECTED_PEERS = 10;
 	private static final long NOT_ALL_CONNECTED_DELAY = SECONDS.toMillis(60);
-	public static final String SEEDNODES_FILENAME = "seednodes.fref";
 	private static final long RETRY_MISSING_SEEDNODES_DELAY = SECONDS.toMillis(30);
 	/** Total nodes added by announcement so far */
 	private int announcementAddedNodes;
@@ -123,7 +122,7 @@ public class Announcer {
 		boolean announceNow = false;
 		if(logMINOR)
 			Logger.minor(this, "Connecting some seednodes...");
-		List<SimpleFieldSet> seeds = Announcer.readSeednodes(node.nodeDir().file(SEEDNODES_FILENAME));
+		List<SimpleFieldSet> seeds = Announcer.readSeednodes(NodeFile.Seednodes.getFile(node));
 		System.out.println("Trying to connect to "+seeds.size()+" seednodes...");
 		long now = System.currentTimeMillis();
 		synchronized(this) {

--- a/src/freenet/node/NodeFile.java
+++ b/src/freenet/node/NodeFile.java
@@ -8,38 +8,38 @@ import java.io.File;
 public enum NodeFile {
     Seednodes(InstallDirectory.Node, "seednodes.fref"),
     InstallerWindows(InstallDirectory.Run, "freenet-latest-installer-windows.exe"),
-	InstallerNonWindows(InstallDirectory.Run, "freenet-latest-installer-nonwindows.jar"),
-	IPv4ToCountry(InstallDirectory.Run, "IpToCountry.dat");
+    InstallerNonWindows(InstallDirectory.Run, "freenet-latest-installer-nonwindows.jar"),
+    IPv4ToCountry(InstallDirectory.Run, "IpToCountry.dat");
 
     private final InstallDirectory dir;
     private final String filename;
-    
+
     /**
      * Gets the absolute file path associated with this file for the given node instance.
      */
     public File getFile(Node node) {
         return dir.getDir(node).file(filename);
     }
-    
+
     /**
      * Gets the filename associated with this file.
      */
     public String getFilename() {
         return filename;
     }
-    
+
     /**
      * Gets the base directory with this file for the given node instance.
      */
     public ProgramDirectory getProgramDirectory(Node node) {
         return dir.getDir(node);
     }
-    
+
     private NodeFile(InstallDirectory dir, String filename) {
         this.dir = dir;
         this.filename = filename;
     }
-    
+
     private enum InstallDirectory {
         // node.install.nodeDir
         Node() {
@@ -83,7 +83,7 @@ public enum NodeFile {
                 return node.pluginDir();
             }
         };
-        
+
         abstract ProgramDirectory getDir(Node node);
     }
 }

--- a/src/freenet/node/NodeFile.java
+++ b/src/freenet/node/NodeFile.java
@@ -1,0 +1,89 @@
+package freenet.node;
+
+import java.io.File;
+
+/**
+ * Mapping of files managed by the node to their respective locations.
+ */
+public enum NodeFile {
+    Seednodes(InstallDirectory.Node, "seednodes.fref"),
+    InstallerWindows(InstallDirectory.Run, "freenet-latest-installer-windows.exe"),
+	InstallerNonWindows(InstallDirectory.Run, "freenet-latest-installer-nonwindows.jar"),
+	IPv4ToCountry(InstallDirectory.Run, "IpToCountry.dat");
+
+    private final InstallDirectory dir;
+    private final String filename;
+    
+    /**
+     * Gets the absolute file path associated with this file for the given node instance.
+     */
+    public File getFile(Node node) {
+        return dir.getDir(node).file(filename);
+    }
+    
+    /**
+     * Gets the filename associated with this file.
+     */
+    public String getFilename() {
+        return filename;
+    }
+    
+    /**
+     * Gets the base directory with this file for the given node instance.
+     */
+    public ProgramDirectory getProgramDirectory(Node node) {
+        return dir.getDir(node);
+    }
+    
+    private NodeFile(InstallDirectory dir, String filename) {
+        this.dir = dir;
+        this.filename = filename;
+    }
+    
+    private enum InstallDirectory {
+        // node.install.nodeDir
+        Node() {
+            @Override
+            ProgramDirectory getDir(Node node) {
+                return node.nodeDir();
+            }
+        },
+        // node.install.cfgDir
+        Cfg() {
+            @Override
+            ProgramDirectory getDir(Node node) {
+                return node.cfgDir();
+            }
+        },
+        // node.install.userDir
+        User() {
+            @Override
+            ProgramDirectory getDir(Node node) {
+                return node.userDir();
+            }
+        },
+        // node.install.runDir
+        Run() {
+            @Override
+            ProgramDirectory getDir(Node node) {
+                return node.runDir();
+            }
+        },
+        // node.install.storeDir
+        Store() {
+            @Override
+            ProgramDirectory getDir(Node node) {
+                return node.storeDir();
+            }
+        },
+        // node.install.pluginDir
+        Plugin() {
+            @Override
+            ProgramDirectory getDir(Node node) {
+                return node.pluginDir();
+            }
+        };
+        
+        abstract ProgramDirectory getDir(Node node);
+    }
+}

--- a/src/freenet/node/simulator/SeednodePingTest.java
+++ b/src/freenet/node/simulator/SeednodePingTest.java
@@ -27,6 +27,7 @@ import freenet.io.comm.ReferenceSignatureVerificationException;
 import freenet.node.Announcer;
 import freenet.node.FSParseException;
 import freenet.node.Node;
+import freenet.node.NodeFile;
 import freenet.node.NodeInitException;
 import freenet.node.NodeStarter;
 import freenet.node.OpennetDisabledException;
@@ -63,7 +64,7 @@ public class SeednodePingTest extends RealNodeTest {
 	node = NodeStarter.createTestNode(DARKNET_PORT, OPENNET_PORT, "seednode-pingtest", false, Node.DEFAULT_MAX_HTL, 0, random, executor, 1000, 5*1024*1024, true, false, false, false, false, false, false, 0, false, false, false, false, null);
 	// Connect & ping
 	List<SeedServerTestPeerNode> seedNodes = new ArrayList<SeedServerTestPeerNode>();
-	List<SimpleFieldSet> seedNodesAsSFS = Announcer.readSeednodes(new File("/tmp/", Announcer.SEEDNODES_FILENAME));
+	List<SimpleFieldSet> seedNodesAsSFS = Announcer.readSeednodes(new File("/tmp/", NodeFile.Seednodes.getFilename()));
 	int numberOfNodesInTheFile = 0;
 	for(SimpleFieldSet sfs : seedNodesAsSFS) {
 		numberOfNodesInTheFile++;

--- a/src/freenet/node/updater/NodeUpdateManager.java
+++ b/src/freenet/node/updater/NodeUpdateManager.java
@@ -32,6 +32,7 @@ import freenet.l10n.NodeL10n;
 import freenet.node.Announcer;
 import freenet.node.Node;
 import freenet.node.NodeInitException;
+import freenet.node.NodeFile;
 import freenet.node.NodeStarter;
 import freenet.node.OpennetManager;
 import freenet.node.PeerNode;
@@ -372,11 +373,11 @@ public class NodeUpdateManager {
 		final String filename;
 		final ProgramDirectory directory;
 
-		public SimplePuller(FreenetURI freenetURI, String filename) {
-		    this(freenetURI, filename, node.runDir());
+		public SimplePuller(FreenetURI freenetURI, NodeFile file) {
+		    this(freenetURI, file.getFilename(), file.getProgramDirectory(node));
 		}
 
-		public SimplePuller(FreenetURI freenetURI, String filename, ProgramDirectory directory) {
+		private SimplePuller(FreenetURI freenetURI, String filename, ProgramDirectory directory) {
 			this.freenetURI = freenetURI;
 			this.filename = filename;
 			this.directory = directory;
@@ -463,12 +464,8 @@ public class NodeUpdateManager {
 
 	}
 
-	public static final String WINDOWS_FILENAME = "freenet-latest-installer-windows.exe";
-	public static final String NON_WINDOWS_FILENAME = "freenet-latest-installer-nonwindows.jar";
-	public static final String IPV4_TO_COUNTRY_FILENAME = "IpToCountry.dat";
-
 	public File getInstallerWindows() {
-		File f = node.runDir().file(WINDOWS_FILENAME);
+		File f = NodeFile.InstallerWindows.getFile(node);
 		if (!(f.exists() && f.canRead() && f.length() > 0))
 			return null;
 		else
@@ -476,7 +473,7 @@ public class NodeUpdateManager {
 	}
 
 	public File getInstallerNonWindows() {
-		File f = node.runDir().file(NON_WINDOWS_FILENAME);
+		File f = NodeFile.InstallerNonWindows.getFile(node);
 		if (!(f.exists() && f.canRead() && f.length() > 0))
 			return null;
 		else
@@ -488,12 +485,12 @@ public class NodeUpdateManager {
 				"seednodes-" + Version.buildNumber());
 	}
 
-	public FreenetURI getInstallerWindowsURI() {
+	public FreenetURI getInstallerNonWindowsURI() {
 		return updateURI.sskForUSK().setDocName(
 				"installer-" + Version.buildNumber());
 	}
 
-	public FreenetURI getInstallerNonWindowsURI() {
+	public FreenetURI getInstallerWindowsURI() {
 		return updateURI.sskForUSK().setDocName(
 				"wininstaller-" + Version.buildNumber());
 	}
@@ -513,7 +510,7 @@ public class NodeUpdateManager {
 		if (updateSeednodes) {
 
 			SimplePuller seedrefsGetter = new SimplePuller(getSeednodesURI(),
-					Announcer.SEEDNODES_FILENAME, node.nodeDir());
+					NodeFile.Seednodes);
 			seedrefsGetter.start(
 					RequestStarter.IMMEDIATE_SPLITFILE_PRIORITY_CLASS,
 					1024 * 1024);
@@ -522,9 +519,9 @@ public class NodeUpdateManager {
 		// Fetch installers and IP-to-country files to the runDir.
 		if (updateInstallers) {
 			SimplePuller installerGetter = new SimplePuller(
-					getInstallerWindowsURI(), NON_WINDOWS_FILENAME);
+					getInstallerNonWindowsURI(), NodeFile.InstallerNonWindows);
 			SimplePuller wininstallerGetter = new SimplePuller(
-					getInstallerNonWindowsURI(), WINDOWS_FILENAME);
+					getInstallerWindowsURI(), NodeFile.InstallerWindows);
 
 			installerGetter.start(RequestStarter.UPDATE_PRIORITY_CLASS,
 					32 * 1024 * 1024);
@@ -535,7 +532,7 @@ public class NodeUpdateManager {
 
 		if (updateIPToCountry) {
 			SimplePuller ip4Getter = new SimplePuller(getIPv4ToCountryURI(),
-					IPV4_TO_COUNTRY_FILENAME);
+					NodeFile.IPv4ToCountry);
 			ip4Getter.start(RequestStarter.UPDATE_PRIORITY_CLASS,
 					8 * 1024 * 1024);
 		}


### PR DESCRIPTION
`seednodes.fred` is read from the `nodeDir` by the `Announcer`, so we should
store it there as well when we fetch the current version.

This should fix [bug 6684](https://bugs.freenetproject.org/view.php?id=6684).