### PR TITLE
fproxy-page: sanitize the content of the key input field

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 next ():
 
+- fproxy: fetch key form: preserve anchor and kill host:port
+- fix monthly bandwidth selection bug
+- fix breakage from increased min bandwidth 
+- prevent denial-of-service via misconstructed manifests
+
+1473 (2016-05-22):
+
 - Add a NEWS file
 - Sort alerts within a category by time, newest first (including node-to-node messages).
 - Optimize CSS to load everything but the first theme in parallel

--- a/src/freenet/clients/http/FProxyToadlet.java
+++ b/src/freenet/clients/http/FProxyToadlet.java
@@ -509,7 +509,14 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
 
 				if(logMINOR) Logger.minor(this, "Redirecting to FreenetURI: "+newURI);
 				String requestedMimeType = httprequest.getParam("type");
-				String location = getLink(newURI, requestedMimeType, maxSize, httprequest.getParam("force", null), httprequest.isParameterSet("forcedownload"), maxRetries, overrideSize);
+				String anchor = null;
+				if (httprequest.isParameterSet("anchor")) {
+					anchor = httprequest.getParam("anchor");
+				}
+				String location = getLink(newURI, requestedMimeType, maxSize,
+				                          httprequest.getParam("force", null), httprequest.isParameterSet("forcedownload"),
+				                          maxRetries, overrideSize, anchor);
+				
 				writeTemporaryRedirect(ctx, null, location);
 				return;
 			}
@@ -1041,7 +1048,12 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
 	}
 
 	private String getLink(FreenetURI uri, String requestedMimeType, long maxSize, String force,
-			boolean forceDownload, int maxRetries, boolean appendMaxSize) {
+	                       boolean forceDownload, int maxRetries, boolean appendMaxSize) {
+		return getLink(uri, requestedMimeType, maxSize, force, forceDownload, maxRetries, appendMaxSize, null);
+	}
+	
+	private String getLink(FreenetURI uri, String requestedMimeType, long maxSize, String force,
+	                       boolean forceDownload, int maxRetries, boolean appendMaxSize, String anchor) {
 		StringBuilder sb = new StringBuilder();
 		sb.append("/");
 		sb.append(uri.toASCIIString());
@@ -1060,6 +1072,12 @@ public final class FProxyToadlet extends Toadlet implements RequestClient {
 		}
 		if(maxRetries >= -1) {
 			sb.append(c).append("max-retries=").append(maxRetries); c = '&';
+		}
+		// Append an anchor. This MUST come last, because everything
+		// after it will not be part of the key.
+		if(anchor != null) {
+			c = '#';
+			sb.append(c).append(anchor);
 		}
 		return sb.toString();
 	}

--- a/src/freenet/clients/http/WelcomeToadlet.java
+++ b/src/freenet/clients/http/WelcomeToadlet.java
@@ -502,7 +502,11 @@ public class WelcomeToadlet extends Toadlet {
 		// Fetch-a-key box
 		HTMLNode fetchKeyContent = ctx.getPageMaker().getInfobox("infobox-normal", l10n("fetchKeyLabel"), contentNode, "fetch-key", true);
 		fetchKeyContent.addAttribute("id", "keyfetchbox");
-		HTMLNode fetchKeyForm = fetchKeyContent.addChild("form", new String[]{"action", "method"}, new String[]{"/", "get"}).addChild("div");
+		// get the javascript for splitting the key into url and hash
+		fetchKeyContent.addChild("script", new String[] {"type", "src"}, new String[] {"text/javascript",  "/static/js/keyinputform.js"});
+		HTMLNode fetchKeyForm = fetchKeyContent.addChild("form",
+		                                                 new String[]{"action", "method", "onsubmit"},
+		                                                 new String[]{"/", "get", "return sanitizeFormInputKey(this);"}).addChild("div");
 		fetchKeyForm.addChild("span", "class", "fetch-key-label", l10n("keyRequestLabel") + ' ');
 		fetchKeyForm.addChild("input", new String[]{"type", "size", "name"}, new String[]{"text", "80", "key"});
 		fetchKeyForm.addChild("input", new String[]{"type", "value"}, new String[]{"submit", l10n("fetch")});

--- a/src/freenet/clients/http/staticfiles/js/keyinputform.js
+++ b/src/freenet/clients/http/staticfiles/js/keyinputform.js
@@ -1,0 +1,23 @@
+function sanitizeFormInputKey(thisForm) {
+    var url = thisForm.elements['key'].value.split('#')[0];
+    var anchor = thisForm.elements['key'].value.split('#')[1];
+    /* Remove default host + port prefix */
+    if (url.startsWith("http://127.0.0.1:8888/")) {
+        url = url.replace("http://127.0.0.1:8888/", "");
+    } else if (url.startsWith("https://127.0.0.1:8888/")) {
+        url = url.replace("https://127.0.0.1:8888/", "");
+    } else if (url.startsWith("http://localhost:8888/")) {
+        url = url.replace("http://localhost:8888/", "");
+    } else if (url.startsWith("https://localhost:8888/")) {
+        url = url.replace("https://localhost:8888/", "");
+    }
+    /* Move anchor into hidden input to prevent escaping the # */
+    if (anchor != null) {
+        var anch = document.createElement('INPUT');
+        thisForm.appendChild(anch);
+        anch.type = 'hidden';
+        anch.name = "anchor";
+        anch.value = anchor;
+        thisForm.elements['key'].value = url;
+    };
+};


### PR DESCRIPTION
With this change, the fetch key field can be used with an anchor as well as with links which use the default host and port. That allows telling users to just put a Freenet link into that fetch field (which also avoids attacks from putting a key into the url field of the browser).