### PR TITLE
Update Winterfacey.css

### DIFF
--- a/src/freenet/clients/http/staticfiles/themes/winterfacey/theme.css
+++ b/src/freenet/clients/http/staticfiles/themes/winterfacey/theme.css
@@ -5,7 +5,7 @@ ul#navlist {
 
 /* from base.css */
 #statusbar-container {
-  color: white;
+  color: grey;
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-top-style: solid;
@@ -485,9 +485,8 @@ div.progressbar .progressbar-min {
 
 div.progressbar .progress_fraction_finalized {
   font-size: 12px;
-  color: #fff;
+  color: grey;
   text-align: center;
-  text-shadow: 0 -1px 0 rgba(0,0,0,0.25);
   font-weight: normal;
   line-height: 20px;
 }


### PR DESCRIPTION
While  testing out the new Winterfacey theme, I noticed that some words where not/barely readable at the bottom of the screen. For example, the words security levels were invisible, because they were the same color as the background. The bar where you see to how many nodes you are currently connected to is also barely readable. So I changed them both to grey as stated below. I also removed the shadow effect as stated below in the progress bar because it made the text look odd, like they were dubbled.



![default winterfacey](https://user-images.githubusercontent.com/32765596/31543169-40c9a2d6-b015-11e7-9d7f-d3130124ff7a.png)
As you see here, the bar below is almost unreadable, with the words security level  even being invisible.

![grey winterfacey with shadows in progress bar](https://user-images.githubusercontent.com/32765596/31543185-52af42a8-b015-11e7-81de-2b3e247b81a3.png)
This is alot better, and makes the letters more readable, but if you look closely, you will see the the text in the progress bar still looks a little bit odd, so i deleted the shadows so it looks better.

![grey winterfacey without shadows in progress bar](https://user-images.githubusercontent.com/32765596/31543208-6c37b192-b015-11e7-9e1e-9d8ae70115af.png)
here you see the it without the shadows, where you dont see the shadows issue.

so what ive done in short:
I changed status bar  and progress_fraction_finalized color to grey. 
Also, I removed text-shadow: 0 -1px 0 rgba(0,0,0,0.25); from progress_fraction_finalized.
