### PR TITLE
Travis CI: Fix for OpenJDK 7 by not using wrapper; shows our own tests fail on OpenJDK 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ cache:
 
 before_install:
   - echo -e "org.gradle.parallel = true\norg.gradle.jvmargs=-Xms256m -Xmx1024m\norg.gradle.configureondemand=true\ntasks.withType(Test) {\n maxParallelForks = Runtime.runtime.availableProcessors()\n}" > gradle.properties
-  # Workaround for openjdk7: Don't use gradlew. When removing this also replace all instances of the "gradle" command in this file with "./gradlew"!
+  # No need to use the binary Gradle download script we ship, Travis CI has gradle installed already.
   - rm ./gradlew
 install: "gradle jar"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,15 +21,19 @@ cache:
   - $HOME/.gradle/caches/
   - $HOME/.gradle/wrapper/
 
-before_install: echo -e "org.gradle.parallel = true\norg.gradle.jvmargs=-Xms256m -Xmx1024m\norg.gradle.configureondemand=true\ntasks.withType(Test) {\n maxParallelForks = Runtime.runtime.availableProcessors()\n}" > gradle.properties
+before_install:
+  - echo -e "org.gradle.parallel = true\norg.gradle.jvmargs=-Xms256m -Xmx1024m\norg.gradle.configureondemand=true\ntasks.withType(Test) {\n maxParallelForks = Runtime.runtime.availableProcessors()\n}" > gradle.properties
+  # Workaround for openjdk7: Don't use gradlew. When removing this also replace the below "gradle javadoc" with "./gradlew javadoc"!
+  - rm ./gradlew
 
 jdk:
   - oraclejdk8
   - oraclejdk9
   - openjdk8
+  - openjdk7
 
 before_deploy:
-  - "./gradlew javadoc"
+  - "gradle javadoc"
   - "pip install --user awscli"
 deploy:
   - provider: script


### PR DESCRIPTION
**NOTICE**: OpenJDK 7 is still the default JRE on a maintained LTS release of a major operating system, namely Ubuntu 14.04, so it DOES make sense to test against it.

Fixes these failures of the Gradle wrapper:
https://travis-ci.org/xor-freenet/fred-staging/jobs/286721010#L461-L511

This shows that freenet.crypt.KeyGenUtilsTest fails on OpenJDK 7:
https://travis-ci.org/freenet/fred/jobs/334276152#L643-L656

Notice: Instead of this PR we could also try updating the Gradle wrapper
binaries to see whether it fixes the failure. I'm not sure how I'm
supposed to obtain them so I did this PR as it does have some benefits
to not use the wrapper:
- Gradle is already installed in the Travis environment so it's faster
to not download it using the wrapper.
- We outsource the maintenance of figuring out which Gradle version to
use to be compatible with the rest of Travis.

Notice: The failure to build on Java 9 is an issue with Travis CI, it will likely go away in a few days, see:
https://github.com/travis-ci/travis-cookbooks/pull/967