### PR TITLE
Don’t send unwanted list request identifiers

### DIFF
--- a/src/freenet/clients/fcp/GetRequestStatusMessage.java
+++ b/src/freenet/clients/fcp/GetRequestStatusMessage.java
@@ -54,7 +54,7 @@ public class GetRequestStatusMessage extends FCPMessage {
                             ProtocolErrorMessage msg = new ProtocolErrorMessage(ProtocolErrorMessage.NO_SUCH_IDENTIFIER, false, null, identifier, global);
                             handler.outputHandler.queue(msg);
                         } else {
-                            req.sendPendingMessages(handler.outputHandler, identifier, true, true, onlyData);
+                            req.sendPendingMessages(handler.outputHandler, null, true, true, onlyData);
                         }
                         return false;
                     }
@@ -65,7 +65,7 @@ public class GetRequestStatusMessage extends FCPMessage {
                 handler.outputHandler.queue(msg);
             }
 		} else {
-			req.sendPendingMessages(handler.outputHandler, identifier, true, true, onlyData);
+			req.sendPendingMessages(handler.outputHandler, null, true, true, onlyData);
 		}
 	}
 


### PR DESCRIPTION
The “listRequestIdentifier” parameter should only be used when sending
messages as a response to a “ListPersistentRequest” command. When using
“GetRequestStatus,” this identifier would only duplicate the
“Identifier” field and is thus not necessary.
