### PR TITLE
Eclipse config: Fix source path of db4o in freenet-ext

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -3,7 +3,7 @@
 	<classpathentry excluding="freenet/node/*Test.java|plugins/JSTUN/**|test/**" kind="src" output="build/main" path="src"/>
 	<classpathentry including="freenet/|org/" kind="src" output="build/test" path="test"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-	<classpathentry exported="true" kind="lib" path="lib/freenet/freenet-ext.jar" sourcepath="/contrib/db4o/src/db4oj"/>
+	<classpathentry exported="true" kind="lib" path="lib/freenet/freenet-ext.jar" sourcepath="/contrib/db4o/src/db4ojdk5"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
 	<classpathentry kind="lib" path="lib/bcprov-jdk15on-154.jar"/>
 	<classpathentry kind="output" path="build/main/"/>


### PR DESCRIPTION
When compiling plugin-WebOfTrust, I noticed a weirdness which shows that
the previous source code path for db4o is wrong:

I changed a function ```foo(ObjectSet<Thing> x)``` to have the signature
```foo(List<Thing> x)```. The compiler did *not* complain when passing
```ObjectSet<Thing>``` to the function which expects a ```List```. So this shows
that class ```ObjectSet<T>``` as we ship it in freenet-ext.jar v29 does
implement ```List<T>```. This can also be shown by unpacking the jar and
running the Java disassembler:
```
    $ javap ObjectSet.class
    ...
    public interface com.db4o.ObjectSet<Item> extends
    java.util.List<Item>, java.util.Iterator<Item> {
```
Yet when browsing the source code as the previous classpath specified
it, the ObjectSet there does **NOT** implement ```List<T>```.

So what happened is that the previous source path was wrongly set to an
old db4o for an old Java version. This happens to also be included in
the contrib repository because db4o considers the "old" implementations
as a foundation for the new ones: The build script compiles by first
compiling the old versions, then the new ones, and finally copying the
build output of the new ones over the old ones to overwrite matching
class files (yikes!).
See https://github.com/freenet/contrib/blob/v29/db4o/build.xml#L65-L76

Thus, this commit fixes the Eclipse classpath to specify the Java >= 5
version of the db4o source code as the sourcepath for db4o.

I do realize that this could mean that Eclipse will not find the
source for some classes, but there is no way to specify multiple paths.
And I would say its better to have Eclipse say "no source file found for
class X" than to blatantly show the *wrong* source file.
Hopefully, thanks to splitting up freenet-ext and moving to Gradle,
this may become irrelevant and we thus could accept the uglyness of this
as a temporary fix.