### PR TITLE
Ant builder: Force user to notice deprecation in favor of Gradle

### DIFF
--- a/build-clean.xml
+++ b/build-clean.xml
@@ -164,7 +164,8 @@ maintainers may prefer to use this instead of build.xml.
 		<available property="lib.bouncycastle.present" classname="org.bouncycastle.crypto.signers.HMacDSAKCalculator" classpathref="lib.path"/>
 		<available property="lib.jna.present" classname="com.sun.jna.Platform" classpathref="lib.path"/>
 		<available property="lib.junit.present" classname="org.junit.runners.JUnit4" classpathref="libtest.path"/>
-		<available property="lib.hamcrest.present" classname="org.hamcrest.Matchers" classpathref="libtest.path"/>
+		<available property="lib.hamcrest.core.present" classname="org.hamcrest.Matcher" classpathref="libtest.path"/>
+		<available property="lib.hamcrest.library.present" classname="org.hamcrest.Matchers" classpathref="libtest.path"/>
 		<available property="lib.objenesis.present" classname="org.objenesis.Objenesis" classpathref="libtest.path"/>
 		<available property="lib.mockito.present" classname="org.mockito.mock.MockName" classpathref="libtest.path"/>
 		<available property="lib.findbugs.present" classname="edu.umd.cs.findbugs.anttask.FindBugsTask" classpath="${findbugs.path}"/>
@@ -196,8 +197,12 @@ maintainers may prefer to use this instead of build.xml.
 		<fail message="JUnit4 not available"/>
 	</target>
 
-	<target name="libdep-hamcrest" depends="env" unless="lib.hamcrest.present">
-		<fail message="Hamcrest-all not available"/>
+	<target name="libdep-hamcrest-core" depends="env" unless="lib.hamcrest.core.present">
+		<fail message="Hamcrest-core not available"/>
+	</target>
+
+	<target name="libdep-hamcrest-library" depends="env" unless="lib.hamcrest.library.present">
+		<fail message="Hamcrest-library not available"/>
 	</target>
 
 	<target name="libdep-objenesis" depends="env" unless="lib.objenesis.present">
@@ -323,7 +328,7 @@ maintainers may prefer to use this instead of build.xml.
 
 	<target name="package" depends="unit, package-only" description="build standard binary packages (Freenet daemon)"/>
 
-	<target name="unit-build" depends="build, libdep-junit, libdep-hamcrest, libdep-objenesis, libdep-mockito" unless="${test.skip}">
+	<target name="unit-build" depends="build, libdep-junit, libdep-hamcrest-core, libdep-hamcrest-library, libdep-objenesis, libdep-mockito" unless="${test.skip}">
 		<javac srcdir="${test.src}" destdir="${test.make}" debug="on" source="1.7" target="1.7" includeAntRuntime="false" encoding="UTF-8">
 			<compilerarg line="${javac.args}"/>
 			<classpath refid="libtest.path"/>

--- a/build-clean.xml
+++ b/build-clean.xml
@@ -77,6 +77,15 @@ maintainers may prefer to use this instead of build.xml.
 	<!-- Miscellaneous                                                       -->
 	<!-- =================================================================== -->
 
+	<fail unless="${ant.enable}" message=
+"The Ant builder has been deprecated in favor of the Gradle builder. Please prefer to use that one
+if possible.
+If you really need one of the build targets which are not available in Gradle yet, you may enable
+Ant by passing the parameter '-Dant.enable=true' or setting 'ant.enable=true' in the file
+'override.properties'.
+For how to use Gradle see https://gradle.org/"
+	/>
+
 	<target name="dist" depends="clean-all, all" description="clean-build everything"/>
 
 	<target name="sign" description="Sign the distribution" depends="package">

--- a/build-clean.xml
+++ b/build-clean.xml
@@ -165,6 +165,7 @@ maintainers may prefer to use this instead of build.xml.
 		<available property="lib.jna.present" classname="com.sun.jna.Platform" classpathref="lib.path"/>
 		<available property="lib.junit.present" classname="org.junit.runners.JUnit4" classpathref="libtest.path"/>
 		<available property="lib.hamcrest.present" classname="org.hamcrest.Matchers" classpathref="libtest.path"/>
+		<available property="lib.objenesis.present" classname="org.objenesis.Objenesis" classpathref="libtest.path"/>
 		<available property="lib.mockito.present" classname="org.mockito.mock.MockName" classpathref="libtest.path"/>
 		<available property="lib.findbugs.present" classname="edu.umd.cs.findbugs.anttask.FindBugsTask" classpath="${findbugs.path}"/>
 		<available property="lib.pmd.present" classname="net.sourceforge.pmd.ant.PMDTask" classpathref="pmd.classpath"/>
@@ -197,6 +198,10 @@ maintainers may prefer to use this instead of build.xml.
 
 	<target name="libdep-hamcrest" depends="env" unless="lib.hamcrest.present">
 		<fail message="Hamcrest-all not available"/>
+	</target>
+
+	<target name="libdep-objenesis" depends="env" unless="lib.objenesis.present">
+		<fail message="Objenesis not available"/>
 	</target>
 
 	<target name="libdep-mockito" depends="env" unless="lib.mockito.present">
@@ -318,7 +323,7 @@ maintainers may prefer to use this instead of build.xml.
 
 	<target name="package" depends="unit, package-only" description="build standard binary packages (Freenet daemon)"/>
 
-	<target name="unit-build" depends="build, libdep-junit, libdep-hamcrest, libdep-mockito" unless="${test.skip}">
+	<target name="unit-build" depends="build, libdep-junit, libdep-hamcrest, libdep-objenesis, libdep-mockito" unless="${test.skip}">
 		<javac srcdir="${test.src}" destdir="${test.make}" debug="on" source="1.7" target="1.7" includeAntRuntime="false" encoding="UTF-8">
 			<compilerarg line="${javac.args}"/>
 			<classpath refid="libtest.path"/>

--- a/build.properties
+++ b/build.properties
@@ -48,7 +48,7 @@ lib.jars = ${bc.jar} ${jna.jar}
 #lib.jars = wrapper.jar db-je.jar bdb-je.jar commons-compress.jar
 
 # jars from ${lib.dir} to use, for tests
-libtest.jars = junit-4.12.jar hamcrest-core-1.3.jar hamcrest-library-1.3.jar mockito-core-1.9.5.jar objenesis-1.0.jar
+libtest.jars = junit-4.12.jar hamcrest-core-1.3.jar hamcrest-library-1.3.jar objenesis-1.0.jar mockito-core-1.9.5.jar
 
 # jars from ${lib.contrib.dir} to use
 lib.contrib.jars = freenet-ext.jar bitcollider-core.jar db4o.jar lzmajio.jar mantissa.jar \

--- a/build.properties
+++ b/build.properties
@@ -48,7 +48,7 @@ lib.jars = ${bc.jar} ${jna.jar}
 #lib.jars = wrapper.jar db-je.jar bdb-je.jar commons-compress.jar
 
 # jars from ${lib.dir} to use, for tests
-libtest.jars = junit4.jar hamcrest-all-1.3.jar mockito-core-1.9.5.jar
+libtest.jars = junit4.jar hamcrest-all-1.3.jar mockito-core-1.9.5.jar objenesis-1.0.jar
 
 # jars from ${lib.contrib.dir} to use
 lib.contrib.jars = freenet-ext.jar bitcollider-core.jar db4o.jar lzmajio.jar mantissa.jar \

--- a/build.properties
+++ b/build.properties
@@ -48,7 +48,7 @@ lib.jars = ${bc.jar} ${jna.jar}
 #lib.jars = wrapper.jar db-je.jar bdb-je.jar commons-compress.jar
 
 # jars from ${lib.dir} to use, for tests
-libtest.jars = junit-4.12.jar hamcrest-all-1.3.jar mockito-core-1.9.5.jar objenesis-1.0.jar
+libtest.jars = junit-4.12.jar hamcrest-core-1.3.jar hamcrest-library-1.3.jar mockito-core-1.9.5.jar objenesis-1.0.jar
 
 # jars from ${lib.contrib.dir} to use
 lib.contrib.jars = freenet-ext.jar bitcollider-core.jar db4o.jar lzmajio.jar mantissa.jar \

--- a/build.properties
+++ b/build.properties
@@ -48,7 +48,7 @@ lib.jars = ${bc.jar} ${jna.jar}
 #lib.jars = wrapper.jar db-je.jar bdb-je.jar commons-compress.jar
 
 # jars from ${lib.dir} to use, for tests
-libtest.jars = junit4.jar hamcrest-all-1.3.jar mockito-core-1.9.5.jar objenesis-1.0.jar
+libtest.jars = junit-4.12.jar hamcrest-all-1.3.jar mockito-core-1.9.5.jar objenesis-1.0.jar
 
 # jars from ${lib.contrib.dir} to use
 lib.contrib.jars = freenet-ext.jar bitcollider-core.jar db4o.jar lzmajio.jar mantissa.jar \


### PR DESCRIPTION
Intended as a replacement for https://github.com/freenet/fred/pull/590
Based on https://github.com/freenet/fred/pull/587 to avoid merge conflicts.

The Ant builder supports various things which the Gradle one cannot do yet, for example:
- Building the JavaDoc
- Computing test coverage (https://github.com/freenet/fred/pull/553)
- Static code analysis using PMD (https://pmd.github.io/)
- Static code analysis using findbugs (http://findbugs.sourceforge.net/)
- Finding duplicate code with CPD (http://pmd.sourceforge.net/pmd-4.3.0/cpd.html)
- The Eclipse IDE (used by toad_ and xor). Notice that albeit #590 claims that it replaces #586 (= fix Eclipse to work) it doesn't actually seem to contain any Eclipse-related code so Eclipse would still be broken with Gradle.

I would thus really like to keep the Ant builder for some time.
To justify that, this PR will make it fail with a deprecation warning until the user manually disables the warning by a command line parameter / changing the override file.

As a compensation for keeping it in the codebase I will continue maintaining it.
