### PR TITLE
Cooldown fixes

### DIFF
--- a/src/freenet/client/async/ClientRequestSelector.java
+++ b/src/freenet/client/async/ClientRequestSelector.java
@@ -201,7 +201,7 @@ public class ClientRequestSelector implements KeysFetchingLocally {
 			SelectorReturn r = chooseRequestInner(fuzz, random, offeredKeys, starter, realTime, context, now);
             SendableRequest req = r.req;
 			if(req == null) {
-			    if(r.wakeupTime != Long.MAX_VALUE) {
+			    if(r.wakeupTime != Long.MAX_VALUE && r.wakeupTime > now) {
 			        // Wake up later.
 			        sched.clientContext.ticker.queueTimedJob(new Runnable() {
 			            

--- a/src/freenet/client/async/ClientRequestSelector.java
+++ b/src/freenet/client/async/ClientRequestSelector.java
@@ -306,7 +306,7 @@ public class ClientRequestSelector implements KeysFetchingLocally {
 		long l = choosePriority(fuzz, random, context, now);
 		if(l > Integer.MAX_VALUE) {
 			if(logMINOR) Logger.minor(this, "No priority available for the next "+TimeUtil.formatTime(l - now));
-			return null;
+			return new SelectorReturn(l);
 		}
 		int choosenPriorityClass = (int)l;
 		if(choosenPriorityClass == -1) {
@@ -316,7 +316,8 @@ public class ClientRequestSelector implements KeysFetchingLocally {
 			}
 			if(logMINOR)
 				Logger.minor(this, "Nothing to do");
-			return null;
+			// No requests queued at all.
+			return new SelectorReturn(Long.MAX_VALUE);
 		}
 		long wakeupTime = Long.MAX_VALUE;
 outer:	for(;choosenPriorityClass <= RequestStarter.MINIMUM_FETCHABLE_PRIORITY_CLASS;choosenPriorityClass++) {
@@ -438,7 +439,7 @@ outer:	for(;choosenPriorityClass <= RequestStarter.MINIMUM_FETCHABLE_PRIORITY_CL
 			}
 		}
 		if(logMINOR) Logger.minor(this, "No requests to run");
-		return null;
+		return new SelectorReturn(wakeupTime);
 	}
 	
 	private static final short[] tweakedPrioritySelector = { 

--- a/src/freenet/client/async/ClientRequestSelector.java
+++ b/src/freenet/client/async/ClientRequestSelector.java
@@ -199,9 +199,21 @@ public class ClientRequestSelector implements KeysFetchingLocally {
 		long now = System.currentTimeMillis();
 		for(int i=0;i<5;i++) {
 			SelectorReturn r = chooseRequestInner(fuzz, random, offeredKeys, starter, realTime, context, now);
-			SendableRequest req = null;
-			if(r != null && r.req != null) req = r.req;
-			if(req == null) continue;
+            SendableRequest req = r.req;
+			if(req == null) {
+			    if(r.wakeupTime != Long.MAX_VALUE) {
+			        // Wake up later.
+			        sched.clientContext.ticker.queueTimedJob(new Runnable() {
+			            
+			            @Override
+			            public void run() {
+			                sched.wakeStarter();
+			            }
+			            
+			        }, r.wakeupTime - now);
+			    }
+			    continue;
+			}
 			if(isInsertScheduler && req instanceof SendableGet) {
 				IllegalStateException e = new IllegalStateException("removeFirstInner returned a SendableGet on an insert scheduler!!");
 				req.internalError(e, sched, context, req.persistent());
@@ -220,6 +232,8 @@ public class ClientRequestSelector implements KeysFetchingLocally {
 			return null;
 		}
 		if(req.getWakeupTime(context, now) != 0) {
+		    // Race condition. We don't need to add a wake-up job. FIXME this shouldn't happen 
+		    // because we only consider local requests of the same type?! Add logging and debug!
 			if(logMINOR) Logger.minor(this, "Request is in cooldown: "+req);
 			return null;
 		}

--- a/src/freenet/node/RequestStarter.java
+++ b/src/freenet/node/RequestStarter.java
@@ -199,8 +199,7 @@ public class RequestStarter implements Runnable, RandomGrabArrayItemExclusionLis
 					req = sched.grabRequest();
 					if(req == null) {
 						try {
-							wait(SECONDS.toMillis(1)); // this can happen when most but not all stuff is already running but there is still stuff to fetch, so don't wait *too* long.
-							// FIXME increase when we can be *sure* there is nothing left in the queue (especially for transient requests).
+							wait();
 						} catch (InterruptedException e) {
 							// Ignore
 						}


### PR DESCRIPTION
This was planned long ago but apparently never implemented. It should make cooldown requests more reliable, and removes the need for the arbitrary wait(1000) in RequestStarter. It may also make #524 viable, or something more ambitious and less ugly.