### PR TITLE
Fix fcp blob downloading

### DIFF
--- a/src/freenet/client/async/BinaryBlobWriter.java
+++ b/src/freenet/client/async/BinaryBlobWriter.java
@@ -61,6 +61,7 @@ public final class BinaryBlobWriter {
 		_binaryBlobKeysAddedAlready = new HashSet<Key>();
 		_buckets = null;
 		_bf = null;
+		assert out != null;
 		_out = out;
 		_isSingleBucket = true;
 	}

--- a/src/freenet/clients/fcp/ClientGet.java
+++ b/src/freenet/clients/fcp/ClientGet.java
@@ -359,7 +359,7 @@ public class ClientGet extends ClientRequest implements ClientGetCallback, Clien
 	@Override
 	public void onSuccess(FetchResult result, ClientGetter state) {
 		Logger.minor(this, "Succeeded: "+identifier);
-		Bucket data = result.asBucket();
+		Bucket data = binaryBlob ? state.getBlobBucket() : result.asBucket();
 		synchronized(this) {
 			if(succeeded) {
 				Logger.error(this, "onSuccess called twice for "+this+" ("+identifier+ ')');

--- a/src/freenet/clients/fcp/ClientGet.java
+++ b/src/freenet/clients/fcp/ClientGet.java
@@ -205,7 +205,7 @@ public class ClientGet extends ClientRequest implements ClientGetCallback, Clien
 		}
 		this.extensionCheck = extensionCheck;
 		this.initialMetadata = null;
-		getter = makeGetter(ret);
+		getter = makeGetter(core, ret);
 	}
 
 	public ClientGet(FCPConnectionHandler handler, ClientGetMessage message, 
@@ -265,10 +265,25 @@ public class ClientGet extends ClientRequest implements ClientGetCallback, Clien
 		}
 		this.extensionCheck = extensionCheck;
 		initialMetadata = message.getInitialMetadata();
-		getter = makeGetter(ret);
+        try {
+            getter = makeGetter(core, ret);
+        } catch (IOException e) {
+            Logger.error(this, "Cannot create bucket for temporary storage: "+e, e);
+            // This is *not* a FetchException since we don't register it: it's a protocol error.
+            throw new MessageInvalidException(ProtocolErrorMessage.INTERNAL_ERROR,
+                    "Cannot create bucket for temporary storage (out of disk space?): " + e, identifier, global);
+        }
 	}
-	
-	private ClientGetter makeGetter(Bucket ret) {
+
+    private ClientGetter makeGetter(Bucket ret) throws IOException {
+        return makeGetter(null, ret);
+    }
+
+    private ClientGetter makeGetter(NodeClientCore core, Bucket ret) throws IOException {
+        if (binaryBlob && ret == null) {
+            ret = core.clientContext.getBucketFactory(persistence == Persistence.FOREVER).makeBucket(fctx.maxOutputLength);
+        }
+
 	    return new ClientGetter(this,
                 uri, fctx, priorityClass,
                 binaryBlob ? new NullBucket() : ret, binaryBlob ? new BinaryBlobWriter(ret) : null, false, initialMetadata, extensionCheck);


### PR DESCRIPTION
This is based on #495 and creates the bucket in makeGetter() instead of at two of its callers. It works in my testing - I get hangs when fetching blobs on 1472 where it only writes what seems to be a header to disk. With these changes applied I get a much larger blob back.

    00000000  6d 58 24 9f 72 d6 7e d9  00 00 00 00 00 00 00 02  |mX$.r.~.........|
    00000010  00 00                                             |..|
    00000012
