### PR TITLE
Remove db4o constructors; fix wrong documentation of repurposed ones

### DIFF
--- a/src/freenet/client/InsertException.java
+++ b/src/freenet/client/InsertException.java
@@ -48,15 +48,6 @@ public class InsertException extends Exception implements Cloneable {
 		});
 	}
 
-	/**
-	 * zero arg c'tor for db4o on jamvm
-	 */
-	@SuppressWarnings("unused")
-	private InsertException() {
-		mode = null;
-		extra = null;
-	}
-
 	public InsertException(InsertExceptionMode m, String msg, FreenetURI expectedURI) {
 		super(getMessage(m)+": "+msg);
 		extra = msg;

--- a/src/freenet/client/async/BaseClientGetter.java
+++ b/src/freenet/client/async/BaseClientGetter.java
@@ -14,8 +14,8 @@ public abstract class BaseClientGetter extends ClientRequester implements
 		super(priorityClass, cb);
 	}
 	
+	/** Required because we implement {@link Serializable}. */
 	protected BaseClientGetter() {
-	    // For serialization.
 	}
 
 }

--- a/src/freenet/client/async/BaseClientPutter.java
+++ b/src/freenet/client/async/BaseClientPutter.java
@@ -3,6 +3,8 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.client.async;
 
+import java.io.Serializable;
+
 /** Base class for inserts, including site inserts, at the level of a ClientRequester.
  * 
  * WARNING: Changing non-transient members on classes that are Serializable can result in 
@@ -12,9 +14,7 @@ public abstract class BaseClientPutter extends ClientRequester {
 
     private static final long serialVersionUID = 1L;
 
-    /**
-	 * zero arg c'tor for db4o on jamvm
-	 */
+	/** Required because {@link Serializable} is implemented by the parent class. */
 	protected BaseClientPutter() {
 	}
 

--- a/src/freenet/client/async/ClientGetter.java
+++ b/src/freenet/client/async/ClientGetter.java
@@ -168,8 +168,8 @@ implements WantsCooldownCallback, FileGetCompletionCallback, Serializable {
 		this.forceCompatibleExtension = forceCompatibleExtension;
 	}
 	
+	/** Required because we implement {@link Serializable}. */
 	protected ClientGetter() {
-	    // For serialization.
 	    clientCallback = null;
 	    ctx = null;
 	    actx = null;

--- a/src/freenet/client/async/ClientPutter.java
+++ b/src/freenet/client/async/ClientPutter.java
@@ -71,23 +71,6 @@ public class ClientPutter extends BaseClientPutter implements PutCompletionCallb
 			}
 		});
 	}
-	
-	/**
-	 * zero arg c'tor for db4o on jamvm
-	 */
-	@SuppressWarnings("unused")
-	private ClientPutter() {
-		targetURI = null;
-		targetFilename = null;
-		overrideSplitfileCrypto = null;
-		isMetadata = false;
-		data = null;
-		ctx = null;
-		cm = null;
-		client = null;
-		binaryBlob = false;
-		metadataThreshold = 0;
-	}
 
 	/**
 	 * @param client The object to call back when we complete, or don't.

--- a/src/freenet/client/async/ClientRequester.java
+++ b/src/freenet/client/async/ClientRequester.java
@@ -58,9 +58,7 @@ public abstract class ClientRequester implements Serializable, ClientRequestSche
 		return priorityClass;
 	}
 
-	/**
-	 * zero arg c'tor for db4o on jamvm / for serialization.
-	 */
+	/** Required because we implement {@link Serializable}. */
 	protected ClientRequester() {
 		realTimeFlag = false;
 		creationTime = 0;

--- a/src/freenet/client/async/ManifestPutter.java
+++ b/src/freenet/client/async/ManifestPutter.java
@@ -3,13 +3,16 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.client.async;
 
+import java.io.Serializable;
+
 import freenet.client.InsertException;
 
 public abstract class ManifestPutter extends BaseClientPutter {
 	
     private static final long serialVersionUID = 1L;
 
-    protected ManifestPutter() {
+	/** Required because {@link Serializable} is implemented by a parent class. */
+	protected ManifestPutter() {
 	}
 
 	protected ManifestPutter(short priorityClass, ClientBaseCallback cb) {

--- a/src/freenet/client/async/SingleFileInserter.java
+++ b/src/freenet/client/async/SingleFileInserter.java
@@ -573,17 +573,6 @@ class SingleFileInserter implements ClientPutState, Serializable {
 			return hashCode;
 		}
 
-		/**
-		 * zero arg c'tor for db4o on jamvm
-		 */
-		@SuppressWarnings("unused")
-		private SplitHandler() {
-			persistent = false;
-			origDataLength = 0;
-			origCompressedDataLength = 0;
-			hashCode = 0;
-		}
-
 		public SplitHandler(long origDataLength, long origCompressedDataLength, boolean allowSizes) {
 			// Default constructor
 			this.persistent = SingleFileInserter.this.persistent;

--- a/src/freenet/clients/fcp/FinishedCompressionMessage.java
+++ b/src/freenet/clients/fcp/FinishedCompressionMessage.java
@@ -16,18 +16,6 @@ public class FinishedCompressionMessage extends FCPMessage {
 	final long origSize;
 	final long compressedSize;
 
-	/**
-	 * zero arg c'tor for db4o on jamvm
-	 */
-	@SuppressWarnings("unused")
-	private FinishedCompressionMessage() {
-		origSize = 0;
-		identifier = null;
-		global = false;
-		compressedSize = 0;
-		codec = 0;
-	}
-
 	public FinishedCompressionMessage(String identifier, boolean global, FinishedCompressionEvent event) {
 		this.identifier = identifier;
 		this.codec = event.codec;

--- a/src/freenet/clients/fcp/PutFailedMessage.java
+++ b/src/freenet/clients/fcp/PutFailedMessage.java
@@ -26,22 +26,6 @@ public class PutFailedMessage extends FCPMessage implements Serializable {
 	final boolean global;
 	final boolean isFatal;
 
-	/**
-	 * zero arg c'tor for db4o on jamvm
-	 */
-	@SuppressWarnings("unused")
-	private PutFailedMessage() {
-		tracker = null;
-		shortCodeDescription = null;
-		isFatal = false;
-		identifier = null;
-		global = false;
-		extraDescription = null;
-		expectedURI = null;
-		codeDescription = null;
-		code = null;
-	}
-
 	public PutFailedMessage(InsertException e, String identifier, boolean global) {
 		this.code = e.getMode();
 		this.codeDescription = InsertException.getMessage(code);

--- a/src/freenet/support/io/ReadOnlyFileSliceBucket.java
+++ b/src/freenet/support/io/ReadOnlyFileSliceBucket.java
@@ -27,16 +27,6 @@ public class ReadOnlyFileSliceBucket implements Bucket, Serializable {
 	private final long startAt;
 	private final long length;
 
-	/**
-	 * zero arg c'tor for db4o on jamvm / serialization
-	 */
-	@SuppressWarnings("unused")
-	private ReadOnlyFileSliceBucket() {
-		startAt = 0;
-		length = 0;
-		file = null;
-	}
-
 	public ReadOnlyFileSliceBucket(File f, long startAt, long length) {
 		this.file = new File(f.getPath()); // copy so we can delete it
 		this.startAt = startAt;


### PR DESCRIPTION
db4o support has been removed by nextgens recently. For some reason, he left some constructors which were labeled as "zero arg c'tor for db4o on jamvm".

Commit d0c1d9f60376335d4cdb5c8b64bd2b7357129383 removes the ones which can be removed. Unfortunately that is not all of them:
While reading related code, I saw that there are similar constructors which were labeled as "For serialization", you can see them in my commit 47c45addd5618c4bc0759a214de473bd20b31653 (which deals with their lack of JavaDoc formatting as a bonus fix). They were added when replacing db4o with Java serialization at toad's commit 10b1d664860f0a74b02e57ba2dc6edbf77cae521. This made me realize that some of the "zero arg c'tor for db4o on jamvm" are probably still needed:
They are protected, not private, just like the "For serialization" ones, which indicates that they could have been repurposed as backend for Java serialization. And indeed the [JavaDoc of Serializable](https://docs.oracle.com/javase/7/docs/api/java/io/Serializable.html) says:

>  To allow subtypes of non-serializable classes to be serialized, the subtype may assume responsibility for saving and restoring the state of the supertype's public, protected, and (if accessible) package fields. The subtype may assume this responsibility only if the class it extends has an accessible no-arg constructor to initialize the class's state. It is an error to declare a class Serializable if this is not the case. The error will be detected at runtime.
> 
> During deserialization, the fields of non-serializable classes will be initialized using the public or protected no-arg constructor of the class. A no-arg constructor must be accessible to the subclass that is serializable. The fields of serializable subclasses will be restored from the stream. 

So if the non-private zero-arg constructors are really intended for Java serialization nowadays, we should not remove them.
Thus as their JavaDoc had not been updated to mention the new reason of their existence, commit 956dd3d86a03179bed8aa5de808cc338533efed7 fixes that.
Further, f385e2070e9c69a170f2ebb8c310558a93c5c22d fixes the complete lack of JavaDoc at a constructor which very likely exists for the same reason.

But: I am still not confident in whether Java serialization really needs all of those protected constructors:
To me the above quote of the JavaDoc of Serializable sounds like this: Zero-arg constructors are only needed in a parent class which doesn't implement Serializable but wants to have children which do.
But some of the classes with the zero-arg constructors here implement Serializable on their own already, so they wouldn't need those constructors.
@toad To allow a further pull request to remove uselss constructors, can you please clarify why you added zero-arg constructors to those classes? Did you test each one without them and it did not work? Or did you just add zero-arg constructors to ALL Serializable classes without even checking for each one whether they are really needed?

**Notice:** Not tested yet, will test after PR https://github.com/freenet/fred/pull/589 is merged.

**Notice:** Please consider including at least part of this PR message as message of the merge commit.
