### PR TITLE
SessionManager: remove dead sanity check

### DIFF
--- a/src/freenet/clients/http/SessionManager.java
+++ b/src/freenet/clients/http/SessionManager.java
@@ -407,30 +407,7 @@ public final class SessionManager {
 		}
 		
 		// FIXME: Execute every few hours only.
-		verifyQueueOrder();
 		verifySessionsByUserIDTable();
-	}
-	
-	/**
-	 * Debug function which checks whether the session LRU queue is in order;
-	 */
-	private synchronized void verifyQueueOrder() {
-		long previousTime = 0;
-		
-		Enumeration<Session> sessions = mSessionsByID.values();
-		while(sessions.hasMoreElements()) {
-			Session session = sessions.nextElement();
-			
-			if(session.getExpirationTime() < previousTime) {
-				long sessionAge = HOURS.convert(CurrentTimeUTC.getInMillis() - session.getExpirationTime(), MILLISECONDS);
-				Logger.error(this, "Session LRU queue out of order! Found session which is " + sessionAge + " hour old: " + session); 
-				Logger.error(this, "Deleting all sessions...");
-				
-				mSessionsByID.clear();
-				mSessionsByUserID.clear();
-				return;
-			}
-		}
 	}
 	
 	/**


### PR DESCRIPTION
`previousTime` was never written, so this check was useless and would never fail.

These kind of checks belong in a unit test, not in production code.