### PR TITLE
Persist "Bookmark Updated" notifications across restarts

### DIFF
--- a/src/freenet/clients/http/BookmarkEditorToadlet.java
+++ b/src/freenet/clients/http/BookmarkEditorToadlet.java
@@ -401,7 +401,10 @@ public class BookmarkEditorToadlet extends Toadlet {
 						if (!isValidName(name)) {
               addNameError(pageMaker, content);
 						} else
-							newBookmark = new BookmarkItem(key, name, req.getPartAsStringFailsafe("descB", MAX_KEY_LENGTH), req.getPartAsStringFailsafe("explain", MAX_EXPLANATION_LENGTH), hasAnActivelink, ctx.getAlertManager());
+							newBookmark = new BookmarkItem(key, name,
+							        req.getPartAsStringFailsafe("descB", MAX_KEY_LENGTH),
+							        req.getPartAsStringFailsafe("explain", MAX_EXPLANATION_LENGTH),
+							        hasAnActivelink, bookmarkManager, ctx.getAlertManager());
 					} else
 						if (!isValidName(name)) {
               addNameError(pageMaker, content);

--- a/src/freenet/clients/http/bookmark/BookmarkItem.java
+++ b/src/freenet/clients/http/bookmark/BookmarkItem.java
@@ -20,6 +20,7 @@ import freenet.support.SimpleFieldSet;
 
 public class BookmarkItem extends Bookmark {
     public static final String NAME = "Bookmark";
+    private final BookmarkManager manager;
     private FreenetURI key;
     private boolean updated;
     private boolean hasAnActivelink = false;
@@ -28,21 +29,22 @@ public class BookmarkItem extends Bookmark {
     protected String desc;
     protected String shortDescription;
 
-    public BookmarkItem(FreenetURI k, String n, String d, String s, boolean hasAnActivelink, UserAlertManager uam)
-            throws MalformedURLException {
-
+    public BookmarkItem(FreenetURI k, String n, String d, String s, boolean hasAnActivelink,
+            BookmarkManager bm, UserAlertManager uam) throws MalformedURLException {
         this.key = k;
         this.name = n;
         this.desc = d;
         this.shortDescription = s;
         this.hasAnActivelink = hasAnActivelink;
+        this.manager = bm;
         this.alerts = uam;
         alert = new BookmarkUpdatedUserAlert();
         assert(name != null);
         assert(key != null);
     }
 
-    public BookmarkItem(SimpleFieldSet sfs, UserAlertManager uam) throws FSParseException, MalformedURLException {
+    public BookmarkItem(SimpleFieldSet sfs, BookmarkManager bm, UserAlertManager uam)
+            throws FSParseException, MalformedURLException {
         this.name = sfs.get("Name");
         if(name == null || name.isEmpty()) name = l10n("unnamedBookmark");
         this.desc = sfs.get("Description");
@@ -51,6 +53,7 @@ public class BookmarkItem extends Bookmark {
         if(shortDescription == null) shortDescription = "";
         this.hasAnActivelink = sfs.getBoolean("hasAnActivelink");
         this.key = new FreenetURI(sfs.get("URI"));
+        this.manager = bm;
         this.alerts = uam;
         this.alert = new BookmarkUpdatedUserAlert();
     }

--- a/src/freenet/clients/http/bookmark/BookmarkItem.java
+++ b/src/freenet/clients/http/bookmark/BookmarkItem.java
@@ -14,7 +14,6 @@ import freenet.node.NodeClientCore;
 import freenet.node.useralerts.AbstractUserAlert;
 import freenet.node.useralerts.UserAlert;
 import freenet.node.useralerts.UserAlertManager;
-import freenet.support.Fields;
 import freenet.support.HTMLNode;
 import freenet.support.Logger;
 import freenet.support.SimpleFieldSet;
@@ -43,18 +42,6 @@ public class BookmarkItem extends Bookmark {
         assert(key != null);
     }
 
-    public BookmarkItem(String line, UserAlertManager uam) throws MalformedURLException {
-        String[] result = line.split("###");
-        this.name = result[0];
-        this.desc = result[1];
-        this.hasAnActivelink = Fields.stringToBool(result[2], false);
-        this.key = new FreenetURI(result[3]);
-        this.alerts = uam;
-        this.alert = new BookmarkUpdatedUserAlert();
-        assert(name != null);
-        assert(key != null);
-    }
-    
     public BookmarkItem(SimpleFieldSet sfs, UserAlertManager uam) throws FSParseException, MalformedURLException {
         this.name = sfs.get("Name");
         if(name == null || name.isEmpty()) name = l10n("unnamedBookmark");

--- a/src/freenet/clients/http/bookmark/BookmarkManager.java
+++ b/src/freenet/clients/http/bookmark/BookmarkManager.java
@@ -411,6 +411,7 @@ public class BookmarkManager implements RequestClient {
 						String name = (isRoot ? "" : prefix + category.name) + '/' + item.name;
 						putPaths(name, item);
 						category.addBookmark(item);
+						item.registerUserAlert();
 						subscribeToUSK(item);
 					} catch(MalformedURLException e) {
 						throw new FSParseException(e);

--- a/src/freenet/clients/http/bookmark/BookmarkManager.java
+++ b/src/freenet/clients/http/bookmark/BookmarkManager.java
@@ -407,7 +407,7 @@ public class BookmarkManager implements RequestClient {
 				for(int i = 0; i < nbBookmarks; i++) {
 					SimpleFieldSet subset = sfs.getSubset(BookmarkItem.NAME + i);
 					try {
-						BookmarkItem item = new BookmarkItem(subset, node.alerts);
+						BookmarkItem item = new BookmarkItem(subset, this, node.alerts);
 						String name = (isRoot ? "" : prefix + category.name) + '/' + item.name;
 						putPaths(name, item);
 						category.addBookmark(item);


### PR DESCRIPTION
Previously, if you received a notification about an updated USK bookmark, and then restarted the node, the notification would be lost: The node stored the updated edition number to disk, but not the notification. So it wouldn't download the edition again, and thus not create another notification.
This is fixed by this PR.

_Please use this PR message as message of the merge commit._
