### PR TITLE
FIX: on too low bandwidth, use min bandwidth

### DIFF
--- a/src/freenet/node/Node.java
+++ b/src/freenet/node/Node.java
@@ -1582,6 +1582,10 @@ public class Node implements TimeSkewDetectorCallback {
 		});
 
 		int obwLimit = nodeConfig.getInt("outputBandwidthLimit");
+		if (obwLimit < minimumBandwidth) {
+			obwLimit = minimumBandwidth; // upgrade slow nodes automatically
+		}
+
 		outputBandwidthLimit = obwLimit;
 		try {
 			checkOutputBandwidthLimit(outputBandwidthLimit);
@@ -1636,6 +1640,9 @@ public class Node implements TimeSkewDetectorCallback {
 		if(ibwLimit == -1) {
 			inputLimitDefault = true;
 			ibwLimit = obwLimit * 4;
+		}
+		else if (ibwLimit < minimumBandwidth) {
+			ibwLimit = minimumBandwidth; // upgrade slow nodes automatically
 		}
 		inputBandwidthLimit = ibwLimit;
 		try {

--- a/src/freenet/node/Node.java
+++ b/src/freenet/node/Node.java
@@ -1584,6 +1584,7 @@ public class Node implements TimeSkewDetectorCallback {
 		int obwLimit = nodeConfig.getInt("outputBandwidthLimit");
 		if (obwLimit < minimumBandwidth) {
 			obwLimit = minimumBandwidth; // upgrade slow nodes automatically
+			Logger.normal(Node.class, "Output bandwidth was lower than minimum bandwidth. Increased to minimum bandwidth.");
 		}
 
 		outputBandwidthLimit = obwLimit;
@@ -1643,6 +1644,7 @@ public class Node implements TimeSkewDetectorCallback {
 		}
 		else if (ibwLimit < minimumBandwidth) {
 			ibwLimit = minimumBandwidth; // upgrade slow nodes automatically
+			Logger.normal(Node.class, "Input bandwidth was lower than minimum bandwidth. Increased to minimum bandwidth.");
 		}
 		inputBandwidthLimit = ibwLimit;
 		try {


### PR DESCRIPTION
I think this should have been the behaviour all along to allow us to upgrade the network to new internet connection requirements without continuously killing old nodes.

I cannot just re-use the checking function, because that must throw an exception for the config settings.