### PR TITLE
Ant builder: Reduce warnings about usage of deprecated API

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -66,7 +66,7 @@ pmd.dir =
 ## build tool options
 
 # Javac
-javac.args=-Xlint
+javac.args=-Xlint -Xlint:-deprecation
 
 # Test properties
 test.skip=false


### PR DESCRIPTION
One regular workflow of using deprecation in fred is:
- A new version of Java appears and allows us to replace custom
  code with Java API.
- The volunteer who discovers this does not have the time or knowledge
  to replace all usages of the custom code immediately.
  For an example of these difficulties, see the commit messages of the
  two commits which this PR highlights in its message:
  https://github.com/freenet/fred/pull/541
- So we instead deprecate our custom API, and wait "some time" before a
  developer comes along who is capable of replacing all usages of it.

As we really don't have enough developers, "some time" is usually years.
So overall, there will be some deprecated things in fred at any time.
Thus we'd constantly have compiler warnings about usage of deprecated API which we cannot fix.
This...:
- is annoying.
- doesn't indicate any real bugs, but rather a lack of code quality.
- should be more considered as in-code documentation than something which must be fixed directly from the compiler output.

So overall, this commit configures the compiler to not warn about each individual deprecation anymore.
It will still print a single warning if there is any deprecated code:
```
[javac] Note: Some input files use or override a deprecated API.
[javac] Note: Recompile with -Xlint:deprecation for details.
```

Also, any decent IDE  will still syntax-highlight usages of deprecated API. For example Eclipse, for which we ship config files, will display called deprecated functions with strikethrough text as "~~function~~()".
This ensures that developers do still notice deprecation, but in a less obnoxious way. This allows them to focus on the more important other warnings, of which we do have 86 currently.
