### PR TITLE
Fix a potential problem with fallocate()

### DIFF
--- a/src/freenet/support/WrapperKeepalive.java
+++ b/src/freenet/support/WrapperKeepalive.java
@@ -1,0 +1,27 @@
+package freenet.support;
+
+import org.tanukisoftware.wrapper.WrapperManager;
+
+import java.io.IOException;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
+
+public class WrapperKeepalive extends Thread implements AutoCloseable {
+  private volatile boolean shutdown = false;
+  private static final int INTERVAL = (int) MINUTES.toMillis(2);
+
+  @Override
+  public void run() {
+    while (!shutdown) {
+      try {
+        WrapperManager.signalStarting(INTERVAL);
+        Thread.sleep(INTERVAL);
+      } catch (InterruptedException e) {}
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    shutdown = true;
+  }
+}

--- a/src/freenet/support/WrapperKeepalive.java
+++ b/src/freenet/support/WrapperKeepalive.java
@@ -5,6 +5,7 @@ import org.tanukisoftware.wrapper.WrapperManager;
 import java.io.IOException;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class WrapperKeepalive extends Thread implements AutoCloseable {
   private volatile boolean shutdown = false;
@@ -14,7 +15,7 @@ public class WrapperKeepalive extends Thread implements AutoCloseable {
   public void run() {
     while (!shutdown) {
       try {
-        WrapperManager.signalStarting(INTERVAL);
+        WrapperManager.signalStarting(INTERVAL + (int)SECONDS.toMillis(5));
         Thread.sleep(INTERVAL);
       } catch (InterruptedException e) {}
     }

--- a/src/freenet/support/io/Fallocate.java
+++ b/src/freenet/support/io/Fallocate.java
@@ -19,7 +19,7 @@ import freenet.support.math.MersenneTwister;
 public final class Fallocate {
 
   private static final boolean IS_LINUX = Platform.isLinux();
-  private static final boolean IS_POSIX = !Platform.isWindows();
+  private static final boolean IS_POSIX = !Platform.isWindows() && !Platform.isMac();
 
   private static final int FALLOC_FL_KEEP_SIZE = 0x01;
 

--- a/src/freenet/support/io/Fallocate.java
+++ b/src/freenet/support/io/Fallocate.java
@@ -76,7 +76,7 @@ public final class Fallocate {
       final int result = FallocateHolder.fallocate(fd, mode, offset, length);
       errno = result == 0 ? 0 : Native.getLastError();
     } else {
-      errno = FallocateHolder.posix_fallocate(fd, offset, length);
+      errno = FallocateHolderPOSIX.posix_fallocate(fd, offset, length);
     }
     if (errno != 0) {
       throw new IOException("fallocate returned " + errno);
@@ -84,12 +84,18 @@ public final class Fallocate {
   }
 
   private static class FallocateHolder {
-
     static {
       Native.register(Platform.C_LIBRARY_NAME);
     }
 
     private static native int fallocate(int fd, int mode, long offset, long length);
+  }
+
+  private static class FallocateHolderPOSIX {
+    static {
+      Native.register(Platform.C_LIBRARY_NAME);
+    }
+
     private static native int posix_fallocate(int fd, long offset, long length);
   }
 

--- a/src/freenet/support/io/Fallocate.java
+++ b/src/freenet/support/io/Fallocate.java
@@ -3,8 +3,6 @@ package freenet.support.io;
 import com.sun.jna.Native;
 import com.sun.jna.Platform;
 
-import org.tanukisoftware.wrapper.WrapperManager;
-
 import java.io.FileDescriptor;
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -12,8 +10,6 @@ import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 
 import freenet.support.math.MersenneTwister;
-
-import static java.util.concurrent.TimeUnit.MINUTES;
 
 /**
  * Provides access to operating system-specific {@code fallocate} and
@@ -119,7 +115,7 @@ public final class Fallocate {
     }
   }
 
-  public static void legacyFill(FileChannel fc, long newLength, long offset, boolean starting) throws IOException {
+  public static void legacyFill(FileChannel fc, long newLength, long offset) throws IOException {
     MersenneTwister mt = new MersenneTwister();
     byte[] b = new byte[4096];
     ByteBuffer bb = ByteBuffer.wrap(b);
@@ -130,15 +126,6 @@ public final class Fallocate {
       offset += fc.write(bb, offset);
       if (offset % (1024 * 1024 * 1024L) == 0) {
         mt = new MersenneTwister();
-        if (starting) {
-          WrapperManager.signalStarting( (int) MINUTES.toMillis(5));
-          if (x++ % 32 == 1)
-            System.err.println(
-                "Preallocating space : "
-                + offset
-                + "/"
-                + newLength);
-        }
       }
     }
   }


### PR DESCRIPTION
It turns out that some old libc will rewrite calls from
 fallocate() to posix_fallocate() ... and this might take
 a while depending on the FS.

We need to ensure that regardless of the situation,
 the wrapper doesn't kill the node.