### PR TITLE
Don't use FOAF if HTL<2

### DIFF
--- a/src/freenet/node/AnnounceSender.java
+++ b/src/freenet/node/AnnounceSender.java
@@ -160,7 +160,7 @@ public class AnnounceSender implements PrioRunnable, ByteCounter {
 			}
 			if(logMINOR) Logger.minor(this, "Routing request to "+next);
 			if(onlyNode == null)
-				next.reportRoutedTo(target, source == null, false, source, nodesRoutedTo);
+				next.reportRoutedTo(target, source == null, false, source, nodesRoutedTo, htl);
 			nodesRoutedTo.add(next);
 
 			long xferUID = sendTo(next);

--- a/src/freenet/node/BaseSender.java
+++ b/src/freenet/node/BaseSender.java
@@ -1,7 +1,5 @@
 package freenet.node;
 
-import static java.util.concurrent.TimeUnit.MINUTES;
-
 import java.util.HashMap;
 import java.util.HashSet;
 
@@ -21,6 +19,8 @@ import freenet.support.LogThresholdCallback;
 import freenet.support.Logger;
 import freenet.support.Logger.LogLevel;
 import freenet.support.TimeUtil;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
 
 /** Base class for request and insert senders.
  * Mostly concerned with what happens *before and up to* we get the Accepted.
@@ -169,7 +169,7 @@ public abstract class BaseSender implements ByteCounter {
 			 * Don't use sendAsync().
 			 */
         	next.sendSync(req, this, realTimeFlag);
-        	next.reportRoutedTo(key.toNormalizedDouble(), source == null, realTimeFlag, source, nodesRoutedTo);
+                next.reportRoutedTo(key.toNormalizedDouble(), source == null, realTimeFlag, source, nodesRoutedTo, htl);
 			node.peers.incrementSelectionSamples(System.currentTimeMillis(), next);
         } catch (NotConnectedException e) {
         	Logger.minor(this, "Not connected");
@@ -502,7 +502,7 @@ loadWaiterLoop:
     			 * Don't use sendAsync().
     			 */
     			if(logMINOR) Logger.minor(this, "Sending "+req+" to "+next);
-    			next.reportRoutedTo(key.toNormalizedDouble(), source == null, realTimeFlag, source, nodesRoutedTo);
+                        next.reportRoutedTo(key.toNormalizedDouble(), source == null, realTimeFlag, source, nodesRoutedTo, htl);
     			next.sendSync(req, this, realTimeFlag);
     		} catch (NotConnectedException e) {
     			Logger.minor(this, "Not connected");

--- a/src/freenet/node/DarknetPeerNode.java
+++ b/src/freenet/node/DarknetPeerNode.java
@@ -1727,8 +1727,8 @@ public class DarknetPeerNode extends PeerNode {
 	}
 
 	@Override
-	public boolean shallWeRouteAccordingToOurPeersLocation() {
-		if(!node.shallWeRouteAccordingToOurPeersLocation()) return false; // Globally disabled
+	public boolean shallWeRouteAccordingToOurPeersLocation(int htl) {
+		if(!node.shallWeRouteAccordingToOurPeersLocation(htl)) return false; // Globally disabled
 		if(trustLevel == FRIEND_TRUST.LOW) return false;
 		return true;
 	}

--- a/src/freenet/node/Node.java
+++ b/src/freenet/node/Node.java
@@ -4464,8 +4464,8 @@ public class Node implements TimeSkewDetectorCallback {
 		return publishOurPeersLocation;
 	}
 
-	public boolean shallWeRouteAccordingToOurPeersLocation() {
-		return routeAccordingToOurPeersLocation;
+	public boolean shallWeRouteAccordingToOurPeersLocation(int htl) {
+		return routeAccordingToOurPeersLocation && htl > 1;
 	}
 
 	/** Can be called to decrypt client.dat* etc, or can be called when switching from another 

--- a/src/freenet/node/OpennetPeerNode.java
+++ b/src/freenet/node/OpennetPeerNode.java
@@ -263,8 +263,8 @@ public class OpennetPeerNode extends PeerNode {
 	}
 	
 	@Override
-	public boolean shallWeRouteAccordingToOurPeersLocation() {
-		return node.shallWeRouteAccordingToOurPeersLocation();
+	public boolean shallWeRouteAccordingToOurPeersLocation(int htl) {
+		return node.shallWeRouteAccordingToOurPeersLocation(htl);
 	}
 
 	@Override

--- a/src/freenet/node/PeerManager.java
+++ b/src/freenet/node/PeerManager.java
@@ -1039,7 +1039,7 @@ public class PeerManager {
 			double diff = realDiff;
 			
 			double[] peersLocation = p.getPeersLocation();
-			if((peersLocation != null) && (p.shallWeRouteAccordingToOurPeersLocation())) {
+			if((peersLocation != null) && (p.shallWeRouteAccordingToOurPeersLocation(outgoingHTL))) {
 				for(double l : peersLocation) {
 					boolean ignoreLoc = false; // Because we've already been there
 					if(Math.abs(l - myLoc) < Double.MIN_VALUE * 2 ||
@@ -1276,7 +1276,7 @@ public class PeerManager {
 			double diff = realDiff;
 			
 			double[] peersLocation = p.getPeersLocation();
-			if((peersLocation != null) && (p.shallWeRouteAccordingToOurPeersLocation())) {
+			if((peersLocation != null) && (p.shallWeRouteAccordingToOurPeersLocation(outgoingHTL))) {
 				for(double l : peersLocation) {
 					boolean ignoreLoc = false; // Because we've already been there
 					if(Math.abs(l - myLoc) < Double.MIN_VALUE * 2 ||

--- a/src/freenet/node/PeerNode.java
+++ b/src/freenet/node/PeerNode.java
@@ -5325,7 +5325,7 @@ public abstract class PeerNode implements USKRetrieverCallback, BasePeerNode, Pe
 	 * allow them to reconnect. */
 	public abstract void fatalTimeout();
 	
-	public abstract boolean shallWeRouteAccordingToOurPeersLocation();
+	public abstract boolean shallWeRouteAccordingToOurPeersLocation(int htl);
 	
 	@Override
 	public PeerMessageQueue getMessageQueue() {
@@ -5524,7 +5524,7 @@ public abstract class PeerNode implements USKRetrieverCallback, BasePeerNode, Pe
 		return false;
 	}
 
-	public void reportRoutedTo(double target, boolean isLocal, boolean realTime, PeerNode prev, Set<PeerNode> routedTo) {
+	public void reportRoutedTo(double target, boolean isLocal, boolean realTime, PeerNode prev, Set<PeerNode> routedTo, int htl) {
 		double distance = Location.distance(target, getLocation());
 		
 		double myLoc = node.getLocation();
@@ -5535,7 +5535,7 @@ public abstract class PeerNode implements USKRetrieverCallback, BasePeerNode, Pe
 			prevLoc = -1.0;
 		
 		double[] peersLocation = getPeersLocation();
-		if((peersLocation != null) && (shallWeRouteAccordingToOurPeersLocation())) {
+		if((peersLocation != null) && (shallWeRouteAccordingToOurPeersLocation(htl))) {
 			for(double l : peersLocation) {
 				boolean ignoreLoc = false; // Because we've already been there
 				if(Math.abs(l - myLoc) < Double.MIN_VALUE * 2 ||

--- a/src/freenet/node/SeedClientPeerNode.java
+++ b/src/freenet/node/SeedClientPeerNode.java
@@ -150,7 +150,7 @@ public class SeedClientPeerNode extends PeerNode {
 	}
 	
 	@Override
-	public boolean shallWeRouteAccordingToOurPeersLocation() {
+	public boolean shallWeRouteAccordingToOurPeersLocation(int htl) {
 		return false; // Irrelevant
 	}
 	

--- a/src/freenet/node/SeedServerPeerNode.java
+++ b/src/freenet/node/SeedServerPeerNode.java
@@ -164,7 +164,7 @@ public class SeedServerPeerNode extends PeerNode {
 	}
 	
 	@Override
-	public boolean shallWeRouteAccordingToOurPeersLocation() {
+	public boolean shallWeRouteAccordingToOurPeersLocation(int htl) {
 		return false; // Irrelevant
 	}
 


### PR DESCRIPTION
This is less invasive than #564 and probably a good idea.

We don't want to land a request far from the target just because it has a peer that's closer to our current location!

Please ACK it; I'm not sure whether the callers setting HTL at silly values should be changed.