### PR TITLE
Add JNAGMP magic to speedup DSA

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -177,6 +177,7 @@ dependencies {
     compile "org.bouncycastle:bcprov-jdk15on:1.54"
     compile "net.java.dev.jna:jna:4.2.2"
     compile "org.freenetproject:freenet-ext@jar"
+    compile "com.squareup.jnagmp:jnagmp:1.1.0"
 
     testCompile 'junit:junit:4.12'
     testCompile "org.mockito:mockito-core:1.9.5"
@@ -191,6 +192,7 @@ dependencyVerification {
         'net.java.dev.jna:jna:1f38af54e06c6e6f6dbf39ba2c052b952dea5dddb4871127b34639ddeb11bdbe',
         'org.freenetproject:freenet-ext:32f2b3d6beedf54137ea2f9a3ebef67666d769f0966b08cd17fd7db59ba4d79f',
         'junit:junit:59721f0805e223d84b90677887d9ff567dc534d7c502ca903c0c2b17f05c116a',
+        'com.squareup.jnagmp:jnagmp:543cc75d72b8670a6f1b9d0dec70830cb5be410bf18866fec5f4dbc026d0e0df',
         'org.mockito:mockito-core:f97483ba0944b9fa133aa29638764ddbeadb51ec3dbc02074c58fa2caecd07fa',
         'org.hamcrest:hamcrest-library:711d64522f9ec410983bd310934296da134be4254a125080a0416ec178dfad1c',
         'org.hamcrest:hamcrest-core:66fdef91e9739348df7a096aa384a5685f4e875584cce89386a7a47251c4d8e9',

--- a/src/freenet/crypt/DSAGroup.java
+++ b/src/freenet/crypt/DSAGroup.java
@@ -3,9 +3,10 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.crypt;
 
+import com.squareup.jnagmp.GmpInteger;
+
 import java.io.IOException;
 import java.io.InputStream;
-import java.math.BigInteger;
 
 import freenet.node.FSParseException;
 import freenet.support.Base64;
@@ -19,12 +20,10 @@ import freenet.support.SimpleFieldSet;
  */
 public class DSAGroup extends CryptoKey {
 	private static final long serialVersionUID = -1;
-	
-	protected static final int Q_BIT_LENGTH = 256;
 
-    private final BigInteger p, q, g;
+    private final GmpInteger p, q, g;
 
-    public DSAGroup(BigInteger p, BigInteger q, BigInteger g) {
+    public DSAGroup(GmpInteger p, GmpInteger q, GmpInteger g) {
         this.p = p;
         this.q = q;
         this.g = g;
@@ -33,36 +32,16 @@ public class DSAGroup extends CryptoKey {
     }
 
     private DSAGroup(DSAGroup group) {
-        this.p = new BigInteger(1, group.p.toByteArray());
-        this.q = new BigInteger(1, group.q.toByteArray());
-        this.g = new BigInteger(1, group.g.toByteArray());
-	}
-    
-    protected DSAGroup() {
-        // For serialization.
-        p = null;
-        q = null;
-        g = null;
+        this.p = new GmpInteger(1, group.p.toByteArray());
+        this.q = new GmpInteger(1, group.q.toByteArray());
+        this.g = new GmpInteger(1, group.g.toByteArray());
     }
 
-	/**
-     * Parses a DSA Group from a string, where p, q, and g are in unsigned
-     * hex-strings, separated by a commas
-     */
-    // see readFromField() below
-    //public static DSAGroup parse(String grp) {
-    //    StringTokenizer str=new StringTokenizer(grp, ",");
-    //    BigInteger p,q,g;
-    //    p = new BigInteger(str.nextToken(), 16);
-    //    q = new BigInteger(str.nextToken(), 16);
-    //    g = new BigInteger(str.nextToken(), 16);
-    //    return new DSAGroup(p,q,g);
-    //}
     public static CryptoKey read(InputStream i) throws IOException, CryptFormatException {
-        BigInteger p, q, g;
-        p = Util.readMPI(i);
-        q = Util.readMPI(i);
-        g = Util.readMPI(i);
+        GmpInteger p, q, g;
+        p = new GmpInteger(Util.readMPI(i));
+        q = new GmpInteger(Util.readMPI(i));
+        g = new GmpInteger(Util.readMPI(i));
         try {
         	DSAGroup group = new DSAGroup(p, q, g);
         	if(group.equals(Global.DSAgroupBigA)) return Global.DSAgroupBigA;
@@ -77,21 +56,21 @@ public class DSAGroup extends CryptoKey {
         return "DSA.g-" + p.bitLength();
     }
 
-    public BigInteger getP() {
+    public GmpInteger getP() {
         return p;
     }
 
-    public BigInteger getQ() {
+    public GmpInteger getQ() {
         return q;
     }
 
-    public BigInteger getG() {
+    public GmpInteger getG() {
         return g;
     }
 
     @Override
-	public byte[] fingerprint() {
-        BigInteger fp[] = new BigInteger[3];
+    public byte[] fingerprint() {
+        GmpInteger fp[] = new GmpInteger[3];
         fp[0] = p;
         fp[1] = q;
         fp[2] = g;
@@ -142,9 +121,9 @@ public class DSAGroup extends CryptoKey {
 		String myQ = fs.get("q");
 		String myG = fs.get("g");
 		if(myP == null || myQ == null || myG == null) throw new FSParseException("The given SFS doesn't contain required fields!");
-		BigInteger p = new BigInteger(1, Base64.decode(myP));
-		BigInteger q = new BigInteger(1, Base64.decode(myQ));
-		BigInteger g = new BigInteger(1, Base64.decode(myG));
+                GmpInteger p = new GmpInteger(1, Base64.decode(myP));
+                GmpInteger q = new GmpInteger(1, Base64.decode(myQ));
+                GmpInteger g = new GmpInteger(1, Base64.decode(myG));
 		DSAGroup dg = new DSAGroup(p, q, g);
 		if(dg.equals(Global.DSAgroupBigA)) return Global.DSAgroupBigA;
 		return dg;

--- a/src/freenet/crypt/DSAPrivateKey.java
+++ b/src/freenet/crypt/DSAPrivateKey.java
@@ -3,6 +3,8 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.crypt;
 
+import com.squareup.jnagmp.GmpInteger;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigInteger;
@@ -16,24 +18,18 @@ import freenet.support.SimpleFieldSet;
 public class DSAPrivateKey extends CryptoKey {
 	private static final long serialVersionUID = -1;
 
-    private final BigInteger x;
+    private final GmpInteger x;
 
-    public DSAPrivateKey(BigInteger x, DSAGroup g) {
+    public DSAPrivateKey(GmpInteger x, DSAGroup g) {
         this.x = x;
         if(x.signum() != 1 || x.compareTo(g.getQ()) > -1 || x.compareTo(BigInteger.ZERO) < 1)
         	throw new IllegalArgumentException();
     }
 
-    // this is dangerous...  better to force people to construct the
-    // BigInteger themselves so they know what is going on with the sign
-    //public DSAPrivateKey(byte[] x) {
-    //    this.x = new BigInteger(1, x);
-    //}
-
     public DSAPrivateKey(DSAGroup g, Random r) {
-        BigInteger tempX;
+        GmpInteger tempX;
         do {
-            tempX = new BigInteger(256, r);
+            tempX = new GmpInteger(256, r);
         } while (tempX.compareTo(g.getQ()) > -1 || tempX.compareTo(BigInteger.ZERO) < 1);
         this.x = tempX;
     }
@@ -48,24 +44,18 @@ public class DSAPrivateKey extends CryptoKey {
         return "DSA.s";
     }
     
-    public BigInteger getX() {
+    public GmpInteger getX() {
         return x;
     }
     
     public static CryptoKey read(InputStream i, DSAGroup g) throws IOException {
-        return new DSAPrivateKey(Util.readMPI(i), g);
+        return new DSAPrivateKey(new GmpInteger(Util.readMPI(i)), g);
     }
     
     @Override
     public String toLongString() {
         return "x="+HexUtil.biToHex(x);
     }
-    
-    // what?  why is DSAGroup passed in?
-    //public static CryptoKey readFromField(DSAGroup group, String field) {
-    //    //BigInteger x=Util.byteArrayToMPI(Util.hexToBytes(field));
-    //    return new DSAPrivateKey(new BigInteger(field, 16));
-    //}
     
     @Override
 	public byte[] asBytes() {
@@ -84,17 +74,10 @@ public class DSAPrivateKey extends CryptoKey {
 	}
 
 	public static DSAPrivateKey create(SimpleFieldSet fs, DSAGroup group) throws IllegalBase64Exception {
-		BigInteger y = new BigInteger(1, Base64.decode(fs.get("x")));
+                GmpInteger y = new GmpInteger(1, Base64.decode(fs.get("x")));
 		if(y.bitLength() > 512)
 			throw new IllegalBase64Exception("Probably a pubkey");
 		return new DSAPrivateKey(y, group);
 	}
-
-//    public static void main(String[] args) throws Exception {
-//        Yarrow y=new Yarrow();
-//        DSAPrivateKey p=new DSAPrivateKey(Global.DSAgroupC, y);
-//        DSAPublicKey pk=new DSAPublicKey(Global.DSAgroupC, p);
-//        p.write(System.out);
-//    }
 }
 

--- a/src/freenet/crypt/Global.java
+++ b/src/freenet/crypt/Global.java
@@ -3,6 +3,8 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.crypt;
 
+import com.squareup.jnagmp.GmpInteger;
+
 import org.bouncycastle.crypto.params.DSAParameters;
 
 import java.math.BigInteger;
@@ -24,11 +26,11 @@ public final class Global {
 	 */
 	public static final DSAGroup DSAgroupBigA =
 		new DSAGroup(
-		new BigInteger( /* p */
+		new GmpInteger( /* p */
 		"008608ac4f55361337f2a3e38ab1864ff3c98d66411d8d2afc9c526320c541f65078e86bc78494a5d73e4a9a67583f941f2993ed6c97dbc795dd88f0915c9cfbffc7e5373cde13e3c7ca9073b9106eb31bf82272ed0057f984a870a19f8a83bfa707d16440c382e62d3890473ea79e9d50c4ac6b1f1d30b10c32a02f685833c6278fc29eb3439c5333885614a115219b3808c92a37a0f365cd5e61b5861761dad9eff0ce23250f558848f8db932b87a3bd8d7a2f7cf99c75822bdc2fb7c1a1d78d0bcf81488ae0de5269ff853ab8b8f1f2bf3e6c0564573f612808f68dbfef49d5c9b4a705794cf7a424cd4eb1e0260552e67bfc1fa37b4a1f78b757ef185e86e9", 16),
-		new BigInteger( /* q */
+		new GmpInteger( /* q */
 		"00b143368abcd51f58d6440d5417399339a4d15bef096a2c5d8e6df44f52d6d379", 16),
-		new BigInteger( /* g */
+		new GmpInteger( /* g */
 		"51a45ab670c1c9fd10bd395a6805d33339f5675e4b0d35defc9fa03aa5c2bf4ce9cfcdc256781291bfff6d546e67d47ae4e160f804ca72ec3c5492709f5f80f69e6346dd8d3e3d8433b6eeef63bce7f98574185c6aff161c9b536d76f873137365a4246cf414bfe8049ee11e31373cd0a6558e2950ef095320ce86218f992551cc292224114f3b60146d22dd51f8125c9da0c028126ffa85efd4f4bfea2c104453329cc1268a97e9a835c14e4a9a43c6a1886580e35ad8f1de230e1af32208ef9337f1924702a4514e95dc16f30f0c11e714a112ee84a9d8d6c9bc9e74e336560bb5cd4e91eabf6dad26bf0ca04807f8c31a2fc18ea7d45baab7cc997b53c356", 16));
 
 	/* NB: for some reason I can't explain, we're signing truncated hashes...
@@ -48,7 +50,7 @@ public final class Global {
 	static final BigInteger SIGNATURE_MASK = Util.TWO.pow(255).subtract(BigInteger.ONE);
 
 	public static byte[] truncateHash(byte[] message) {
-		BigInteger m = new BigInteger(1, message);
+		BigInteger m = new GmpInteger(1, message);
 		m = m.and(SIGNATURE_MASK);
 		return m.toByteArray();
 	}

--- a/src/freenet/keys/InsertableClientSSK.java
+++ b/src/freenet/keys/InsertableClientSSK.java
@@ -3,6 +3,8 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.keys;
 
+import com.squareup.jnagmp.GmpInteger;
+
 import org.bouncycastle.crypto.digests.SHA256Digest;
 import org.bouncycastle.crypto.params.DSAPrivateKeyParameters;
 import org.bouncycastle.crypto.signers.DSASigner;
@@ -90,7 +92,7 @@ public class InsertableClientSSK extends ClientSSK {
 		DSAGroup g = Global.DSAgroupBigA;
 		DSAPrivateKey privKey;
 		try {
-			privKey = new DSAPrivateKey(new BigInteger(1, uri.getRoutingKey()), g);
+			privKey = new DSAPrivateKey(new GmpInteger(1, uri.getRoutingKey()), g);
 		} catch(IllegalArgumentException e) {
 			// DSAPrivateKey is invalid
 			Logger.error(InsertableClientSSK.class, "Caught "+e, e);

--- a/src/freenet/keys/SSKBlock.java
+++ b/src/freenet/keys/SSKBlock.java
@@ -3,10 +3,11 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.keys;
 
+import com.squareup.jnagmp.GmpInteger;
+
 import org.bouncycastle.crypto.params.DSAPublicKeyParameters;
 import org.bouncycastle.crypto.signers.DSASigner;
 
-import java.math.BigInteger;
 import java.security.MessageDigest;
 import java.util.Arrays;
 
@@ -155,8 +156,8 @@ public class SSKBlock implements KeyBlock {
 			}
 			
 			// Now verify it
-			BigInteger r = new BigInteger(1, bufR);
-			BigInteger s = new BigInteger(1, bufS);
+			GmpInteger r = new GmpInteger(1, bufR);
+			GmpInteger s = new GmpInteger(1, bufS);
 			DSASigner dsa = new DSASigner();
 			dsa.init(false, new DSAPublicKeyParameters(pubKey.getY(), Global.getDSAgroupBigAParameters()));
 


### PR DESCRIPTION
I am not convinced that their binaries are more trustworthy than ours... but they're more recent and support constant-time operations...

Alternatively we could go back to using the NativeBigInteger we already ship (still with JNA)