### PR TITLE
Fix Eclipse classpath to match the Gradle one

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -9,5 +9,6 @@
 	<classpathentry kind="lib" path="lib/hamcrest-core-1.3.jar"/>
 	<classpathentry kind="lib" path="lib/hamcrest-library-1.3.jar"/>
 	<classpathentry kind="lib" path="lib/junit-4.12.jar"/>
+	<classpathentry kind="lib" path="lib/mockito-core-1.9.5.jar"/>
 	<classpathentry kind="output" path="build/main/"/>
 </classpath>

--- a/.classpath
+++ b/.classpath
@@ -5,6 +5,7 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry exported="true" kind="lib" path="lib/freenet/freenet-ext.jar" sourcepath="/contrib/db4o/src/db4ojdk5"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
+	<classpathentry kind="lib" path="lib/jna-4.2.2.jar"/>
 	<classpathentry kind="lib" path="lib/bcprov-jdk15on-154.jar"/>
 	<classpathentry kind="output" path="build/main/"/>
 </classpath>

--- a/.classpath
+++ b/.classpath
@@ -10,5 +10,6 @@
 	<classpathentry kind="lib" path="lib/hamcrest-library-1.3.jar"/>
 	<classpathentry kind="lib" path="lib/junit-4.12.jar"/>
 	<classpathentry kind="lib" path="lib/mockito-core-1.9.5.jar"/>
+	<classpathentry kind="lib" path="lib/objenesis-1.0.jar"/>
 	<classpathentry kind="output" path="build/main/"/>
 </classpath>

--- a/.classpath
+++ b/.classpath
@@ -4,8 +4,10 @@
 	<classpathentry including="freenet/|org/" kind="src" output="build/test" path="test"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry exported="true" kind="lib" path="lib/freenet/freenet-ext.jar" sourcepath="/contrib/db4o/src/db4ojdk5"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
 	<classpathentry kind="lib" path="lib/jna-4.2.2.jar"/>
 	<classpathentry kind="lib" path="lib/bcprov-jdk15on-154.jar"/>
+	<classpathentry kind="lib" path="lib/hamcrest-core-1.3.jar"/>
+	<classpathentry kind="lib" path="lib/hamcrest-library-1.3.jar"/>
+	<classpathentry kind="lib" path="lib/junit-4.12.jar"/>
 	<classpathentry kind="output" path="build/main/"/>
 </classpath>


### PR DESCRIPTION
Notice:
This adds some dependencies even though they're only listed at `dependencyVerification` sections of Gradle, not  `dependencies`. This is because they're dependencies of other dependencies:
- `hamcrest-core-1.3.jar`  is a compile-time dependency of `hamcrest-library-1.3.jar` 
- `objenesis-1.0.jar` is a runtime dependency of `mockito-core-1.9.5.jar`

_Please consider using this PR message as message of the merge commit._
