### PR TITLE
adjust bandwidth: min peers 7 and min bandwidth 7KiB/s (safer option)

### DIFF
--- a/src/freenet/clients/http/wizardsteps/BANDWIDTH_MONTHLY.java
+++ b/src/freenet/clients/http/wizardsteps/BANDWIDTH_MONTHLY.java
@@ -27,7 +27,7 @@ public class BANDWIDTH_MONTHLY extends BandwidthManipulator implements Step {
 	 */
 	private static final Double minCap = 2*Node.getMinimumBandwidth()*secondsPerMonth/GB;
 
-	private static final long[] caps = { (long)Math.ceil(minCap), 100, 150, 250, 500 };
+	private static final long[] caps = { (long)Math.ceil(minCap), 50, 100, 150, 250, 500 };
 
 	public BANDWIDTH_MONTHLY(NodeClientCore core, Config config) {
 		super(core, config);

--- a/src/freenet/node/Node.java
+++ b/src/freenet/node/Node.java
@@ -782,11 +782,11 @@ public class Node implements TimeSkewDetectorCallback {
 	private boolean enableRoutedPing;
 
 	/**
-	 * Minimum bandwidth limit in bytes considered usable: 10 KiB. If there is an attempt to set a limit below this -
+	 * Minimum bandwidth limit in bytes considered usable: 7 KiB. If there is an attempt to set a limit below this -
 	 * excluding the reserved -1 for input bandwidth - the callback will throw. See the callbacks for
-	 * outputBandwidthLimit and inputBandwidthLimit. 10 KiB are equivalent to 50 GiB traffic per month.
+	 * outputBandwidthLimit and inputBandwidthLimit. 7 KiB are equivalent to 35 GiB traffic per month.
 	 */
-	private static final int minimumBandwidth = 10 * 1024;
+	private static final int minimumBandwidth = 7 * 1024;
 
 	/** Quality of Service mark we will use for all outgoing packets (opennet/darknet) */
 	private TrafficClass trafficClass;

--- a/src/freenet/node/OpennetManager.java
+++ b/src/freenet/node/OpennetManager.java
@@ -190,16 +190,16 @@ public class OpennetManager {
 	/** Enable scaling of peers with bandwidth? */
 	public static final boolean ENABLE_PEERS_PER_KB_OUTPUT = true;
 	/** Constant for scaling peers: we multiply bandwidth in kB/sec by this
-	 * and then take the square root. 12 gives 11 at 10K, 15 at 20K, 19 at
-	 * 30K, 26 at 60K, 34 at 100K, 40 at 140K, 100 at 2500K.
-	 * 212 at 30mbit/s (the mean upload in Japan in 2014) and
-	 * 363 at 88mbit/s (the mean upload in Hong Kong in 2014).*/
-	public static final double SCALING_CONSTANT = 12.0;
+	 * and then take the square root. 7 gives 7 at 7K, 8 at 10K, 12 at 20K, 14 at
+	 * 30K, 20 at 60K, 26 at 100K, 31 at 140K, 132 at 2500K.
+	 * 162 at 30mbit/s (the mean upload in Japan in 2014) and
+	 * 277 at 88mbit/s (the mean upload in Hong Kong in 2014).*/
+	public static final double SCALING_CONSTANT = 7.0;
 	/**
 	 * Minimum number of peers. Do not reduce this: As a rough estimate, because the vast majority
 	 * of requests complete in 5 hops, this gives just one binary decision per hop on average.
 	 */
-	public static final int MIN_PEERS_FOR_SCALING = 10;
+	public static final int MIN_PEERS_FOR_SCALING = 7;
 	/** The maximum possible distance between two nodes in the wrapping [0,1) location space. */
 	public static final double MAX_DISTANCE = 0.5;
 	/** The fraction of nodes which are only a short distance away. */


### PR DESCRIPTION
This is one of two options I see for reducing the required peer count per bandwidth.

I see it as important, because current versions of Freenet have difficulty keeping more than 70 connections, so users with high bandwidth have flapping connections, which will stop convergence of the network.

This is the less risky option: reducing the minimum bandwidth back down to 7KiB and allowing the peers to go down to 7 — 2 long connections and 5 short ones. With this change, very slow nodes should still contribute to routing — for long, medium (<0.01), and for short distances. 

They might have problems to keep these connections (as do 10KiB/s nodes with 10 connections).
