### PR TITLE
Fix uncompleted uploads being treated as failed in queue

### DIFF
--- a/src/freenet/clients/http/QueueToadlet.java
+++ b/src/freenet/clients/http/QueueToadlet.java
@@ -121,8 +121,8 @@ public class QueueToadlet extends Toadlet implements RequestCompletionCallback, 
 		FailedBadMIMEType(false, true, false),
 		FailedUnknownMIMEType(false, true, false),
 		UncompletedDownload(false, false, false),
-		UncompletedUpload(false, true, true),
-		UncompletedDirUpload(false, true, true);
+		UncompletedUpload(false, false, true),
+		UncompletedDirUpload(false, false, true);
 
 		final boolean isCompleted;
 		final boolean isFailed;


### PR DESCRIPTION
This fixes a regression introduced in
c11c5a93a7299eb63c2b1110e07df694bddaf04c (#513) that lead to the absence of
the priority buttons and presence of the restart button, for all
uncompleted uploads.