### PR TITLE
Class IfNull: Deprecate in favor of Java 7 providing the same

### DIFF
--- a/src/freenet/support/codeshortification/IfNull.java
+++ b/src/freenet/support/codeshortification/IfNull.java
@@ -3,6 +3,8 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.support.codeshortification;
 
+import java.util.Objects;
+
 
 /**
  * Class for reducing the amount of code to type with regards to null pointers: <br>
@@ -11,14 +13,21 @@ package freenet.support.codeshortification;
  * <code>IfNull.thenThrow(value, message);</code>
  * 
  * @author xor (xor@freenetproject.org)
+ * @deprecated
+ *     Use {@link Objects#requireNonNull(Object)} or {@link Objects#requireNonNull(Object, String)}
  */
+@Deprecated
 public final class IfNull {
 	
+	/** @deprecated Use {@link Objects#requireNonNull(Object)} */
+	@Deprecated
 	public static void thenThrow(Object value) {
 		if(value == null)
 			throw new NullPointerException();
 	}
 	
+	/** @deprecated Use {@link Objects#requireNonNull(Object, String)} */
+	@Deprecated
 	public static void thenThrow(Object value, String message) {
 		if(value == null)
 			throw new NullPointerException(message);


### PR DESCRIPTION
Fred does not use these, they were added for plugins.
So let's deprecate them for a while before we remove them.