### PR TITLE
Add support for `gradle publish` to S3 Maven repo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,13 +13,38 @@ configurations {
     compile
 }
 
+group 'org.freenetproject'
+
 apply plugin: 'witness'
 apply plugin: 'java'
+apply plugin: 'maven-publish'
+
+archivesBaseName = 'freenet'
+version = '1'
 
 repositories {
     jcenter()
     mavenLocal() // TODO: use lib/ instead?
     maven { url 'https://mvn.freenetproject.org' }
+}
+
+
+// AWS credentials can be set below, gradle.properties or command line
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            from components.java
+        }
+    }
+    repositories {
+        maven {
+            url "s3://mvn.freenetproject.org.s3-website-us-east-1.amazonaws.com/"
+            credentials(AwsCredentials) {
+                accessKey ""
+                secretKey ""
+            }
+        }
+    }
 }
 
 sourceSets {

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,14 @@ repositories {
     maven { url 'https://mvn.freenetproject.org' }
 }
 
+ext {
+    if (!project.hasProperty('S3AccessKey')) {
+        S3AccessKey = ''
+    }
+    if (!project.hasProperty('S3SecretKey')) {
+        S3SecretKey = ''
+    }
+}
 
 /*
  * AWS credentials can be set in gradle.properties or command line:

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,6 @@ apply plugin: 'java'
 apply plugin: 'maven-publish'
 
 archivesBaseName = 'freenet'
-version = '1'
 
 repositories {
     jcenter()
@@ -88,6 +87,7 @@ task buildInfo {
     } catch (java.io.IOException e) {
         gitrev = "@unknown@"
     }
+    version = gitrev
 }
 
 task compileVersion (type: JavaCompile) {

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,11 @@ repositories {
 }
 
 
-// AWS credentials can be set below, gradle.properties or command line
+/*
+ * AWS credentials can be set in gradle.properties or command line:
+ * S3AccessKey=
+ * S3SecretKey=
+ */
 publishing {
     publications {
         mavenJava(MavenPublication) {
@@ -38,10 +42,10 @@ publishing {
     }
     repositories {
         maven {
-            url "s3://mvn.freenetproject.org.s3-website-us-east-1.amazonaws.com/"
+            url "s3://mvn.freenetproject.org/"
             credentials(AwsCredentials) {
-                accessKey ""
-                secretKey ""
+                accessKey S3AccessKey
+                secretKey S3SecretKey
             }
         }
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,2 @@
+rootProject.name = 'freenet'
+

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,0 @@
-rootProject.name = 'freenet'
-


### PR DESCRIPTION
Thanks to @D-sha for getting this started in #615 and @nextgens for pointing out the existing `git describe` support (hacky though it may be; dunno if it works on Windows) to avoid the need for Gradle plugins. (I am not aware of an automated mechanism for verifying Gradle plugins like `gradle-witness` does for dependencies.)