### PR TITLE
NodeStats: reduce code duplication in request location tracking

### DIFF
--- a/src/freenet/node/NodeStats.java
+++ b/src/freenet/node/NodeStats.java
@@ -58,7 +58,38 @@ public class NodeStats implements Persistable, BlockTimeCallback {
 		CHK_OFFER_FETCH,
 		SSK_OFFER_FETCH;
 	}
-	
+
+	/** Histogram for request locations. */
+	private static class RequestsByLocation {
+		private final int[] bins;
+		private int count = 0;
+
+		/** Constructs a request location histogram with the given number of bins. */
+		RequestsByLocation(int numBins) {
+			bins = new int[numBins];
+		}
+
+		/** Update the request counts with a request for the given location. */
+		final void report(final double loc) {
+			assert(loc >= 0 && loc < 1.0);
+			final int bin = (int)Math.floor(loc * bins.length);
+			synchronized (this) {
+				bins[bin]++;
+			}
+		}
+
+		/** Get the request count bins. The total request count is placed at position zero of the
+		  * given array. */
+		final int[] getCounts(final int[] total) {
+			final int[] ret = new int[bins.length];
+			synchronized (this) {
+				System.arraycopy(bins, 0, ret, 0, bins.length);
+				total[0] = count;
+			}
+			return ret;
+		}
+	}
+
 	/** Sub-max ping time. If ping is greater than this, we reject some requests. */
 	public static final long DEFAULT_SUB_MAX_PING_TIME = MILLISECONDS.toMillis(700);
 	/** Maximum overall average ping time. If ping is greater than this,
@@ -84,14 +115,13 @@ public class NodeStats implements Persistable, BlockTimeCallback {
 	 * block send time.
 	 */
 	public static final long MAX_INTERREQUEST_TIME = SECONDS.toMillis(10);
+
 	/** Locations of incoming requests */
-	private final int[] incomingRequestsByLoc = new int[10];
-	private int incomingRequestsAccounted = 0;
+	private final RequestsByLocation incomingRequests = new RequestsByLocation(10);
 	/** Locations of outgoing requests */
-	private final int[] outgoingLocalRequestByLoc = new int[10];
-	private int outgoingLocalRequestsAccounted = 0;
-	private final int[] outgoingRequestByLoc = new int[10];
-	private int outgoingRequestsAccounted = 0;
+	private final RequestsByLocation outgoingLocalRequests = new RequestsByLocation(10);
+	private final RequestsByLocation outgoingRequests = new RequestsByLocation(10);
+
 	private volatile long subMaxPingTime;
 	private volatile long maxPingTime;
 
@@ -2996,60 +3026,27 @@ public class NodeStats implements Persistable, BlockTimeCallback {
 	}
 
 	public void reportIncomingRequestLocation(double loc) {
-		assert((loc > 0) && (loc < 1.0));
-
-		synchronized(incomingRequestsByLoc) {
-			incomingRequestsByLoc[(int)Math.floor(loc*incomingRequestsByLoc.length)]++;
-			incomingRequestsAccounted++;
-		}
+		incomingRequests.report(loc);
 	}
 
 	public int[] getIncomingRequestLocation(int[] retval) {
-		int[] result = new int[incomingRequestsByLoc.length];
-		synchronized(incomingRequestsByLoc) {
-			System.arraycopy(incomingRequestsByLoc, 0, result, 0, incomingRequestsByLoc.length);
-			retval[0] = incomingRequestsAccounted;
-		}
-
-		return result;
+		return incomingRequests.getCounts(retval);
 	}
 
 	public void reportOutgoingLocalRequestLocation(double loc) {
-		assert((loc > 0) && (loc < 1.0));
-
-		synchronized(outgoingLocalRequestByLoc) {
-			outgoingLocalRequestByLoc[(int)Math.floor(loc*outgoingLocalRequestByLoc.length)]++;
-			outgoingLocalRequestsAccounted++;
-		}
+		outgoingLocalRequests.report(loc);
 	}
 
 	public int[] getOutgoingLocalRequestLocation(int[] retval) {
-		int[] result = new int[outgoingLocalRequestByLoc.length];
-		synchronized(outgoingLocalRequestByLoc) {
-			System.arraycopy(outgoingLocalRequestByLoc, 0, result, 0, outgoingLocalRequestByLoc.length);
-			retval[0] = outgoingLocalRequestsAccounted;
-		}
-
-		return result;
+		return outgoingLocalRequests.getCounts(retval);
 	}
 
 	public void reportOutgoingRequestLocation(double loc) {
-		assert((loc > 0) && (loc < 1.0));
-
-		synchronized(outgoingRequestByLoc) {
-			outgoingRequestByLoc[(int)Math.floor(loc*outgoingRequestByLoc.length)]++;
-			outgoingRequestsAccounted++;
-		}
+		outgoingRequests.report(loc);
 	}
 
 	public int[] getOutgoingRequestLocation(int[] retval) {
-		int[] result = new int[outgoingRequestByLoc.length];
-		synchronized(outgoingRequestByLoc) {
-			System.arraycopy(outgoingRequestByLoc, 0, result, 0, outgoingRequestByLoc.length);
-			retval[0] = outgoingRequestsAccounted;
-		}
-
-		return result;
+		return outgoingRequests.getCounts(retval);
 	}
 
 	public void reportCHKOutcome(long rtt, boolean successful, double location, boolean isRealtime) {


### PR DESCRIPTION
Just some minor deduplication of code.

Mind that the assertion `assert(loc > 0 && loc < 1.0);` has been changed to `assert(loc >= 0 && loc < 1.0);`, zero *is* a valid location after all.