### PR TITLE
JVMVersion: add distinction between EoL alert and updater

### DIFF
--- a/src/freenet/node/Node.java
+++ b/src/freenet/node/Node.java
@@ -1666,7 +1666,7 @@ public class Node implements TimeSkewDetectorCallback {
 		clientCore = new NodeClientCore(this, config, nodeConfig, installConfig, getDarknetPortNumber(), sortOrder, oldConfig, fproxyConfig, toadlets, databaseKey, persistentSecret);
 		toadlets.setCore(clientCore);
 
-		if (JVMVersion.isTooOld()) {
+		if (JVMVersion.isEOL()) {
 			clientCore.alerts.register(new JVMVersionAlert());
 		}
 

--- a/src/freenet/node/updater/NodeUpdateManager.java
+++ b/src/freenet/node/updater/NodeUpdateManager.java
@@ -225,7 +225,7 @@ public class NodeUpdateManager {
 
 		// Set default update URI for new nodes depending on JVM version.
 		updaterConfig
-				.register("URI", JVMVersion.isTooOld() ? transitionMainJarURIAsUSK.toString() : UPDATE_URI,
+				.register("URI", JVMVersion.needsLegacyUpdater() ? transitionMainJarURIAsUSK.toString() : UPDATE_URI,
 				          3, true, true,
 						"NodeUpdateManager.updateURI",
 						"NodeUpdateManager.updateURILong",
@@ -242,7 +242,7 @@ public class NodeUpdateManager {
 		 * The update URI is always written, so override the existing key depending on JVM version.
 		 * Only override the official legacy URI to not interfere with unofficial update keys.
 		 */
-		if (updateURI.equalsKeypair(transitionMainJarURI) && !JVMVersion.isTooOld()) {
+		if (updateURI.equalsKeypair(transitionMainJarURI) && !JVMVersion.needsLegacyUpdater()) {
 			try {
 				updaterConfig.set("URI", UPDATE_URI);
 			} catch (NodeNeedRestartException e) {

--- a/src/freenet/node/useralerts/JVMVersionAlert.java
+++ b/src/freenet/node/useralerts/JVMVersionAlert.java
@@ -24,7 +24,7 @@ public class JVMVersionAlert extends AbstractUserAlert {
 		return NodeL10n.getBase().getString("JavaEOLAlert.body",
 		                                    new String[] {"current", "new"},
 		                                    new String[] {JVMVersion.getCurrent(),
-		                                                  JVMVersion.REQUIRED});
+		                                                  JVMVersion.EOL_THRESHOLD});
 	}
 
 	@Override

--- a/src/freenet/support/JVMVersion.java
+++ b/src/freenet/support/JVMVersion.java
@@ -16,7 +16,7 @@ public class JVMVersion {
 	/**
 	 * Pre-9 is formatted as: major.feature[.maintenance[_update]]-ident
 	 * Post-9 is formatted as: major[.minor[.security[. ...]]]-ident
-	 * For comparison of compatibility, information beyong the major, feature/minor,
+	 * For comparison of compatibility, information beyond the major, feature/minor,
 	 * maintenance/security and pre-9 update fields should not be of interest.
 	 * We find a common denominator in major(.a(.b([._]c)?)?)?, skipping any additional postfix.
 	 * The regex omits leading zeroes.

--- a/src/freenet/support/JVMVersion.java
+++ b/src/freenet/support/JVMVersion.java
@@ -11,7 +11,16 @@ import java.util.regex.Pattern;
  * http://openjdk.java.net/jeps/223 (post-9)
  */
 public class JVMVersion {
-	public static final String REQUIRED = "1.8";
+	/**
+	 * Java version before which to display an End-of-Life warning. Subsequent releases of Freenet will function with
+	 * them, but that may soon not be the case.
+	 */
+	public static final String EOL_THRESHOLD = "1.8";
+
+	/**
+	 * Java version before which to use the legacy updater URI.
+	 */
+	public static final String UPDATER_THRESHOLD = "1.7";
 
 	/**
 	 * Pre-9 is formatted as: major.feature[.maintenance[_update]]-ident
@@ -24,18 +33,30 @@ public class JVMVersion {
 	private static final Pattern VERSION_PATTERN =
 	    Pattern.compile("^0*(\\d+)(?:\\.0*(\\d+)(?:\\.0*(\\d+)(?:[_.]0*(\\d+))?)?)?.*$");
 
-	public static boolean isTooOld() {
-		return isTooOld(getCurrent());
+	public static boolean isEOL() {
+		return isEOL(getCurrent());
+	}
+
+	public static boolean needsLegacyUpdater() {
+		return needsLegacyUpdater(getCurrent());
 	}
 
 	public static String getCurrent() {
 		return System.getProperty("java.version");
 	}
 
-	static boolean isTooOld(String version) {
+	static boolean isEOL(String version) {
 		if (version == null) return false;
 
-		return compareVersion(version, REQUIRED) < 0;
+		return compareVersion(version, EOL_THRESHOLD) < 0;
+	}
+
+	static boolean needsLegacyUpdater(String version) {
+		if (version == null) {
+			return false;
+		}
+
+		return compareVersion(version, UPDATER_THRESHOLD) < 0;
 	}
 
 	public static final boolean is32Bit() {

--- a/test/freenet/support/JVMVersionTest.java
+++ b/test/freenet/support/JVMVersionTest.java
@@ -5,22 +5,45 @@ import junit.framework.TestCase;
 
 public class JVMVersionTest extends TestCase {
 
-	public void testTooOld() {
-		Assert.assertTrue(JVMVersion.isTooOld("1.6.0_32"));
-		Assert.assertTrue(JVMVersion.isTooOld("1.6"));
-		Assert.assertTrue(JVMVersion.isTooOld("1.5"));
-		Assert.assertTrue(JVMVersion.isTooOld("1.7.0_65"));
-		Assert.assertTrue(JVMVersion.isTooOld("1.7"));
+	public void testTooOldWarning() {
+		Assert.assertTrue(JVMVersion.isEOL("1.6.0_32"));
+		Assert.assertTrue(JVMVersion.isEOL("1.6"));
+		Assert.assertTrue(JVMVersion.isEOL("1.5"));
+		Assert.assertTrue(JVMVersion.isEOL("1.7.0_65"));
+		Assert.assertTrue(JVMVersion.isEOL("1.7"));
 	}
 
-	public void testRecentEnough() {
-		Assert.assertFalse(JVMVersion.isTooOld("1.8.0_9"));
-		Assert.assertFalse(JVMVersion.isTooOld("9-ea"));
-		Assert.assertFalse(JVMVersion.isTooOld("10"));
+	public void testTooOldUpdater() {
+		Assert.assertTrue(JVMVersion.needsLegacyUpdater("1.6.0_32"));
+		Assert.assertTrue(JVMVersion.needsLegacyUpdater("1.6"));
+		Assert.assertTrue(JVMVersion.needsLegacyUpdater("1.5"));
+	}
+
+	public void testRecentEnoughWarning() {
+		Assert.assertFalse(JVMVersion.isEOL("1.8.0_9"));
+		Assert.assertFalse(JVMVersion.isEOL("9-ea"));
+		Assert.assertFalse(JVMVersion.isEOL("10"));
+	}
+
+	public void testRecentEnoughUpdater() {
+		Assert.assertFalse(JVMVersion.needsLegacyUpdater("1.7.0_65"));
+		Assert.assertFalse(JVMVersion.needsLegacyUpdater("1.7"));
+		Assert.assertFalse(JVMVersion.needsLegacyUpdater("1.8.0_9"));
+		Assert.assertFalse(JVMVersion.needsLegacyUpdater("9-ea"));
+		Assert.assertFalse(JVMVersion.needsLegacyUpdater("10"));
+	}
+
+	public void testRelative() {
+		/*
+		 * Being at too old a version for the modern updater URI must produce a warning, but a warning can be shown for
+		 * a version not yet too old for the modern updater URI.
+		 */
+		Assert.assertTrue(JVMVersion.compareVersion(JVMVersion.UPDATER_THRESHOLD, JVMVersion.EOL_THRESHOLD) <= 0);
 	}
 
 	public void testNull() {
-		Assert.assertFalse(JVMVersion.isTooOld(null));
+		Assert.assertFalse(JVMVersion.isEOL(null));
+		Assert.assertFalse(JVMVersion.needsLegacyUpdater(null));
 	}
 
 	public void testCompare() {


### PR DESCRIPTION
When the too-old version was advanced to 1.8 in 465cf7391d9f11fb05b2dea8f6cf382d5b714d6f it caused new installs on Java 7 to begin checking the legacy Java 6 update URI, despite only being intended to change the EoL alert. This introduces a distinction between a version old enough to display an alert, and a version old enough to use the legacy update URI.

I have not yet tested a node with these changes, but I did run into the problem when resetting my node's updater settings page to defaults while using Java 7.