### PR TITLE
Fix ContentFilterTest to work with both Gradle and Ant

### DIFF
--- a/build-clean.xml
+++ b/build-clean.xml
@@ -164,7 +164,9 @@ maintainers may prefer to use this instead of build.xml.
 		<available property="lib.bouncycastle.present" classname="org.bouncycastle.crypto.signers.HMacDSAKCalculator" classpathref="lib.path"/>
 		<available property="lib.jna.present" classname="com.sun.jna.Platform" classpathref="lib.path"/>
 		<available property="lib.junit.present" classname="org.junit.runners.JUnit4" classpathref="libtest.path"/>
-		<available property="lib.hamcrest.present" classname="org.hamcrest.Matchers" classpathref="libtest.path"/>
+		<available property="lib.hamcrest.core.present" classname="org.hamcrest.Matcher" classpathref="libtest.path"/>
+		<available property="lib.hamcrest.library.present" classname="org.hamcrest.Matchers" classpathref="libtest.path"/>
+		<available property="lib.objenesis.present" classname="org.objenesis.Objenesis" classpathref="libtest.path"/>
 		<available property="lib.mockito.present" classname="org.mockito.mock.MockName" classpathref="libtest.path"/>
 		<available property="lib.findbugs.present" classname="edu.umd.cs.findbugs.anttask.FindBugsTask" classpath="${findbugs.path}"/>
 		<available property="lib.pmd.present" classname="net.sourceforge.pmd.ant.PMDTask" classpathref="pmd.classpath"/>
@@ -195,8 +197,16 @@ maintainers may prefer to use this instead of build.xml.
 		<fail message="JUnit4 not available"/>
 	</target>
 
-	<target name="libdep-hamcrest" depends="env" unless="lib.hamcrest.present">
-		<fail message="Hamcrest-all not available"/>
+	<target name="libdep-hamcrest-core" depends="env" unless="lib.hamcrest.core.present">
+		<fail message="Hamcrest-core not available"/>
+	</target>
+
+	<target name="libdep-hamcrest-library" depends="env" unless="lib.hamcrest.library.present">
+		<fail message="Hamcrest-library not available"/>
+	</target>
+
+	<target name="libdep-objenesis" depends="env" unless="lib.objenesis.present">
+		<fail message="Objenesis not available"/>
 	</target>
 
 	<target name="libdep-mockito" depends="env" unless="lib.mockito.present">
@@ -318,7 +328,7 @@ maintainers may prefer to use this instead of build.xml.
 
 	<target name="package" depends="unit, package-only" description="build standard binary packages (Freenet daemon)"/>
 
-	<target name="unit-build" depends="build, libdep-junit, libdep-hamcrest, libdep-mockito" unless="${test.skip}">
+	<target name="unit-build" depends="build, libdep-junit, libdep-hamcrest-core, libdep-hamcrest-library, libdep-objenesis, libdep-mockito" unless="${test.skip}">
 		<javac srcdir="${test.src}" destdir="${test.make}" debug="on" source="1.7" target="1.7" includeAntRuntime="false" encoding="UTF-8">
 			<compilerarg line="${javac.args}"/>
 			<classpath refid="libtest.path"/>

--- a/build.properties
+++ b/build.properties
@@ -48,7 +48,7 @@ lib.jars = ${bc.jar} ${jna.jar}
 #lib.jars = wrapper.jar db-je.jar bdb-je.jar commons-compress.jar
 
 # jars from ${lib.dir} to use, for tests
-libtest.jars = junit4.jar hamcrest-all-1.3.jar mockito-core-1.9.5.jar
+libtest.jars = junit-4.12.jar hamcrest-core-1.3.jar hamcrest-library-1.3.jar objenesis-1.0.jar mockito-core-1.9.5.jar
 
 # jars from ${lib.contrib.dir} to use
 lib.contrib.jars = freenet-ext.jar bitcollider-core.jar db4o.jar lzmajio.jar mantissa.jar \

--- a/src/freenet/l10n/NodeL10n.java
+++ b/src/freenet/l10n/NodeL10n.java
@@ -3,8 +3,9 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.l10n;
 
-import freenet.l10n.BaseL10n.LANGUAGE;
 import java.io.File;
+
+import freenet.l10n.BaseL10n.LANGUAGE;
 
 /**
  * This is the interface used to localize the Node. It just wraps a BaseL10n
@@ -18,6 +19,11 @@ import java.io.File;
  * @author Artefact2
  */
 public class NodeL10n {
+
+	public static final String L10N_FILES_MASK = "freenet.l10n.${lang}.properties";
+
+	public static final String L10N_OVERRIDE_FILES_MASK
+		= "freenet.l10n.${lang}.override.properties";
 
 	private static BaseL10n b;
 
@@ -36,8 +42,16 @@ public class NodeL10n {
 	 * @see LANGUAGE#mapToLanguage(String)
 	 */
 	public NodeL10n(final LANGUAGE lang, File overrideDir) {
-		NodeL10n.b = new BaseL10n("freenet/l10n/", "freenet.l10n.${lang}.properties",
-		  overrideDir.getPath()+File.separator+"freenet.l10n.${lang}.override.properties", lang);
+		NodeL10n.b = new BaseL10n("freenet/l10n/", L10N_FILES_MASK,
+		  overrideDir.getPath()+File.separator+L10N_OVERRIDE_FILES_MASK, lang);
+	}
+
+	/**
+	 * Typically for unit test purposes only:
+	 * Constructor which supports overriding the default directory of the l10n files. */
+	public NodeL10n(final LANGUAGE lang, File l10nDir, File overrideDir) {
+		NodeL10n.b = new BaseL10n(l10nDir.toString(), L10N_FILES_MASK,
+			overrideDir.getPath()+File.separator+L10N_OVERRIDE_FILES_MASK, lang);
 	}
 
 	/**

--- a/test/freenet/client/filter/ContentFilterTest.java
+++ b/test/freenet/client/filter/ContentFilterTest.java
@@ -3,24 +3,28 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.client.filter;
 
-import junit.framework.TestCase;
-
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.util.LinkedHashMap;
 
+import junit.framework.TestCase;
+import freenet.client.filter.ContentFilter;
+import freenet.client.filter.DataFilterException;
+import freenet.client.filter.GenericReadFilterCallback;
+import freenet.client.filter.HTMLFilter;
 import freenet.client.filter.ContentFilter.FilterStatus;
-import freenet.client.filter.HTMLFilter.ParsedTag;
-import freenet.client.filter.HTMLFilter.TagVerifier;
+import freenet.client.filter.HTMLFilter.*;
 import freenet.clients.http.ExternalLinkToadlet;
+import freenet.l10n.NodeL10n;
 import freenet.support.Logger;
 import freenet.support.Logger.LogLevel;
-import freenet.support.TestProperty;
 import freenet.support.io.ArrayBucket;
+
+import freenet.support.TestProperty;
 
 /**
  * A simple meta-test to track regressions of the content-filter
@@ -122,6 +126,8 @@ public class ContentFilterTest extends TestCase {
 	private static final String CSS_SPEC_EXAMPLE1 = "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01//EN\">\n<HTML>\n  <HEAD>\n  <TITLE>Bach's home page</TITLE>\n  <STYLE type=\"text/css\">\n    body {\n      font-family: \"Gill Sans\", sans-serif;\n      font-size: 12pt;\n      margin: 3em;\n\n    }\n  </STYLE>\n  </HEAD>\n  <BODY>\n    <H1>Bach's home page</H1>\n    <P>Johann Sebastian Bach was a prolific composer.\n  </BODY>\n</HTML>";
 
 	public void testHTMLFilter() throws Exception {
+		new NodeL10n();
+
 		if (TestProperty.VERBOSE) {
 			Logger.setupStdoutLogging(LogLevel.MINOR, "freenet.client.filter.Generic:DEBUG");
 		}
@@ -205,9 +211,11 @@ public class ContentFilterTest extends TestCase {
 	private static final String META_BOGUS_REDIRECT4 = "<meta http-equiv=\"refresh\" content=\"30; url=//www.google.com\">";
 	private static final String META_BOGUS_REDIRECT5 = "<meta http-equiv=\"refresh\" content=\"30; url=\"/KSK@gpl.txt\"\">";
 	private static final String META_BOGUS_REDIRECT6 = "<meta http-equiv=\"refresh\" content=\"30; /KSK@gpl.txt\">";
-	private static final String META_BOGUS_REDIRECT1_OUT = "<!-- GenericReadFilterCallback.malformedRelativeURL-->";
+	private static final String META_BOGUS_REDIRECT1_OUT = "<!-- Malformed URL (relative): There is no @ in that URI! ()-->";
+	private static final String META_BOGUS_REDIRECT2_OUT = "<!-- Malformed URL (relative): There is no @ in that URI! (plugins)-->";
 	private static final String META_BOGUS_REDIRECT3_OUT = "<meta http-equiv=\"refresh\" content=\"30; url=/external-link/?_CHECKED_HTTP_=http://www.google.com\">";
-	private static final String META_BOGUS_REDIRECT4_OUT = "<!-- GenericReadFilterCallback.deletedURI-->";
+	private static final String META_BOGUS_REDIRECT4_OUT = "<!-- Deleted invalid or dangerous URI-->";
+	private static final String META_BOGUS_REDIRECT5_OUT = "<!-- Malformed URL (relative): Invalid key type: \"/KSK-->";
 	private static final String META_BOGUS_REDIRECT_NO_URL = "<!-- no url but doesn't parse as number in meta refresh -->";
 	
 	public void testMetaRefresh() throws Exception {
@@ -222,10 +230,10 @@ public class ContentFilterTest extends TestCase {
 		assertEquals(META_VALID_REDIRECT, headFilter(META_VALID_REDIRECT));
 		assertEquals(META_VALID_REDIRECT, headFilter(META_VALID_REDIRECT_NOSPACE));
 		assertEquals(META_BOGUS_REDIRECT1_OUT, headFilter(META_BOGUS_REDIRECT1));
-		assertEquals(META_BOGUS_REDIRECT1_OUT, headFilter(META_BOGUS_REDIRECT2));
+		assertEquals(META_BOGUS_REDIRECT2_OUT, headFilter(META_BOGUS_REDIRECT2));
 		assertEquals(META_BOGUS_REDIRECT3_OUT, headFilter(META_BOGUS_REDIRECT3));
 		assertEquals(META_BOGUS_REDIRECT4_OUT, headFilter(META_BOGUS_REDIRECT4));
-		assertEquals(META_BOGUS_REDIRECT1_OUT, headFilter(META_BOGUS_REDIRECT5));
+		assertEquals(META_BOGUS_REDIRECT5_OUT, headFilter(META_BOGUS_REDIRECT5));
 		assertEquals(META_BOGUS_REDIRECT_NO_URL, headFilter(META_BOGUS_REDIRECT6));
 		HTMLFilter.metaRefreshSamePageMinInterval = -1;
 		HTMLFilter.metaRefreshRedirectMinInterval = -1;

--- a/test/freenet/client/filter/ContentFilterTest.java
+++ b/test/freenet/client/filter/ContentFilterTest.java
@@ -3,6 +3,7 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.client.filter;
 
+import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -20,10 +21,10 @@ import freenet.client.filter.ContentFilter.FilterStatus;
 import freenet.client.filter.HTMLFilter.*;
 import freenet.clients.http.ExternalLinkToadlet;
 import freenet.l10n.NodeL10n;
+import freenet.l10n.BaseL10n.LANGUAGE;
 import freenet.support.Logger;
 import freenet.support.Logger.LogLevel;
 import freenet.support.io.ArrayBucket;
-
 import freenet.support.TestProperty;
 
 /**
@@ -217,7 +218,15 @@ public class ContentFilterTest extends TestCase {
 	private static final String META_BOGUS_REDIRECT4_OUT = "<!-- Deleted invalid or dangerous URI-->";
 	private static final String META_BOGUS_REDIRECT5_OUT = "<!-- Malformed URL (relative): Invalid key type: \"/KSK-->";
 	private static final String META_BOGUS_REDIRECT_NO_URL = "<!-- no url but doesn't parse as number in meta refresh -->";
-	
+
+
+	public void setUp() {
+		// L10n files are located in a different place for unit tests so automatic discovery will
+		// not work. Thus we must manually tell NodeL10n where the files are.
+		File l10nDir = new File(TestProperty.L10nPath_main);
+		new NodeL10n(LANGUAGE.ENGLISH, l10nDir, l10nDir);
+	}
+
 	public void testMetaRefresh() throws Exception {
 		HTMLFilter.metaRefreshSamePageMinInterval = 5;
 		HTMLFilter.metaRefreshRedirectMinInterval = 30;


### PR DESCRIPTION
Notice: This is based on https://github.com/freenet/fred/pull/587 to ensure Ant works in the first place.

Commit 813c2c94c95e3cde72c7c2ba5a12bbb3ea2e3e9b fixed ContentFilterTest to succeed with Gradle but broke it for Ant.

This PR reverts that part of 813c2c94c95e3cde72c7c2ba5a12bbb3ea2e3e9b and uses code which the same commit added to other tests to fix ContentFilterTest to work with *both* Gradle and Ant.

_Please consider using the subject and body of this PR as the message of the merge commit._