### PR TITLE
Remove unused parameter

### DIFF
--- a/src/freenet/clients/fcp/ClientGet.java
+++ b/src/freenet/clients/fcp/ClientGet.java
@@ -461,9 +461,9 @@ public class ClientGet extends ClientRequest implements ClientGetCallback, Clien
     }
 
     @Override
-	public void sendPendingMessages(FCPConnectionOutputHandler handler, String listRequestIdentifier, boolean includePersistentRequest, boolean includeData, boolean onlyData) {
+	public void sendPendingMessages(FCPConnectionOutputHandler handler, String listRequestIdentifier, boolean includeData, boolean onlyData) {
 		if(!onlyData) {
-			if(includePersistentRequest) {
+			if (true) {
 				FCPMessage msg = persistentTagMessage();
 				handler.queue(FCPMessage.withListRequestIdentifier(msg, listRequestIdentifier));
 			}

--- a/src/freenet/clients/fcp/ClientGet.java
+++ b/src/freenet/clients/fcp/ClientGet.java
@@ -463,10 +463,8 @@ public class ClientGet extends ClientRequest implements ClientGetCallback, Clien
     @Override
 	public void sendPendingMessages(FCPConnectionOutputHandler handler, String listRequestIdentifier, boolean includeData, boolean onlyData) {
 		if(!onlyData) {
-			if (true) {
-				FCPMessage msg = persistentTagMessage();
-				handler.queue(FCPMessage.withListRequestIdentifier(msg, listRequestIdentifier));
-			}
+			FCPMessage msg = persistentTagMessage();
+			handler.queue(FCPMessage.withListRequestIdentifier(msg, listRequestIdentifier));
 			if(progressPending != null) {
 				handler.queue(FCPMessage.withListRequestIdentifier(progressPending, listRequestIdentifier));
 			}

--- a/src/freenet/clients/fcp/ClientPutBase.java
+++ b/src/freenet/clients/fcp/ClientPutBase.java
@@ -418,8 +418,8 @@ public abstract class ClientPutBase extends ClientRequest implements ClientPutCa
 	protected abstract FCPMessage persistentTagMessage();
 
 	@Override
-	public void sendPendingMessages(FCPConnectionOutputHandler handler, String listRequestIdentifier, boolean includePersistentRequest, boolean includeData, boolean onlyData) {
-		if(includePersistentRequest) {
+	public void sendPendingMessages(FCPConnectionOutputHandler handler, String listRequestIdentifier, boolean includeData, boolean onlyData) {
+		if (true) {
 			FCPMessage msg = FCPMessage.withListRequestIdentifier(persistentTagMessage(), listRequestIdentifier);
 			handler.queue(msg);
 		}

--- a/src/freenet/clients/fcp/ClientPutBase.java
+++ b/src/freenet/clients/fcp/ClientPutBase.java
@@ -419,13 +419,10 @@ public abstract class ClientPutBase extends ClientRequest implements ClientPutCa
 
 	@Override
 	public void sendPendingMessages(FCPConnectionOutputHandler handler, String listRequestIdentifier, boolean includeData, boolean onlyData) {
-		if (true) {
-			FCPMessage msg = FCPMessage.withListRequestIdentifier(persistentTagMessage(), listRequestIdentifier);
-			handler.queue(msg);
-		}
+		FCPMessage msg = FCPMessage.withListRequestIdentifier(persistentTagMessage(), listRequestIdentifier);
+		handler.queue(msg);
 
 		boolean generated = false;
-		FCPMessage msg = null;
 		boolean fin = false;
 		Bucket meta;
 		synchronized (this) {

--- a/src/freenet/clients/fcp/ClientRequest.java
+++ b/src/freenet/clients/fcp/ClientRequest.java
@@ -177,7 +177,7 @@ public abstract class ClientRequest implements Serializable {
 	public abstract void onLostConnection(ClientContext context);
 
 	/** Send any pending messages for a persistent request e.g. after reconnecting */
-	public abstract void sendPendingMessages(FCPConnectionOutputHandler handler, String listRequestIdentifier, boolean includePersistentRequest, boolean includeData, boolean onlyData);
+	public abstract void sendPendingMessages(FCPConnectionOutputHandler handler, String listRequestIdentifier, boolean includeData, boolean onlyData);
 
 	// Persistence
 

--- a/src/freenet/clients/fcp/GetRequestStatusMessage.java
+++ b/src/freenet/clients/fcp/GetRequestStatusMessage.java
@@ -54,7 +54,7 @@ public class GetRequestStatusMessage extends FCPMessage {
                             ProtocolErrorMessage msg = new ProtocolErrorMessage(ProtocolErrorMessage.NO_SUCH_IDENTIFIER, false, null, identifier, global);
                             handler.outputHandler.queue(msg);
                         } else {
-                            req.sendPendingMessages(handler.outputHandler, identifier, true, true, onlyData);
+                            req.sendPendingMessages(handler.outputHandler, identifier, true, onlyData);
                         }
                         return false;
                     }
@@ -65,7 +65,7 @@ public class GetRequestStatusMessage extends FCPMessage {
                 handler.outputHandler.queue(msg);
             }
 		} else {
-			req.sendPendingMessages(handler.outputHandler, identifier, true, true, onlyData);
+			req.sendPendingMessages(handler.outputHandler, identifier, true, onlyData);
 		}
 	}
 

--- a/src/freenet/clients/fcp/PersistentRequestClient.java
+++ b/src/freenet/clients/fcp/PersistentRequestClient.java
@@ -191,7 +191,7 @@ public class PersistentRequestClient {
 		int i = 0;
 		for(i=offset;i<Math.min(reqs.length,offset+max);i++) {
 			ClientRequest req = (ClientRequest) reqs[i];
-			((ClientRequest)reqs[i]).sendPendingMessages(outputHandler, listRequestIdentifier, true, false, false);
+			((ClientRequest)reqs[i]).sendPendingMessages(outputHandler, listRequestIdentifier, false, false);
 		}
 		return i;
 	}
@@ -207,7 +207,7 @@ public class PersistentRequestClient {
 		int i = 0;
 		for(i=offset;i<Math.min(reqs.length,offset+max);i++) {
 			ClientRequest req = (ClientRequest) reqs[i];
-			req.sendPendingMessages(outputHandler, listRequestIdentifier, true, false, false);
+			req.sendPendingMessages(outputHandler, listRequestIdentifier, false, false);
 		}
 		return i;
 	}


### PR DESCRIPTION
The “includePersistentRequest” parameter was always `true`.
