### PR TITLE
Warn users that java1.7 is EOL

### DIFF
--- a/src/freenet/node/useralerts/JVMVersionAlert.java
+++ b/src/freenet/node/useralerts/JVMVersionAlert.java
@@ -10,7 +10,7 @@ import freenet.support.JVMVersion;
 public class JVMVersionAlert extends AbstractUserAlert {
 
 	public JVMVersionAlert() {
-        super(true, null, null, null, null, UserAlert.ERROR, true,
+        super(true, null, null, null, null, UserAlert.WARNING, true,
               NodeL10n.getBase().getString("UserAlert.hide"), true, null);
 	}
 

--- a/src/freenet/support/JVMVersion.java
+++ b/src/freenet/support/JVMVersion.java
@@ -9,7 +9,7 @@ import java.util.regex.Pattern;
  * See documentation: http://www.oracle.com/technetwork/java/javase/versioning-naming-139433.html
  */
 public class JVMVersion {
-	public static final String REQUIRED = "1.7";
+	public static final String REQUIRED = "1.8";
 
 	/** Regular expression for versions: major.feature[.maintenance[_update]],
 	 * leading zeroes and optional identifier stripped. */

--- a/test/freenet/support/JVMVersionTest.java
+++ b/test/freenet/support/JVMVersionTest.java
@@ -9,11 +9,11 @@ public class JVMVersionTest extends TestCase {
 		Assert.assertTrue(JVMVersion.isTooOld("1.6.0_32"));
 		Assert.assertTrue(JVMVersion.isTooOld("1.6"));
 		Assert.assertTrue(JVMVersion.isTooOld("1.5"));
+		Assert.assertTrue(JVMVersion.isTooOld("1.7.0_65"));
+		Assert.assertTrue(JVMVersion.isTooOld("1.7"));
 	}
 
 	public void testRecentEnough() {
-		Assert.assertFalse(JVMVersion.isTooOld("1.7.0_65"));
-		Assert.assertFalse(JVMVersion.isTooOld("1.7"));
 		Assert.assertFalse(JVMVersion.isTooOld("1.8.0_9"));
 		Assert.assertFalse(JVMVersion.isTooOld("1.10"));
 	}


### PR DESCRIPTION
Odds are we won't require java8 before it's in debian stable...
and it won't be before stretch is released (freeze is scheduled for 02/2017)