### PR TITLE
Fix Ant classpath to match the Gradle one

### DIFF
--- a/build-clean.xml
+++ b/build-clean.xml
@@ -164,7 +164,8 @@ maintainers may prefer to use this instead of build.xml.
 		<available property="lib.bouncycastle.present" classname="org.bouncycastle.crypto.signers.HMacDSAKCalculator" classpathref="lib.path"/>
 		<available property="lib.jna.present" classname="com.sun.jna.Platform" classpathref="lib.path"/>
 		<available property="lib.junit.present" classname="org.junit.runners.JUnit4" classpathref="libtest.path"/>
-		<available property="lib.hamcrest.present" classname="org.hamcrest.Matchers" classpathref="libtest.path"/>
+		<available property="lib.hamcrest.core.present" classname="org.hamcrest.Matcher" classpathref="libtest.path"/>
+		<available property="lib.hamcrest.library.present" classname="org.hamcrest.Matchers" classpathref="libtest.path"/>
 		<available property="lib.objenesis.present" classname="org.objenesis.Objenesis" classpathref="libtest.path"/>
 		<available property="lib.mockito.present" classname="org.mockito.mock.MockName" classpathref="libtest.path"/>
 		<available property="lib.findbugs.present" classname="edu.umd.cs.findbugs.anttask.FindBugsTask" classpath="${findbugs.path}"/>
@@ -196,8 +197,12 @@ maintainers may prefer to use this instead of build.xml.
 		<fail message="JUnit4 not available"/>
 	</target>
 
-	<target name="libdep-hamcrest" depends="env" unless="lib.hamcrest.present">
-		<fail message="Hamcrest-all not available"/>
+	<target name="libdep-hamcrest-core" depends="env" unless="lib.hamcrest.core.present">
+		<fail message="Hamcrest-core not available"/>
+	</target>
+
+	<target name="libdep-hamcrest-library" depends="env" unless="lib.hamcrest.library.present">
+		<fail message="Hamcrest-library not available"/>
 	</target>
 
 	<target name="libdep-objenesis" depends="env" unless="lib.objenesis.present">
@@ -323,7 +328,7 @@ maintainers may prefer to use this instead of build.xml.
 
 	<target name="package" depends="unit, package-only" description="build standard binary packages (Freenet daemon)"/>
 
-	<target name="unit-build" depends="build, libdep-junit, libdep-hamcrest, libdep-objenesis, libdep-mockito" unless="${test.skip}">
+	<target name="unit-build" depends="build, libdep-junit, libdep-hamcrest-core, libdep-hamcrest-library, libdep-objenesis, libdep-mockito" unless="${test.skip}">
 		<javac srcdir="${test.src}" destdir="${test.make}" debug="on" source="1.7" target="1.7" includeAntRuntime="false" encoding="UTF-8">
 			<compilerarg line="${javac.args}"/>
 			<classpath refid="libtest.path"/>

--- a/build-clean.xml
+++ b/build-clean.xml
@@ -165,6 +165,7 @@ maintainers may prefer to use this instead of build.xml.
 		<available property="lib.jna.present" classname="com.sun.jna.Platform" classpathref="lib.path"/>
 		<available property="lib.junit.present" classname="org.junit.runners.JUnit4" classpathref="libtest.path"/>
 		<available property="lib.hamcrest.present" classname="org.hamcrest.Matchers" classpathref="libtest.path"/>
+		<available property="lib.objenesis.present" classname="org.objenesis.Objenesis" classpathref="libtest.path"/>
 		<available property="lib.mockito.present" classname="org.mockito.mock.MockName" classpathref="libtest.path"/>
 		<available property="lib.findbugs.present" classname="edu.umd.cs.findbugs.anttask.FindBugsTask" classpath="${findbugs.path}"/>
 		<available property="lib.pmd.present" classname="net.sourceforge.pmd.ant.PMDTask" classpathref="pmd.classpath"/>
@@ -197,6 +198,10 @@ maintainers may prefer to use this instead of build.xml.
 
 	<target name="libdep-hamcrest" depends="env" unless="lib.hamcrest.present">
 		<fail message="Hamcrest-all not available"/>
+	</target>
+
+	<target name="libdep-objenesis" depends="env" unless="lib.objenesis.present">
+		<fail message="Objenesis not available"/>
 	</target>
 
 	<target name="libdep-mockito" depends="env" unless="lib.mockito.present">
@@ -318,7 +323,7 @@ maintainers may prefer to use this instead of build.xml.
 
 	<target name="package" depends="unit, package-only" description="build standard binary packages (Freenet daemon)"/>
 
-	<target name="unit-build" depends="build, libdep-junit, libdep-hamcrest, libdep-mockito" unless="${test.skip}">
+	<target name="unit-build" depends="build, libdep-junit, libdep-hamcrest, libdep-objenesis, libdep-mockito" unless="${test.skip}">
 		<javac srcdir="${test.src}" destdir="${test.make}" debug="on" source="1.7" target="1.7" includeAntRuntime="false" encoding="UTF-8">
 			<compilerarg line="${javac.args}"/>
 			<classpath refid="libtest.path"/>

--- a/build.properties
+++ b/build.properties
@@ -48,7 +48,7 @@ lib.jars = ${bc.jar} ${jna.jar}
 #lib.jars = wrapper.jar db-je.jar bdb-je.jar commons-compress.jar
 
 # jars from ${lib.dir} to use, for tests
-libtest.jars = junit-4.12.jar hamcrest-core-1.3.jar hamcrest-library-1.3.jar mockito-core-1.9.5.jar objenesis-1.0.jar
+libtest.jars = junit-4.12.jar hamcrest-core-1.3.jar hamcrest-library-1.3.jar objenesis-1.0.jar mockito-core-1.9.5.jar
 
 # jars from ${lib.contrib.dir} to use
 lib.contrib.jars = freenet-ext.jar bitcollider-core.jar db4o.jar lzmajio.jar mantissa.jar \

--- a/build.properties
+++ b/build.properties
@@ -48,7 +48,7 @@ lib.jars = ${bc.jar} ${jna.jar}
 #lib.jars = wrapper.jar db-je.jar bdb-je.jar commons-compress.jar
 
 # jars from ${lib.dir} to use, for tests
-libtest.jars = junit4.jar hamcrest-all-1.3.jar mockito-core-1.9.5.jar
+libtest.jars = junit4.jar hamcrest-all-1.3.jar mockito-core-1.9.5.jar objenesis-1.0.jar
 
 # jars from ${lib.contrib.dir} to use
 lib.contrib.jars = freenet-ext.jar bitcollider-core.jar db4o.jar lzmajio.jar mantissa.jar \

--- a/build.properties
+++ b/build.properties
@@ -48,7 +48,7 @@ lib.jars = ${bc.jar} ${jna.jar}
 #lib.jars = wrapper.jar db-je.jar bdb-je.jar commons-compress.jar
 
 # jars from ${lib.dir} to use, for tests
-libtest.jars = junit-4.12.jar hamcrest-all-1.3.jar mockito-core-1.9.5.jar objenesis-1.0.jar
+libtest.jars = junit-4.12.jar hamcrest-core-1.3.jar hamcrest-library-1.3.jar mockito-core-1.9.5.jar objenesis-1.0.jar
 
 # jars from ${lib.contrib.dir} to use
 lib.contrib.jars = freenet-ext.jar bitcollider-core.jar db4o.jar lzmajio.jar mantissa.jar \

--- a/build.properties
+++ b/build.properties
@@ -48,7 +48,7 @@ lib.jars = ${bc.jar} ${jna.jar}
 #lib.jars = wrapper.jar db-je.jar bdb-je.jar commons-compress.jar
 
 # jars from ${lib.dir} to use, for tests
-libtest.jars = junit4.jar hamcrest-all-1.3.jar mockito-core-1.9.5.jar objenesis-1.0.jar
+libtest.jars = junit-4.12.jar hamcrest-all-1.3.jar mockito-core-1.9.5.jar objenesis-1.0.jar
 
 # jars from ${lib.contrib.dir} to use
 lib.contrib.jars = freenet-ext.jar bitcollider-core.jar db4o.jar lzmajio.jar mantissa.jar \


### PR DESCRIPTION
Notice:
This adds some dependencies even though they're only listed at `dependencyVerification` sections of Gradle, not  `dependencies`. This is because they're dependencies of other dependencies:
- `hamcrest-core-1.3.jar`  is a compile-time dependency of `hamcrest-library-1.3.jar` 
- `objenesis-1.0.jar` is a runtime dependency of `mockito-core-1.9.5.jar`

_Please consider using this PR message as message of the merge commit._
