### PR TITLE
Deprecate functions of class Fields in favor of Java API

### DIFF
--- a/src/freenet/support/Fields.java
+++ b/src/freenet/support/Fields.java
@@ -425,9 +425,7 @@ public abstract class Fields {
 			return compareBytes(o1, o2);
 		}
 	}
-
-	// could add stuff like IntegerComparator, LongComparator etc.
-	// if we need it
+	
 	public static int hashCode(byte[] b) {
 		return hashCode(b, 0, b.length);
 	}

--- a/src/freenet/support/Fields.java
+++ b/src/freenet/support/Fields.java
@@ -391,6 +391,8 @@ public abstract class Fields {
 		return 0;
 	}
 
+	/** @deprecated Use {@link Arrays#equals(byte[], byte[])} */
+	@Deprecated
 	public static boolean byteArrayEqual(byte[] a, byte[] b) {
 		if(a.length != b.length)
 			return false;

--- a/src/freenet/support/Fields.java
+++ b/src/freenet/support/Fields.java
@@ -8,6 +8,7 @@ import java.util.Calendar;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.GregorianCalendar;
+import java.util.List;
 import java.util.StringTokenizer;
 import java.util.TimeZone;
 
@@ -426,13 +427,20 @@ public abstract class Fields {
 		}
 	}
 	
+	/** @deprecated Use {@link Arrays#hashCode(byte[])} */
+	@Deprecated
 	public static int hashCode(byte[] b) {
 		return hashCode(b, 0, b.length);
 	}
 
 	/**
 	 * A generic hashcode suited for byte arrays that are more or less random.
+	 * @deprecated
+	 *     Use {@link Arrays#asList(Object...) Arrays.asList(array)}
+	 *     .{@link List#subList(int, int) subList(from, to)}
+	 *     .{@link List#hashCode() hashCode()}
 	 */
+	@Deprecated
 	public static int hashCode(byte[] b, int ptr, int length) {
 		int h = 0;
 		for(int i = length - 1; i >= 0; --i) {

--- a/src/freenet/support/Fields.java
+++ b/src/freenet/support/Fields.java
@@ -934,14 +934,20 @@ public abstract class Fields {
 		return 0;
 	}
 	
-	/** Avoid issues with overflow, 2's complement. E.g. 0-Integer.MIN_VALUE = Integer.MIN_VALUE-0. */
+	/**
+	 * Avoid issues with overflow, 2's complement. E.g. 0-Integer.MIN_VALUE = Integer.MIN_VALUE-0.
+	 * @deprecated Use {@link Integer#compare(int, int)} */
+	@Deprecated
 	public static final int compare(int x, int y) {
 		if(x > y) return 1;
 		if(y > x) return -1;
 		return 0;
 	}
 	
-	/** Avoid issues with overflow, 2's complement. */
+	/**
+	 * Avoid issues with overflow, 2's complement.
+	 * @deprecated Use {@link Long#compare(long, long)} */
+	@Deprecated
 	public static final int compare(long x, long y) {
 		if(x > y) return 1;
 		if(y > x) return -1;

--- a/src/freenet/support/Fields.java
+++ b/src/freenet/support/Fields.java
@@ -954,7 +954,13 @@ public abstract class Fields {
 		return 0;
 	}
 
-	/** Avoid issues with NaN's. */
+	/**
+	 * Avoid issues with NaN's.
+	 * @deprecated
+	 *     Use {@link Double#compare(double, double)}. Notice: It may behave differently with
+	 *     regards to special values (e.g. -0.0). Check its source code if you need precisely
+	 *     the same behavior. */
+	@Deprecated
 	public static final int compare(double x, double y) {
 		if(Double.isNaN(x)) {
 			if(Double.isNaN(y)) {
@@ -973,7 +979,13 @@ public abstract class Fields {
 		return 0;
 	}
 
-	/** Avoid issues with NaN's. */
+	/**
+	 * Avoid issues with NaN's.
+	 * @deprecated
+	 *     Use {@link Float#compare(float, float)}. Notice: It may behave differently with
+	 *     regards to special values (e.g. -0.0). Check its source code if you need precisely
+	 *     the same behavior. */
+	@Deprecated
 	public static final int compare(float x, float y) {
 		if(Float.isNaN(x)) {
 			if(Float.isNaN(y)) {

--- a/src/freenet/support/Fields.java
+++ b/src/freenet/support/Fields.java
@@ -452,14 +452,16 @@ public abstract class Fields {
 
 	/**
 	 * Long version of above Not believed to be secure in any sense of the word :)
-	 */
+	 * @deprecated Not used by fred. Give plugins some time to migrate before removing it. */
+	@Deprecated
 	public static long longHashCode(byte[] b) {
 		return longHashCode(b, 0, b.length);
 	}
 
 	/**
 	 * Long version of above Not believed to be secure in any sense of the word :)
-	 */
+	 * @deprecated Not used by fred. Give plugins some time to migrate before removing it. */
+	@Deprecated
 	public static long longHashCode(byte[] b, int offset, int length) {
 		long h = 0;
 		for(int i = length - 1; i >= 0; --i) {


### PR DESCRIPTION
Please review carefully:
I'm not qualified to perfectly judge whether the replacements behave sufficiently similar.
This especially applies to commits b2fdf98cb8322fc8578c0d0ee3d94ce23ce5238e and cacf24e30ceb5d0b45073d3bd50eb899b1d6f05d.