### PR TITLE
Make seednodes.fref parsing more robust

### DIFF
--- a/src/freenet/node/Announcer.java
+++ b/src/freenet/node/Announcer.java
@@ -277,9 +277,15 @@ public class Announcer {
 						list.add(fs);
 				} catch (EOFException e) {
 					return list;
+				} catch (IOException e) {
+					Logger.error(Announcer.class, "Error while reading seednodes from " + file, e);
+					// Continue reading. If this entry failed, we still want the following noderefs.
+					// However, read a line to prevent us getting stuck in an endless loop.
+					br.readLine();
 				}
 			}
 		} catch (IOException e) {
+			Logger.error(Announcer.class, "Unexpected error while reading seednodes from " + file, e);
 			return list;
 		} finally {
 			Closer.close(fis);

--- a/src/freenet/node/Announcer.java
+++ b/src/freenet/node/Announcer.java
@@ -280,7 +280,7 @@ public class Announcer {
 				} catch (IOException e) {
 					Logger.error(Announcer.class, "Error while reading seednodes from " + file, e);
 					// Continue reading. If this entry failed, we still want the following noderefs.
-					// However, read a line to prevent us getting stuck in an endless loop.
+					// Read a line to advance the parsing position and avoid an endless loop.
 					br.readLine();
 				}
 			}


### PR DESCRIPTION
Always log errors when we fail to parse the seednodes file. If we fail
on one entry, now read to the end of the line and proceed parsing
instead of bailing out prematurely.