### PR TITLE
DSA: remove inaccurate comments

### DIFF
--- a/src/freenet/crypt/DSA.java
+++ b/src/freenet/crypt/DSA.java
@@ -14,12 +14,6 @@ import freenet.support.Logger;
  * Implements the Digital Signature Algorithm (DSA) described in FIPS-186
  *
  * This is legacy and largely deprecated. You shouldn't be using it for new code
- * Several concerns:
- *  - we have no idea of where the DSA group came from
- *  - until recently the code wasn't using deterministic signatures
- *      (and we're not sure about the PRNG either!)
- *  - the group is *way* too small (1024bits)
- *  - the signature masking thingy is dodgy
  */
 public class DSA {
 


### PR DESCRIPTION
Eleriseth@WPECGLtYbVi8Rl6Y7Vzl2Lvd2EUVW99v3yNV3IWROG8.fms [posted](http://127.0.0.1:8888/SSK%40WPECGLtYbVi8Rl6Y7Vzl2Lvd2EUVW99v3yNV3IWROG8%2CMnwtfrASwEUVgXVCxNALLwCKqe6woGt3biDRVcBulkk%2CAQACAAE/fms%7C2016%2D04%2D18%7CMessage%2D0?type=text/plain) this:

> As I pointed out many times, this is a *2048*-bit group, not a *1024*-bit group.
> As for origin, ask toad. I verified that at least p and q was generated using modified FIPS procedure from specified seed (was not able to reproduce g yet, but at least it passes partial validation).
> As for "signature masking", while it seems totally unnecessary (e.g. FIPS 186-4 is happy with truncating it at upper byte boundary), it does not break anything either.
> As for "deterministic signatures", they are not used by most mainstream libraries either.
Any concern about PRNG quality affects a lot more than DSA, there are no point to single it out.