### PR TITLE
A really samll edit to make the build-clean.xml fit the README.build.md better

### DIFF
--- a/build-clean.xml
+++ b/build-clean.xml
@@ -308,7 +308,7 @@ maintainers may prefer to use this instead of build.xml.
 
 	<target name="package" depends="unit, package-only" description="build standard binary packages (Freenet daemon)"/>
 
-	<target name="unit-build" depends="build" unless="${tests.skip}">
+	<target name="unit-build" depends="build" unless="${test.skip}">
 		<antcall target="libdep-junit"/>
 		<antcall target="libdep-hamcrest"/>
 		<javac srcdir="${test.src}" destdir="${test.make}" debug="on" source="1.7" target="1.7" includeAntRuntime="false" encoding="UTF-8">

--- a/build-clean.xml
+++ b/build-clean.xml
@@ -308,7 +308,7 @@ maintainers may prefer to use this instead of build.xml.
 
 	<target name="package" depends="unit, package-only" description="build standard binary packages (Freenet daemon)"/>
 
-	<target name="unit-build" depends="build" unless="${test.skip}">
+	<target name="unit-build" depends="build" unless="${tests.skip}">
 		<antcall target="libdep-junit"/>
 		<antcall target="libdep-hamcrest"/>
 		<javac srcdir="${test.src}" destdir="${test.make}" debug="on" source="1.7" target="1.7" includeAntRuntime="false" encoding="UTF-8">


### PR DESCRIPTION
when i built the release edition 'build01478' i didn't past all the given tests. So i intended to skip the tests by following the instruction on the screen: 
`ant Dtests.skip=true` 
but it didn't work for me, it still executed the test progress. Than i looked up the related build files and i found in the `build-clean.xml` file, in which the value was "test.skip=true". After i edited it to "tests.skip=true", i finally got the "freenet.jar" which works fine for me. Thats all, this is my first PR, hope it can help :)
 