### PR TITLE
PluginInfoMessage: Fix wrong "does not provide FCP" info about plugins

### DIFF
--- a/src/freenet/clients/fcp/PluginInfoMessage.java
+++ b/src/freenet/clients/fcp/PluginInfoMessage.java
@@ -32,7 +32,10 @@ public class PluginInfoMessage extends FCPMessage {
 		classname = pi.getPluginClassName();
 		originuri = pi.getFilename();
 		started = pi.getStarted();
-		isTalkable = pi.isFCPPlugin();
+		// isFCPPlugin() is the deprecated old plugin FCP API, isFCPServerPlugin() the new one.
+		// Plugins may implement only the old, or the new, or both. As the on-network format is
+		// backwards compatible, we report them as talkable if any is implemented.
+		isTalkable = pi.isFCPPlugin() || pi.isFCPServerPlugin();
 		longVersion = pi.getPluginLongVersion();
 		version = pi.getPluginVersion();
 	}


### PR DESCRIPTION
Thanks to @Bombe for discovering this!

See https://github.com/freenet/fred/pull/319 for details about the new API, including statements about the compatibility.