### PR TITLE
Fix parsing of Java versions >= 9 (JEP-223)

### DIFF
--- a/src/freenet/support/JVMVersion.java
+++ b/src/freenet/support/JVMVersion.java
@@ -6,15 +6,23 @@ import java.util.regex.Pattern;
 /**
  * JVM version utilities.
  *
- * See documentation: http://www.oracle.com/technetwork/java/javase/versioning-naming-139433.html
+ * See documentation:
+ * http://www.oracle.com/technetwork/java/javase/versioning-naming-139433.html (pre-9)
+ * http://openjdk.java.net/jeps/223 (post-9)
  */
 public class JVMVersion {
 	public static final String REQUIRED = "1.8";
 
-	/** Regular expression for versions: major.feature[.maintenance[_update]],
-	 * leading zeroes and optional identifier stripped. */
+	/**
+	 * Pre-9 is formatted as: major.feature[.maintenance[_update]]-ident
+	 * Post-9 is formatted as: major[.minor[.security[. ...]]]-ident
+	 * For comparison of compatibility, information beyong the major, feature/minor,
+	 * maintenance/security and pre-9 update fields should not be of interest.
+	 * We find a common denominator in major(.a(.b([._]c)?)?)?, skipping any additional postfix.
+	 * The regex omits leading zeroes.
+	 */
 	private static final Pattern VERSION_PATTERN =
-	    Pattern.compile("^0*(\\d+)\\.0*(\\d+)(?:\\.0*(\\d+)(?:_0*(\\d+))?)?(?:-.*)?$");
+	    Pattern.compile("^0*(\\d+)(?:\\.0*(\\d+)(?:\\.0*(\\d+)(?:[_.]0*(\\d+))?)?)?.*$");
 
 	public static boolean isTooOld() {
 		return isTooOld(getCurrent());

--- a/test/freenet/support/JVMVersionTest.java
+++ b/test/freenet/support/JVMVersionTest.java
@@ -15,7 +15,8 @@ public class JVMVersionTest extends TestCase {
 
 	public void testRecentEnough() {
 		Assert.assertFalse(JVMVersion.isTooOld("1.8.0_9"));
-		Assert.assertFalse(JVMVersion.isTooOld("1.10"));
+		Assert.assertFalse(JVMVersion.isTooOld("9-ea"));
+		Assert.assertFalse(JVMVersion.isTooOld("10"));
 	}
 
 	public void testNull() {
@@ -24,7 +25,7 @@ public class JVMVersionTest extends TestCase {
 
 	public void testCompare() {
 	    String[] orderedVersions = new String[] {
-	        "1.7.bogus", // Bogus versions are treated as 0.0.0_0
+	        "bogus", // Bogus versions are treated as 0.0.0_0
 	        "1.5",
 	        "1.6.0",
 	        "1.6.0_32",
@@ -38,8 +39,12 @@ public class JVMVersionTest extends TestCase {
 	        "1.7.2-ea",
 	        "1.7.3_0",
 	        "1.8-beta",
-	        "1.10",
-	        "1.10.1"
+	        "9-ea",
+	        "9.0.1.0",
+	        "9.0.1.1.0.1-ea",
+	        "9.2",
+	        "10",
+	        "10.0.2"
 	    };
 
 	    // Compare all combinations and check correctness of their ordering
@@ -49,7 +54,7 @@ public class JVMVersionTest extends TestCase {
 	            String v2 = orderedVersions[j];
 	            int expected = Integer.signum(Integer.valueOf(i).compareTo(Integer.valueOf(j)));
 	            int actual = Integer.signum(JVMVersion.compareVersion(v1, v2));
-	            assertEquals(expected, actual);
+	            assertEquals(v1 + " <> " + v2, expected, actual);
 	        }
 	    }
 	}


### PR DESCRIPTION
This fixes bug [6862](https://bugs.freenetproject.org/view.php?id=6862) by parsing less strictly.