### PR TITLE
Ant builder: Analyze test coverage and code complexity using Cobertura

### DIFF
--- a/build-clean.xml
+++ b/build-clean.xml
@@ -222,6 +222,8 @@ maintainers may prefer to use this instead of build.xml.
 		<mkdir dir="${main.dst}"/>
 		<mkdir dir="${test.make}"/>
 		<mkdir dir="${test.dst}"/>
+		<mkdir dir="${test.coverage.make}"/>
+		<mkdir dir="${test.coverage.dst}"/>
 	</target>
 
 	<target name="dep" depends="ensure-ext, ensure-bc, ensure-gjs"/>
@@ -357,6 +359,8 @@ maintainers may prefer to use this instead of build.xml.
 		<delete dir="${main.dst}"/>
 		<delete dir="${test.make}"/>
 		<delete dir="${test.dst}"/>
+		<delete dir="${test.coverage.make}"/>
+		<delete dir="${test.coverage.dst}"/>
 	</target>
 
 	<!-- =================================================================== -->

--- a/build-clean.xml
+++ b/build-clean.xml
@@ -379,6 +379,11 @@ maintainers may prefer to use this instead of build.xml.
 				<path if:true="${test.coverage}" refid="libtest.coverage.path"/>
 			</classpath>
 
+			<!-- Workaround for Cobertura failing on Java 7 with:
+				   "Expecting a stackmap frame at branch target [...]"
+				 TODO: Code quality: Remove if not necessary anymore. Added on 2016-05-31. -->
+			<jvmarg if:true="${test.coverage}" value="-XX:-UseSplitVerifier"/>
+
 			<formatter type="plain" usefile="false"/>
 			<formatter type="xml" if="${test.xml_output}"/>
 			<formatter classname="org.apache.tools.ant.taskdefs.optional.junit.TearDownOnVmCrash" usefile="false"/>

--- a/build-clean.xml
+++ b/build-clean.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project name="freenet" default="package" basedir=".">
+<project name="freenet" default="package" basedir="." xmlns:if="ant:if">
 	<description>
 Freenet is free software that lets you publish and retrieve information without
 fear of censorship. To achieve this, the network is entirely decentralized, and
@@ -368,7 +368,17 @@ maintainers may prefer to use this instead of build.xml.
 
 	<target name="unit" depends="unit-build, unit-inject-cobertura" unless="${test.skip}">
 		<junit printsummary="yes" haltonfailure="${test.haltonfailure}" logfailedtests="yes" showoutput="yes" filtertrace="no" fork="on" forkmode="perTest" maxmemory="256m" dir="${test.dst}">
-			<classpath refid="libtest.path"/>
+			<classpath>
+				<!-- Cobertura injects its code into copies of the main fred classes. We put the
+				     directory with the copies before the original ones to ensure the copies are
+				     preferred. -->
+				<pathelement if:true="${test.coverage}" location="${test.coverage.make}"/>
+				<!-- Original classes -->
+				<path refid="libtest.path"/>
+				<!-- Cobertura library -->
+				<path if:true="${test.coverage}" refid="libtest.coverage.path"/>
+			</classpath>
+
 			<formatter type="plain" usefile="false"/>
 			<formatter type="xml" if="${test.xml_output}"/>
 			<formatter classname="org.apache.tools.ant.taskdefs.optional.junit.TearDownOnVmCrash" usefile="false"/>

--- a/build-clean.xml
+++ b/build-clean.xml
@@ -342,7 +342,31 @@ maintainers may prefer to use this instead of build.xml.
 		</copy>
 	</target>
 
-	<target name="unit" depends="unit-build" unless="${test.skip}">
+	<target name="unit-inject-cobertura" depends="build, unit-build" unless="${test.skip}"
+			if="${test.coverage}">
+		
+		<fail unless="${lib.cobertura.present}" message="${libtest.coverage.jars} not found!"/>
+		
+		<taskdef classpathref="libtest.coverage.path" resource="tasks.properties"/>
+		
+		<!-- We must copy the main non-test build output to separate directory as input for
+			 Cobertura: It will inject its code into the class files.
+			 We use overwrite="true" in case we're doing an incremental compilation
+			 - the directory is only used for Cobertura so this shouldn't cause any problems. -->
+		<copy todir="${test.coverage.make}" overwrite="true">
+			<fileset dir="${main.make}">
+				<include name="**/*.class" />
+				<!-- Not necessary: ${main.make} does not contain the tests -->
+				<!-- <exclude name="**/*Test*.class" /> -->
+			</fileset>
+		</copy>
+
+		<cobertura-instrument datafile="${test.coverage.dst}/cobertura.ser">
+			<fileset dir="${test.coverage.make}"/>
+		</cobertura-instrument>
+	</target>
+
+	<target name="unit" depends="unit-build, unit-inject-cobertura" unless="${test.skip}">
 		<junit printsummary="yes" haltonfailure="${test.haltonfailure}" logfailedtests="yes" showoutput="yes" filtertrace="no" fork="on" forkmode="perTest" maxmemory="256m" dir="${test.dst}">
 			<classpath refid="libtest.path"/>
 			<formatter type="plain" usefile="false"/>

--- a/build-clean.xml
+++ b/build-clean.xml
@@ -101,6 +101,7 @@ maintainers may prefer to use this instead of build.xml.
 		<echo message="  skip        Skip all tests"/>
 		<echo message="  verbose     Report additional information"/>
 		<echo message="  benchmark   Run benchmark tests"/>
+		<echo message="  coverage    Run test coverage analysis using Cobertura"/>
 		<echo message="  extensive   Run extensive tests"/>
 		<echo message=""/>
 		<echo message="Misc parameters (-DPARAM=VALUE)"/>

--- a/build-clean.xml
+++ b/build-clean.xml
@@ -35,6 +35,10 @@ maintainers may prefer to use this instead of build.xml.
 		<pathelement path="${main.make}"/>
 		<pathelement path="${test.make}"/>
 	</path>
+	<path id="libtest.coverage.path">
+		<fileset dir="${lib.dir}" includes="${libtest.coverage.jars}"/>
+		<fileset dir="/usr/share/java" includes="${libtest.coverage.jars}" erroronmissingdir="false"/>
+	</path>
 
 	<property name="gjs.dst" value="${main.src}/freenet/clients/http/staticfiles/freenetjs"/>
 	<property name="gjs.dir" value="generator/js"/>
@@ -164,6 +168,7 @@ maintainers may prefer to use this instead of build.xml.
 		<available property="lib.bouncycastle.present" classname="org.bouncycastle.crypto.signers.HMacDSAKCalculator" classpathref="lib.path"/>
 		<available property="lib.junit.present" classname="org.junit.runners.JUnit4" classpathref="libtest.path"/>
 		<available property="lib.hamcrest.present" classname="org.hamcrest.SelfDescribing" classpathref="libtest.path"/>
+		<available property="lib.cobertura.present" classname="net.sourceforge.cobertura.ant.InstrumentTask" classpathref="libtest.coverage.path"/>
 		<available property="lib.findbugs.present" classname="edu.umd.cs.findbugs.anttask.FindBugsTask" classpath="${findbugs.path}"/>
 		<available property="lib.pmd.present" classname="net.sourceforge.pmd.ant.PMDTask" classpathref="pmd.classpath"/>
 		<available property="lib.cpd.present" classname="net.sourceforge.pmd.cpd.CPDTask" classpathref="pmd.classpath"/>

--- a/build-clean.xml
+++ b/build-clean.xml
@@ -394,6 +394,12 @@ maintainers may prefer to use this instead of build.xml.
 			<!-- TODO source needs to be edited too; the old variables were "benchmark" and "extensiveTesting" -->
 			<assertions><enable/></assertions>
 		</junit>
+
+		<cobertura-report if:true="${test.coverage}"
+			srcdir="${main.src}"
+			datafile="${test.coverage.dst}/cobertura.ser"
+			destdir="${test.coverage.dst}/html"
+			format="html"/>
 	</target>
 
 	<target name="clean" description="clean standard build products">

--- a/build-clean.xml
+++ b/build-clean.xml
@@ -314,7 +314,8 @@ maintainers may prefer to use this instead of build.xml.
 		</jar>
 	</target>
 
-	<target name="package" depends="unit, package-only" description="build standard binary packages (Freenet daemon)"/>
+	<target name="package" depends="unit, unit-coverage-report, package-only"
+		description="build standard binary packages (Freenet daemon)"/>
 
 	<target name="unit-build" depends="build" unless="${test.skip}">
 		<antcall target="libdep-junit"/>
@@ -399,8 +400,10 @@ maintainers may prefer to use this instead of build.xml.
 			<!-- TODO source needs to be edited too; the old variables were "benchmark" and "extensiveTesting" -->
 			<assertions><enable/></assertions>
 		</junit>
+	</target>
 
-		<cobertura-report if:true="${test.coverage}"
+	<target name="unit-coverage-report" depends="unit" unless="${test.skip}" if="${test.coverage}">
+		<cobertura-report
 			srcdir="${main.src}"
 			datafile="${test.coverage.dst}/cobertura.ser"
 			destdir="${test.coverage.dst}/html"

--- a/build-clean.xml
+++ b/build-clean.xml
@@ -389,6 +389,8 @@ maintainers may prefer to use this instead of build.xml.
 			<sysproperty key="test.verbose" value="${test.verbose}"/>
 			<sysproperty key="test.benchmark" value="${test.benchmark}"/>
 			<sysproperty key="test.extensive" value="${test.extensive}"/>
+			<sysproperty if:true="${test.coverage}" key="net.sourceforge.cobertura.datafile"
+				file="${test.coverage.dst}/cobertura.ser" />
 			<!-- TODO source needs to be edited too; the old variables were "benchmark" and "extensiveTesting" -->
 			<assertions><enable/></assertions>
 		</junit>

--- a/build.properties
+++ b/build.properties
@@ -76,6 +76,7 @@ javac.args=-Xlint
 # Test properties
 test.skip=false
 test.verbose=false
+test.coverage=false
 test.benchmark=false
 test.extensive=false
 test.xml_output=true

--- a/build.properties
+++ b/build.properties
@@ -52,6 +52,8 @@ lib.jars = ${bc.jar}
 # jars from ${lib.dir} to use, for tests
 libtest.jars = junit4.jar hamcrest-core.jar
 
+libtest.coverage.jars = cobertura.jar
+
 # jars from ${lib.contrib.dir} to use
 lib.contrib.jars = freenet-ext.jar bitcollider-core.jar db4o.jar lzmajio.jar mantissa.jar \
  wrapper.jar db-je.jar bdb-je.jar commons-compress.jar

--- a/build.properties
+++ b/build.properties
@@ -18,6 +18,9 @@ test.src=test
 test.make=build/test
 test.dst=run
 
+test.coverage.make=build/test-coverage
+test.coverage.dst=test-coverage
+
 doc.src=doc
 doc.dst=javadoc
 doc.api=javadoc


### PR DESCRIPTION
(Please consider including the subject and description of this PR as body of the merge commit message.)

Cobertura is a tool which injects its own code during the unit tests to analyze which code of the fred core is called during test runs. This yields HTML output which contains things such as:
- a view of the source code with the lines being color-coded as: red = untested, green = tested. 
- a percentage of how many lines of code are covered by the tests.
- a percentage of how many code paths (if() etc) are covered by the tests.
- bonus static analysis: the "average McCabe's cyclomatic code complexity for all methods." = average number of code paths. This can be used to find giant functions which need to be split up.
- the above statistics both for the whole repository and also for each package and class.

This branch amends the Ant builder to optionally use Cobertura and provide the HTML output at `./test-coverage/html`

As dependency you only need to install the standard Ubuntu "cobertura" package. Alternatively, put a cobertura.jar into `./lib`
It can then be executed by:
`ant clean && ant -Dtest.coverage=true`
Incremental compilation, i.e. leaving out the `ant clean`, should also work as long as you don't delete classes.
You can also compute test coverage as caused by only a specific single unit test class:
`ant -Dtest.coverage=true -Dtest.class=freenet.packageName.ClassName`

Full HTML output, accessible with Freenet:
http://127.0.0.1:8888/CHK@ukoL~NGt6t0p9VRJ7RATO0vxlGVr0mBvL0qB164A4Y8,DbjfwdzSP7hDN11-s20k79tRURobCRtyZyVGppVH1ZY,AAMC--8/test-coverage-fred_testing-build-1474-pre1-122-g5baa142/index.html

Clearnet-accesible screenshot of the overall statistics for the whole repository: http://i.imgur.com/xTuZwBv.png

For review purposes, consult the Cobertura Ant documentation at https://github.com/cobertura/cobertura/wiki/Ant-Task-Reference
