### PR TITLE
Use JNA interface mapping in ProcessPriority on 64-bit Windows

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -171,6 +171,7 @@ test {
 dependencies {
     compile "org.bouncycastle:bcprov-jdk15on:1.57"
     compile "net.java.dev.jna:jna:4.2.2"
+    compile "net.java.dev.jna:jna-platform:4.2.2"
     compile "org.freenetproject:freenet-ext:29"
 
     testCompile 'junit:junit:4.12'


### PR DESCRIPTION
As discussed on IRC a few weeks ago, the ProcessPriority class is currently using JNA direct mapping (`Native.register()`) on Windows, Linux, and Mac, but this causes a segfault on 64-bit Windows.

Some other projects have noticed that rolling back the JNA version "fixes" the issue without any changes to the code. It might or might not be a JNA bug, but it works properly on the current JNA version if we use JNA interface mapping instead with the correct native types, `DWORD` and `HANDLE` from `jna-platform`. 

Interface mapping is apparently slower, but that should be OK here as it is only used once during the life of the process.

The exception refers to an invalid calling convention `63`,  but that's likely not the real issue. `63` is just a constant that means `stdcall`, and 64-bit Windows only has one calling convention.

```
STATUS | wrapper  | 2017/07/07 01:46:11 | --> Wrapper Started as Console
STATUS | wrapper  | 2017/07/07 01:46:11 | Java Service Wrapper Community Edition 64-bit 3.5.32
STATUS | wrapper  | 2017/07/07 01:46:11 |   Copyright (C) 1999-2017 Tanuki Software, Ltd. All Rights Reserved.
STATUS | wrapper  | 2017/07/07 01:46:11 |     http://wrapper.tanukisoftware.com
STATUS | wrapper  | 2017/07/07 01:46:11 | 
STATUS | wrapper  | 2017/07/07 01:46:12 | Launching a JVM...
INFO   | jvm 1    | 2017/07/07 01:46:12 | Exception in thread "main" java.lang.ExceptionInInitializerError
INFO   | jvm 1    | 2017/07/07 01:46:12 | 	at freenet.support.ProcessPriority.enterBackgroundMode(ProcessPriority.java:64)
INFO   | jvm 1    | 2017/07/07 01:46:12 | 	at freenet.node.NodeStarter.main(NodeStarter.java:264)
INFO   | jvm 1    | 2017/07/07 01:46:12 | Caused by: java.lang.IllegalArgumentException: Invalid calling convention 63
INFO   | jvm 1    | 2017/07/07 01:46:12 | 	at com.sun.jna.Native.registerMethod(Native Method)
INFO   | jvm 1    | 2017/07/07 01:46:12 | 	at com.sun.jna.Native.register(Native.java:1772)
INFO   | jvm 1    | 2017/07/07 01:46:12 | 	at com.sun.jna.Native.register(Native.java:1643)
INFO   | jvm 1    | 2017/07/07 01:46:12 | 	at com.sun.jna.Native.register(Native.java:1360)
INFO   | jvm 1    | 2017/07/07 01:46:12 | 	at freenet.support.ProcessPriority$WindowsHolder.<clinit>(ProcessPriority.java:29)
INFO   | jvm 1    | 2017/07/07 01:46:12 | 	... 2 more
ERROR  | wrapper  | 2017/07/07 01:46:12 | JVM exited while loading the application.
```