### PR TITLE
Reduce algorithmic complexity of FOAF routing

### DIFF
--- a/src/freenet/node/PeerLocation.java
+++ b/src/freenet/node/PeerLocation.java
@@ -1,8 +1,6 @@
 package freenet.node;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import java.util.Arrays;
 import java.util.Set;
 
 import freenet.support.Logger;
@@ -11,8 +9,9 @@ public class PeerLocation {
 	
 	/** Current location in the keyspace, or -1 if it is unknown */
 	private double currentLocation;
-	/** Current sorted unmodifiable list of locations of our peer's peers */
-	private List<Double> currentPeersLocation;
+	/** Current sorted array of locations of our peer's peers. Must not be modified,
+	 may only be replaced entirely. */
+	private double[] currentPeersLocation;
 	/** Time the location was set */
 	private long locSetTime;
 
@@ -39,8 +38,9 @@ public class PeerLocation {
 		return currentLocation;
 	}
 
-	synchronized List<Double> getPeerLocations() {
-		return currentPeersLocation;
+	/** Returns an array copy of locations of our peer's peers. */
+	public synchronized double[] getPeersLocationArray() {
+		return Arrays.copyOf(currentPeersLocation, currentPeersLocation.length);
 	}
 
 	public synchronized long getLocationSetTime() {
@@ -53,7 +53,7 @@ public class PeerLocation {
 
 	public synchronized int getDegree() {
 		if (currentPeersLocation == null) return 0;
-		return currentPeersLocation.size();
+		return currentPeersLocation.length;
 	}
 
 	boolean updateLocation(double newLoc, double[] newLocs) {
@@ -63,17 +63,18 @@ public class PeerLocation {
 			return false;
 		}
 
-		ArrayList<Double> newPeersLocation = new ArrayList<Double>(newLocs.length);
-		for (double loc : newLocs) {
+		final double[] newPeersLocation = new double[newLocs.length];
+		for (int i = 0; i < newLocs.length; i++) {
+			final double loc = newLocs[i];
 			if (!Location.isValid(loc)) {
 				Logger.error(this, "Invalid location update for " + this + " (" + loc + ")", new Exception("error"));
 				// Ignore it
 				return false;
 			}
-			newPeersLocation.add(loc);
+			newPeersLocation[i] = loc;
 		}
 		
-		Collections.sort(newPeersLocation);
+		Arrays.sort(newPeersLocation);
 		boolean anythingChanged = false;
 
 		synchronized (this) {
@@ -81,18 +82,18 @@ public class PeerLocation {
 				anythingChanged = true;
 			}
 			if (!anythingChanged) {
-				anythingChanged = currentPeersLocation.size() != newPeersLocation.size();
+				anythingChanged = currentPeersLocation.length != newPeersLocation.length;
 			}
 			if (!anythingChanged) {
-				for (int i = 0; i < currentPeersLocation.size(); i++) {
-					if (!Location.equals(currentPeersLocation.get(i), newPeersLocation.get(i))) {
+				for (int i = 0; i < currentPeersLocation.length; i++) {
+					if (!Location.equals(currentPeersLocation[i], newPeersLocation[i])) {
 						anythingChanged = true;
 						break;
 					}
 				}
 			}
 			currentLocation = newLoc;
-			currentPeersLocation = Collections.unmodifiableList(newPeersLocation);
+			currentPeersLocation = newPeersLocation;
 			locSetTime = System.currentTimeMillis();
 		}
 		return anythingChanged;
@@ -112,16 +113,16 @@ public class PeerLocation {
 	 * or -1 if none.
 	 * This is a binary search of logarithmic complexity.
 	 */
-	private static int findFirstGreater(List<Double> elems, double x) {
+	private static int findFirstGreater(final double[] elems, final double x) {
 		int low = 0;
-		int high = elems.size();
+		int high = elems.length;
 		int mid;
-		if (elems.get(high - 1) <= x) {
+		if (elems[high - 1] <= x) {
 			return -1;
 		}
 		while (low != high) {
 			mid = low + (high - low) / 2;
-			if (elems.get(mid) > x) {
+			if (elems[mid] > x) {
 				high = mid;
 			} else {
 				low = mid + 1;
@@ -134,9 +135,9 @@ public class PeerLocation {
 	 * Finds the position of the closest location in the sorted list of locations.
 	 * This is a binary search of logarithmic complexity.
 	 */
-	static int findClosestLocation(List<Double> locs, double l) {
-		assert(locs.size() > 0);
-		if (locs.size() == 1) {
+	static int findClosestLocation(final double[] locs, final double l) {
+		assert(locs.length > 0);
+		if (locs.length == 1) {
 			return 0;
 		}
 		final int firstGreater = findFirstGreater(locs, l);
@@ -145,13 +146,13 @@ public class PeerLocation {
 		if (firstGreater == -1 || firstGreater == 0) {
 			// All locations are greater, or all locations are smaller.
 			// Closest location must be either smallest or greatest location.
-			left = locs.size() - 1;
+			left = locs.length - 1;
 			right = 0;
 		} else {
 			left = firstGreater - 1;
 			right = firstGreater;
 		}
-		if (Location.distance(l, locs.get(left)) <= Location.distance(l, locs.get(right))) {
+		if (Location.distance(l, locs[left]) <= Location.distance(l, locs[right])) {
 			return left;
 		}
 		return right;
@@ -163,40 +164,42 @@ public class PeerLocation {
 	 * @param exclude the set of locations to exclude, may be null
 	 * @return the closest non-excluded peer's location, or NaN if none is found
 	 */
-	public double getClosestPeerLocation(double l, Set<Double> exclude) {
-		List<Double> locs = getPeerLocations();
-		final int N = locs.size();
-		if (N == 0) {
+	public double getClosestPeerLocation(final double l, Set<Double> exclude) {
+		final double[] locs;
+		synchronized (this) {
+			locs = currentPeersLocation;
+		}
+		if (locs == null || locs.length == 0) {
 			return Double.NaN;
 		}
 		final int closest = findClosestLocation(locs, l);
 		if (exclude == null || !exclude.contains(closest)) {
-			return locs.get(closest);
+			return locs[closest];
 		}
 
-		int left = (closest - 1) % N;
-		int right = (closest + 1) % N;
-		double leftDist = Location.distance(l, locs.get(left));
-		double rightDist = Location.distance(l, locs.get(right));
+		int left = (closest - 1) % locs.length;
+		int right = (closest + 1) % locs.length;
+		double leftDist = Location.distance(l, locs[left]);
+		double rightDist = Location.distance(l, locs[right]);
 		// Iterate over at most m closest peers
 		while (left != right) {
 			if (leftDist <= rightDist) {
-				final double loc = locs.get(left);
+				final double loc = locs[left];
 				if (!exclude.contains(loc)) {
 					return loc;
 				}
-				left = (left - 1) % N;
-				leftDist = Location.distance(l, locs.get(left));
+				left = (left - 1) % locs.length;
+				leftDist = Location.distance(l, locs[left]);
 			} else {
-				final double loc = locs.get(right);
+				final double loc = locs[right];
 				if (!exclude.contains(loc)) {
 					return loc;
 				}
-				right = (right + 1) % N;
-				rightDist = Location.distance(l, locs.get(right));
+				right = (right + 1) % locs.length;
+				rightDist = Location.distance(l, locs[right]);
 			}
 		}
-		final double loc = locs.get(left);
+		final double loc = locs[left];
 		if (!exclude.contains(loc)) {
 			return loc;
 		}

--- a/src/freenet/node/PeerLocation.java
+++ b/src/freenet/node/PeerLocation.java
@@ -38,8 +38,11 @@ public class PeerLocation {
 		return currentLocation;
 	}
 
-	/** Returns an array copy of locations of our peer's peers. */
+	/** Returns an array copy of locations of our peer's peers, or null if we don't have them. */
 	public synchronized double[] getPeersLocationArray() {
+		if (currentPeersLocation == null) {
+			return null;
+		}
 		return Arrays.copyOf(currentPeersLocation, currentPeersLocation.length);
 	}
 

--- a/src/freenet/node/PeerLocation.java
+++ b/src/freenet/node/PeerLocation.java
@@ -3,6 +3,7 @@ package freenet.node;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 import freenet.support.Logger;
 
@@ -106,4 +107,99 @@ public class PeerLocation {
 		return oldLoc;
 	}
 
+	/**
+	 * Finds the position of the first element in the sorted list greater than the given element,
+	 * or -1 if none.
+	 * This is a binary search of logarithmic complexity.
+	 */
+	private static int findFirstGreater(List<Double> elems, double x) {
+		int low = 0;
+		int high = elems.size();
+		int mid;
+		if (elems.get(high - 1) <= x) {
+			return -1;
+		}
+		while (low != high) {
+			mid = low + (high - low) / 2;
+			if (elems.get(mid) > x) {
+				high = mid;
+			} else {
+				low = mid + 1;
+			}
+		}
+		return low;
+	}
+
+	/**
+	 * Finds the position of the closest location in the sorted list of locations.
+	 * This is a binary search of logarithmic complexity.
+	 */
+	static int findClosestLocation(List<Double> locs, double l) {
+		assert(locs.size() > 0);
+		if (locs.size() == 1) {
+			return 0;
+		}
+		final int firstGreater = findFirstGreater(locs, l);
+		final int left;
+		final int right;
+		if (firstGreater == -1 || firstGreater == 0) {
+			// All locations are greater, or all locations are smaller.
+			// Closest location must be either smallest or greatest location.
+			left = locs.size() - 1;
+			right = 0;
+		} else {
+			left = firstGreater - 1;
+			right = firstGreater;
+		}
+		if (Location.distance(l, locs.get(left)) <= Location.distance(l, locs.get(right))) {
+			return left;
+		}
+		return right;
+	}
+
+	/**
+	 * Finds the closest non-excluded peer in O(log n + m) time, where n is the number of peers and
+	 * m the number of exclusions.
+	 * @param exclude the set of locations to exclude, may be null
+	 * @return the closest non-excluded peer's location, or NaN if none is found
+	 */
+	public double getClosestPeerLocation(double l, Set<Double> exclude) {
+		List<Double> locs = getPeerLocations();
+		final int N = locs.size();
+		if (N == 0) {
+			return Double.NaN;
+		}
+		final int closest = findClosestLocation(locs, l);
+		if (exclude == null || !exclude.contains(closest)) {
+			return locs.get(closest);
+		}
+
+		int left = (closest - 1) % N;
+		int right = (closest + 1) % N;
+		double leftDist = Location.distance(l, locs.get(left));
+		double rightDist = Location.distance(l, locs.get(right));
+		// Iterate over at most m closest peers
+		while (left != right) {
+			if (leftDist <= rightDist) {
+				final double loc = locs.get(left);
+				if (!exclude.contains(loc)) {
+					return loc;
+				}
+				left = (left - 1) % N;
+				leftDist = Location.distance(l, locs.get(left));
+			} else {
+				final double loc = locs.get(right);
+				if (!exclude.contains(loc)) {
+					return loc;
+				}
+				right = (right + 1) % N;
+				rightDist = Location.distance(l, locs.get(right));
+			}
+		}
+		final double loc = locs.get(left);
+		if (!exclude.contains(loc)) {
+			return loc;
+		}
+		return Double.NaN;
+	}
 }

--- a/src/freenet/node/PeerLocation.java
+++ b/src/freenet/node/PeerLocation.java
@@ -176,12 +176,12 @@ public class PeerLocation {
 			return Double.NaN;
 		}
 		final int closest = findClosestLocation(locs, l);
-		if (exclude == null || !exclude.contains(closest)) {
+		if (exclude == null || !exclude.contains(locs[closest])) {
 			return locs[closest];
 		}
 
-		int left = (closest - 1) % locs.length;
-		int right = (closest + 1) % locs.length;
+		int left = (closest == 0) ? (locs.length - 1) : (closest - 1);
+		int right = (closest == locs.length - 1) ? 0 : (closest + 1);
 		double leftDist = Location.distance(l, locs[left]);
 		double rightDist = Location.distance(l, locs[right]);
 		// Iterate over at most m closest peers
@@ -191,14 +191,14 @@ public class PeerLocation {
 				if (!exclude.contains(loc)) {
 					return loc;
 				}
-				left = (left - 1) % locs.length;
+				left = (left == 0) ? (locs.length - 1) : (left - 1);
 				leftDist = Location.distance(l, locs[left]);
 			} else {
 				final double loc = locs[right];
 				if (!exclude.contains(loc)) {
 					return loc;
 				}
-				right = (right + 1) % locs.length;
+				right = (right == locs.length - 1) ? 0 : (right + 1);
 				rightDist = Location.distance(l, locs[right]);
 			}
 		}

--- a/src/freenet/node/PeerManager.java
+++ b/src/freenet/node/PeerManager.java
@@ -973,6 +973,15 @@ public class PeerManager {
 			totalSelectionRate += selectionRates[i];
 		}
 		boolean enableFOAFMitigationHack = (peers.length >= PeerNode.SELECTION_MIN_PEERS) && (totalSelectionRate > 0.0);
+
+		// Locations not to consider for routing: our own location, and locations already routed to
+		Set<Double> excludeLocations = new HashSet<Double>();
+		excludeLocations.add(myLoc);
+		excludeLocations.add(prevLoc);
+		for (PeerNode routedToNode : routedTo) {
+			excludeLocations.add(routedToNode.getLocation());
+		}
+
 		for(int i = 0; i < peers.length; i++) {
 			PeerNode p = peers[i];
 			if(routedTo.contains(p)) {
@@ -1038,21 +1047,9 @@ public class PeerManager {
 			double realDiff = Location.distance(loc, target);
 			double diff = realDiff;
 			
-			List<Double> peersLocation = p.getPeersLocation();
-			if((peersLocation != null) && (p.shallWeRouteAccordingToOurPeersLocation())) {
-				for(double l : peersLocation) {
-					boolean ignoreLoc = false; // Because we've already been there
-					if(Math.abs(l - myLoc) < Double.MIN_VALUE * 2 ||
-							Math.abs(l - prevLoc) < Double.MIN_VALUE * 2)
-						ignoreLoc = true;
-					else {
-						for(PeerNode cmpPN : routedTo)
-							if(Math.abs(l - cmpPN.getLocation()) < Double.MIN_VALUE * 2) {
-								ignoreLoc = true;
-								break;
-							}
-					}
-					if(ignoreLoc) continue;
+			if (p.shallWeRouteAccordingToOurPeersLocation()) {
+				double l = p.getClosestPeerLocation(target, excludeLocations);
+				if (!Double.isNaN(l)) {
 					double newDiff = Location.distance(l, target);
 					if(newDiff < diff) {
 						loc = l;
@@ -1264,6 +1261,11 @@ public class PeerManager {
 	 */
 	private long checkBackoffsForRecentlyFailed(PeerNode[] peers, PeerNode best, double target, double bestDistance, double myLoc, double prevLoc, long now, TimedOutNodesList entry, short outgoingHTL) {
 		long overallWakeup = Long.MAX_VALUE;
+
+		Set<Double> excludeLocations = new HashSet<Double>();
+		excludeLocations.add(myLoc);
+		excludeLocations.add(prevLoc);
+
 		for(PeerNode p : peers) {
 			if(p == best) continue;
 			if(!p.isRoutable()) continue;
@@ -1275,16 +1277,9 @@ public class PeerManager {
 			double realDiff = Location.distance(loc, target);
 			double diff = realDiff;
 			
-			List<Double> peersLocation = p.getPeersLocation();
-			if((peersLocation != null) && (p.shallWeRouteAccordingToOurPeersLocation())) {
-				for(double l : peersLocation) {
-					boolean ignoreLoc = false; // Because we've already been there
-					if(Math.abs(l - myLoc) < Double.MIN_VALUE * 2 ||
-							Math.abs(l - prevLoc) < Double.MIN_VALUE * 2)
-						continue;
-					// For purposes of recently failed, we haven't routed anywhere else.
-					// However we do need to check for our location, and the source's location.
-					if(ignoreLoc) continue;
+			if (p.shallWeRouteAccordingToOurPeersLocation()) {
+				double l = p.getClosestPeerLocation(target, excludeLocations);
+				if (!Double.isNaN(l)) {
 					double newDiff = Location.distance(l, target);
 					if(newDiff < diff) {
 						loc = l;

--- a/src/freenet/node/PeerManager.java
+++ b/src/freenet/node/PeerManager.java
@@ -1038,7 +1038,7 @@ public class PeerManager {
 			double realDiff = Location.distance(loc, target);
 			double diff = realDiff;
 			
-			double[] peersLocation = p.getPeersLocation();
+			List<Double> peersLocation = p.getPeersLocation();
 			if((peersLocation != null) && (p.shallWeRouteAccordingToOurPeersLocation())) {
 				for(double l : peersLocation) {
 					boolean ignoreLoc = false; // Because we've already been there
@@ -1275,7 +1275,7 @@ public class PeerManager {
 			double realDiff = Location.distance(loc, target);
 			double diff = realDiff;
 			
-			double[] peersLocation = p.getPeersLocation();
+			List<Double> peersLocation = p.getPeersLocation();
 			if((peersLocation != null) && (p.shallWeRouteAccordingToOurPeersLocation())) {
 				for(double l : peersLocation) {
 					boolean ignoreLoc = false; // Because we've already been there

--- a/src/freenet/node/PeerNode.java
+++ b/src/freenet/node/PeerNode.java
@@ -977,8 +977,22 @@ public abstract class PeerNode implements USKRetrieverCallback, BasePeerNode, Pe
 		}
 	}
 
-	public double[] getPeersLocation() {
+	/** Returns a sorted list of locations of this PeerNode's peers. */
+	public List<Double> getPeersLocation() {
 		return location.getPeerLocations();
+	}
+
+	/** Returns an array copy of locations of this PeerNode's peers. */
+	double[] getPeersLocationArray() {
+		List<Double> locs = getPeersLocation();
+		if (locs == null) {
+			return null;
+		}
+		double[] result = new double[locs.size()];
+		for (int i = 0; i < locs.size(); i++) {
+			result[i] = locs.get(i);
+		}
+		return result;
 	}
 
 	public long getLocSetTime() {
@@ -2712,7 +2726,7 @@ public abstract class PeerNode implements USKRetrieverCallback, BasePeerNode, Pe
 			fs.put("hadRoutableConnectionCount", hadRoutableConnectionCount);
 		if(routableConnectionCheckCount > 0)
 			fs.put("routableConnectionCheckCount", routableConnectionCheckCount);
-		double[] peerLocs = getPeersLocation();
+		double[] peerLocs = getPeersLocationArray();
 		if(peerLocs != null)
 			fs.put("peersLocation", peerLocs);
 		return fs;
@@ -5534,7 +5548,7 @@ public abstract class PeerNode implements USKRetrieverCallback, BasePeerNode, Pe
 		else
 			prevLoc = -1.0;
 		
-		double[] peersLocation = getPeersLocation();
+		List<Double> peersLocation = getPeersLocation();
 		if((peersLocation != null) && (shallWeRouteAccordingToOurPeersLocation())) {
 			for(double l : peersLocation) {
 				boolean ignoreLoc = false; // Because we've already been there

--- a/src/freenet/node/PeerNode.java
+++ b/src/freenet/node/PeerNode.java
@@ -977,22 +977,9 @@ public abstract class PeerNode implements USKRetrieverCallback, BasePeerNode, Pe
 		}
 	}
 
-	/** Returns a sorted list of locations of this PeerNode's peers. */
-	public List<Double> getPeersLocation() {
-		return location.getPeerLocations();
-	}
-
 	/** Returns an array copy of locations of this PeerNode's peers. */
 	double[] getPeersLocationArray() {
-		List<Double> locs = getPeersLocation();
-		if (locs == null) {
-			return null;
-		}
-		double[] result = new double[locs.size()];
-		for (int i = 0; i < locs.size(); i++) {
-			result[i] = locs.get(i);
-		}
-		return result;
+		return location.getPeersLocationArray();
 	}
 
 	/**

--- a/src/freenet/node/PeerNode.java
+++ b/src/freenet/node/PeerNode.java
@@ -977,7 +977,7 @@ public abstract class PeerNode implements USKRetrieverCallback, BasePeerNode, Pe
 		}
 	}
 
-	/** Returns an array copy of locations of this PeerNode's peers. */
+	/** Returns an array copy of locations of this PeerNode's peers, or null if unknown. */
 	double[] getPeersLocationArray() {
 		return location.getPeersLocationArray();
 	}

--- a/src/freenet/node/PeerNode.java
+++ b/src/freenet/node/PeerNode.java
@@ -995,6 +995,15 @@ public abstract class PeerNode implements USKRetrieverCallback, BasePeerNode, Pe
 		return result;
 	}
 
+	/**
+	 * Finds the closest non-excluded peer.
+	 * @param exclude the set of locations to exclude, may be null
+	 * @return the closest non-excluded peer's location, or NaN if none is found
+	 */
+	public double getClosestPeerLocation(double l, Set<Double> exclude) {
+		return location.getClosestPeerLocation(l, exclude);
+	}
+
 	public long getLocSetTime() {
 		return location.getLocationSetTime();
 	}
@@ -5547,22 +5556,17 @@ public abstract class PeerNode implements USKRetrieverCallback, BasePeerNode, Pe
 			prevLoc = prev.getLocation();
 		else
 			prevLoc = -1.0;
-		
-		List<Double> peersLocation = getPeersLocation();
-		if((peersLocation != null) && (shallWeRouteAccordingToOurPeersLocation())) {
-			for(double l : peersLocation) {
-				boolean ignoreLoc = false; // Because we've already been there
-				if(Math.abs(l - myLoc) < Double.MIN_VALUE * 2 ||
-						Math.abs(l - prevLoc) < Double.MIN_VALUE * 2)
-					ignoreLoc = true;
-				else {
-					for(PeerNode cmpPN : routedTo)
-						if(Math.abs(l - cmpPN.getLocation()) < Double.MIN_VALUE * 2) {
-							ignoreLoc = true;
-							break;
-						}
-				}
-				if(ignoreLoc) continue;
+
+		Set<Double> excludeLocations = new HashSet<Double>();
+		excludeLocations.add(myLoc);
+		excludeLocations.add(prevLoc);
+		for (PeerNode routedToNode : routedTo) {
+			excludeLocations.add(routedToNode.getLocation());
+		}
+
+		if (shallWeRouteAccordingToOurPeersLocation()) {
+			double l = getClosestPeerLocation(target, excludeLocations);
+			if (!Double.isNaN(l)) {
 				double newDiff = Location.distance(l, target);
 				if(newDiff < distance) {
 					distance = newDiff;

--- a/src/freenet/node/PeerNodeStatus.java
+++ b/src/freenet/node/PeerNodeStatus.java
@@ -149,7 +149,7 @@ public class PeerNodeStatus {
 		this.statusName = peerNode.getPeerNodeStatusString();
 		this.statusCSSName = peerNode.getPeerNodeStatusCSSClassName();
 		this.location = peerNode.getLocation();
-		this.peersLocation = peerNode.getPeersLocation();
+		this.peersLocation = peerNode.getPeersLocationArray();
 		this.version = peerNode.getVersion();
 		this.simpleVersion = peerNode.getSimpleVersion();
 		this.routingBackoffLengthRT = peerNode.getRoutingBackoffLength(true);

--- a/test/freenet/node/PeerLocationTest.java
+++ b/test/freenet/node/PeerLocationTest.java
@@ -1,0 +1,110 @@
+package freenet.node;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import junit.framework.TestCase;
+
+public class PeerLocationTest extends TestCase {
+
+    private static final double[][] PEER_LOCATIONS = new double[][] {
+        // Must be sorted!
+        { 0.1 },
+        { 0.0 },
+        { 0.9 },
+        { 0.1, 0.3 },
+        { 0.1, 0.3, 0.4 },
+        { 0.0, 0.1, 0.2, 0.3, 0.3, 0.35, 0.5, 0.5, 0.99 },
+        { 0.1, 0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.18, 0.19, 0.20, 0.21, 0.22, 0.23, 0.24 }
+    };
+
+    private static final double[] TARGET_LOCATIONS = new double[] {
+        0.0, 0.01, 0.05, 0.09, 0.1, 0.11, 0.29, 0.3, 0.31,
+        0.35, 0.4, 0.45, 0.5, 0.51, 0.9, 0.91, 0.9999
+    };
+
+    public void testFindClosestLocation() {
+        for (double[] peers : PEER_LOCATIONS) {
+            for (double target : TARGET_LOCATIONS) {
+                int closest = PeerLocation.findClosestLocation(peers, target);
+                double ref = trivialFindClosestDistance(peers, target);
+                assertEquals(ref, Location.distance(peers[closest], target));
+            }
+        }
+    }
+
+    public void testGetClosestPeerLocation() {
+        for (double[] peers : PEER_LOCATIONS) {
+            PeerLocation pl = new PeerLocation("0.0");
+            assertTrue(pl.updateLocation(0.0, peers));
+            for (double target : TARGET_LOCATIONS) {
+                for (Set<Double> exclude : omit(peers)) {
+                    double closest = pl.getClosestPeerLocation(target, exclude);
+                    assertFalse(exclude.contains(closest));
+                    double ref = trivialFindClosestDistance(peers, target, exclude);
+                    if (!Double.isInfinite(ref)) {
+                        assertFalse(Double.isNaN(closest));
+                        boolean isPeer = false;
+                        for (double peer : peers) {
+                            if (closest == peer) {
+                                isPeer = true;
+                                break;
+                            }
+                        }
+                        assertTrue(isPeer);
+                        assertEquals(ref, Location.distance(closest, target));
+                    } else {
+                        assertTrue(Double.isNaN(closest));
+                    }
+                }
+            }
+        }
+    }
+
+    // Generate sets of sequential omitted values of half the length, plus the empty set
+    @SuppressWarnings("unchecked")
+    private Set<Double>[] omit(double[] locs) {
+        Set<Double>[] result = (Set<Double>[]) new Set<?>[locs.length + 1];
+        result[locs.length] = new HashSet<Double>();
+        int n = locs.length / 2 + 1;
+        for (int i = 0; i < locs.length; i++) {
+            Set<Double> s = new HashSet<Double>();
+            for (int j = 0; j < n; j++) {
+                s.add(locs[(i + j) % locs.length]);
+            }
+            result[i] = s;
+            assertFalse(result[i].isEmpty());
+        }
+        return result;
+    }
+
+    // Trivial reference implementation that finds the distance to the closest location
+    private double trivialFindClosestDistance(double[] locs, double l) {
+        double minDist = Double.POSITIVE_INFINITY;
+        for (int i = 0; i < locs.length; i++) {
+            final double d = Location.distance(locs[i], l);
+            if (d < minDist) {
+                minDist = d;
+            }
+        }
+        return minDist;
+    }
+
+    // Trivial reference implementation that finds the distance to the closest location, with some
+    // locations excluded from consideration
+    private double trivialFindClosestDistance(double[] locs, double l, Set<Double> exclude) {
+        double minDist = Double.POSITIVE_INFINITY;
+        for (int i = 0; i < locs.length; i++) {
+            if (exclude.contains(locs[i])) {
+                continue;
+            }
+            final double d = Location.distance(locs[i], l);
+            if (d < minDist) {
+                minDist = d;
+            }
+        }
+        return minDist;
+    }
+}
+

--- a/test/freenet/node/PeerLocationTest.java
+++ b/test/freenet/node/PeerLocationTest.java
@@ -7,6 +7,7 @@ import java.util.Set;
 import junit.framework.TestCase;
 
 public class PeerLocationTest extends TestCase {
+    private static final double EPSILON = 1e-15;
 
     private static final double[][] PEER_LOCATIONS = new double[][] {
         // Must be sorted!
@@ -16,12 +17,14 @@ public class PeerLocationTest extends TestCase {
         { 0.1, 0.3 },
         { 0.1, 0.3, 0.4 },
         { 0.0, 0.1, 0.2, 0.3, 0.3, 0.35, 0.5, 0.5, 0.99 },
-        { 0.1, 0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.18, 0.19, 0.20, 0.21, 0.22, 0.23, 0.24 }
+        { 0.1, 0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.18, 0.19, 0.20, 0.21, 0.22, 0.23, 0.24 },
+        { 0.0000001, 0.0000003, 0.0001, 0.0002, 0.4, 0.5, 0.999, 0.999999, 0.9999995 },
+        { 0, 0.1, 0.11, 0.9, 0.99, 1 }
     };
 
     private static final double[] TARGET_LOCATIONS = new double[] {
-        0.0, 0.01, 0.05, 0.09, 0.1, 0.11, 0.29, 0.3, 0.31,
-        0.35, 0.4, 0.45, 0.5, 0.51, 0.9, 0.91, 0.9999
+        0.0, 1e-12, 0.01, 0.05, 0.09, 0.1, 0.11, 0.29, 0.3, 0.31,
+        0.35, 0.4, 0.45, 0.5, 0.51, 0.9, 0.91, 0.9999, 1 - 1e-12
     };
 
     public void testFindClosestLocation() {
@@ -29,7 +32,7 @@ public class PeerLocationTest extends TestCase {
             for (double target : TARGET_LOCATIONS) {
                 int closest = PeerLocation.findClosestLocation(peers, target);
                 double ref = trivialFindClosestDistance(peers, target);
-                assertEquals(ref, Location.distance(peers[closest], target));
+                assertEquals(ref, Location.distance(peers[closest], target), EPSILON);
             }
         }
     }
@@ -53,7 +56,7 @@ public class PeerLocationTest extends TestCase {
                             }
                         }
                         assertTrue(isPeer);
-                        assertEquals(ref, Location.distance(closest, target));
+                        assertEquals(ref, Location.distance(closest, target), EPSILON);
                     } else {
                         assertTrue(Double.isNaN(closest));
                     }


### PR DESCRIPTION
This design works under the assumption that location doubles can be compared by equality; something that is not necessarily true for doubles in general. It can be modified to work without this assumption, at the expense of some additional computational complexity.

This drops the algorithmic complexity of finding the next peer to route to from O(n² m) to O(n log n + nm), where *n* is the number of peers (assuming our peers have the same number of peers as we have), and *m* is the number of peers that are excluded from routing towards.

Despite its simplicity, this needs careful review and testing. ~~Oh, and did I mention that it still needs a unit test at least for the algorithmic parts?~~ Breaking routing means breaking Freenet at its core.
*In vivo* this seems to work fine, but breakage will probably only be perceivable if the majority of nodes breaks.

For review, not for merge yet.