### PR TITLE
Fix wrapper for new windows installs

### DIFF
--- a/src/freenet/config/WrapperConfig.java
+++ b/src/freenet/config/WrapperConfig.java
@@ -40,10 +40,13 @@ public class WrapperConfig {
 			Logger.normal(WrapperConfig.class, "Cannot alter properties: not running under wrapper");
 			return false;
 		}
-		File f = new File("wrapper.conf");
+		File f = new File("wrapper/wrapper.conf");
 		if(!f.exists()) {
-			Logger.normal(WrapperConfig.class, "Cannot alter properties: wrapper.conf does not exist");
-			return false;
+			f = new File("wrapper.conf");
+			if(!f.exists()) {
+                            Logger.normal(WrapperConfig.class, "Cannot alter properties: wrapper.conf does not exist");
+                            return false;
+ 			}
 		}
 		if(!f.canRead()) {
 			Logger.normal(WrapperConfig.class, "Cannot alter properties: wrapper.conf not readable");


### PR DESCRIPTION
Moving wrapper.conf into $\wrapper broke parsing/saving of the memory usage option.

If I did things right, it should check $\wrapper\wrapper.conf first, then fall back to $\wrapper.conf if not found.