### PR TITLE
adjust bw limit: min peers 4 and min bandwidth 5KiB/s (more risky option)

### DIFF
--- a/src/freenet/clients/http/wizardsteps/BANDWIDTH_MONTHLY.java
+++ b/src/freenet/clients/http/wizardsteps/BANDWIDTH_MONTHLY.java
@@ -27,7 +27,7 @@ public class BANDWIDTH_MONTHLY extends BandwidthManipulator implements Step {
 	 */
 	private static final Double minCap = 2*Node.getMinimumBandwidth()*secondsPerMonth/GB;
 
-	private static final long[] caps = { (long)Math.ceil(minCap), 100, 150, 250, 500 };
+	private static final long[] caps = { (long)Math.ceil(minCap), 50, 100, 150, 250, 500 };
 
 	public BANDWIDTH_MONTHLY(NodeClientCore core, Config config) {
 		super(core, config);

--- a/src/freenet/node/Node.java
+++ b/src/freenet/node/Node.java
@@ -782,11 +782,11 @@ public class Node implements TimeSkewDetectorCallback {
 	private boolean enableRoutedPing;
 
 	/**
-	 * Minimum bandwidth limit in bytes considered usable: 5 KiB. If there is an attempt to set a limit below this -
+	 * Minimum bandwidth limit in bytes considered usable: 4 KiB. If there is an attempt to set a limit below this -
 	 * excluding the reserved -1 for input bandwidth - the callback will throw. See the callbacks for
-	 * outputBandwidthLimit and inputBandwidthLimit. 5 KiB are equivalent to 25 GiB traffic per month.
+	 * outputBandwidthLimit and inputBandwidthLimit. 4 KiB are equivalent to 20 GiB traffic per month.
 	 */
-	private static final int minimumBandwidth = 5 * 1024;
+	private static final int minimumBandwidth = 4 * 1024;
 
 	/** Quality of Service mark we will use for all outgoing packets (opennet/darknet) */
 	private TrafficClass trafficClass;

--- a/src/freenet/node/Node.java
+++ b/src/freenet/node/Node.java
@@ -782,11 +782,11 @@ public class Node implements TimeSkewDetectorCallback {
 	private boolean enableRoutedPing;
 
 	/**
-	 * Minimum bandwidth limit in bytes considered usable: 10 KiB. If there is an attempt to set a limit below this -
+	 * Minimum bandwidth limit in bytes considered usable: 5 KiB. If there is an attempt to set a limit below this -
 	 * excluding the reserved -1 for input bandwidth - the callback will throw. See the callbacks for
-	 * outputBandwidthLimit and inputBandwidthLimit. 10 KiB are equivalent to 50 GiB traffic per month.
+	 * outputBandwidthLimit and inputBandwidthLimit. 5 KiB are equivalent to 25 GiB traffic per month.
 	 */
-	private static final int minimumBandwidth = 10 * 1024;
+	private static final int minimumBandwidth = 5 * 1024;
 
 	/** Quality of Service mark we will use for all outgoing packets (opennet/darknet) */
 	private TrafficClass trafficClass;

--- a/src/freenet/node/OpennetManager.java
+++ b/src/freenet/node/OpennetManager.java
@@ -190,16 +190,20 @@ public class OpennetManager {
 	/** Enable scaling of peers with bandwidth? */
 	public static final boolean ENABLE_PEERS_PER_KB_OUTPUT = true;
 	/** Constant for scaling peers: we multiply bandwidth in kB/sec by this
-	 * and then take the square root. 12 gives 11 at 10K, 15 at 20K, 19 at
-	 * 30K, 26 at 60K, 34 at 100K, 40 at 140K, 100 at 2500K.
-	 * 212 at 30mbit/s (the mean upload in Japan in 2014) and
-	 * 363 at 88mbit/s (the mean upload in Hong Kong in 2014).*/
-	public static final double SCALING_CONSTANT = 12.0;
+	 * and then take the square root. scaling at 4 gives 4 peers at 5K,
+	 * 5 at 7K, 6 at 10K, 9 at 20K, 11 at
+	 * 30K, 15 at 60K, 20 at 100K, 24 at 140K, 100 at 2500K.
+	 * 122 at 30mbit/s (the mean upload in Japan in 2014) and
+	 * 210 at 88mbit/s (the mean upload in Hong Kong in 2014).*/
+	public static final double SCALING_CONSTANT = 4.0;
 	/**
-	 * Minimum number of peers. Do not reduce this: As a rough estimate, because the vast majority
-	 * of requests complete in 5 hops, this gives just one binary decision per hop on average.
+	 * Minimum number of peers. As a rough estimate, because the vast majority
+	 * of requests complete in 5 hops, 10 peers give just one binary decision
+	 * per hop. However the distribution of peers before the link length fix
+ 	 * showed that having 3 short distance peers still worked, since requests
+ 	 * preferentially go through higher capacity nodes with more FOAFs.
 	 */
-	public static final int MIN_PEERS_FOR_SCALING = 10;
+	public static final int MIN_PEERS_FOR_SCALING = 4;
 	/** The maximum possible distance between two nodes in the wrapping [0,1) location space. */
 	public static final double MAX_DISTANCE = 0.5;
 	/** The fraction of nodes which are only a short distance away. */

--- a/src/freenet/node/OpennetManager.java
+++ b/src/freenet/node/OpennetManager.java
@@ -209,7 +209,7 @@ public class OpennetManager {
 	/** The fraction of nodes which are only a short distance away. */
 	public static final double SHORT_NODES_FRACTION = LONG_DISTANCE / MAX_DISTANCE;
 	/** The estimated average number of nodes which are active at any given time. */
-	public static final int LAST_NETWORK_SIZE_ESTIMATE = 5000;
+	public static final int LAST_NETWORK_SIZE_ESTIMATE = 3000;
 	/** The estimated number of nodes which are a short distance away. */
 	public static final int AVAILABLE_SHORT_DISTANCE_NODES =
 		(int) (LAST_NETWORK_SIZE_ESTIMATE * SHORT_NODES_FRACTION);


### PR DESCRIPTION
This is one of two options I see for reducing the required peer count per bandwidth.

I see it as important, because current versions of Freenet have difficulty keeping more than 70 connections, so users with high bandwidth have flapping connections, which will stop convergence of the network.

This is the more risky option: reducing the minimum bandwidth back down to 5KiB and allowing the peers to go down to 4 — one long connection and 3 short ones. With this change, very slow nodes should contribute to routing roughly as much (or as little) as they did with 10 connections before the link length fix.

On the other hand, with this change, slow nodes should easily be able to keep all their connections.
