### PR TITLE
Rekey the update URIs to ensure they are RFC6979

### DIFF
--- a/src/freenet/node/updater/NodeUpdateManager.java
+++ b/src/freenet/node/updater/NodeUpdateManager.java
@@ -78,17 +78,24 @@ import freenet.support.io.FileUtil;
 public class NodeUpdateManager {
 
 	/**
-	 * The last build on the old key with Java 6 support. Older nodes can
+	 * The last build on the previous key with Java 7 support. Older nodes can
 	 * update to this point via old UOM.
 	 */
-	public final static int TRANSITION_VERSION = 1472;
+	public final static int TRANSITION_VERSION = 1481;
 
-	/** The URI for post-TRANSITION_VERSION builds' freenet.jar. */
-	public final static String UPDATE_URI = "USK@O~UmMwTeDcyDIW-NsobFBoEicdQcogw7yrLO2H-sJ5Y,JVU4L7m9mNppkd21UNOCzRHKuiTucd6Ldw8vylBOe5o,AQACAAE/jar/"
+	/** The URI for post-TRANSITION_VERSION builds' freenet.jar on modern JVMs. */
+	public final static String UPDATE_URI = "USK@vCKGjQtKuticcaZ-dwOgmkYPVLj~N1dm9mb3j3Smg4Y,-wz5IYtd7PlhI2Kx4cAwpUu13fW~XBglPyOn8wABn60,AQACAAE/jar/"
 			+ Version.buildNumber();
 
-	/** Might as well be the SSK */
-	public final static String LEGACY_UPDATE_URI = "freenet:SSK@sabn9HY9MKLbFPp851AO98uKtsCtYHM9rqB~A5cCGW4,3yps2z06rLnwf50QU4HvsILakRBYd4vBlPtLv0elUts,AQACAAE/jar-"
+	/** The URI for post-TRANSITION_VERSION builds' freenet.jar on EoL JVMs. */
+	public final static String LEGACY_UPDATE_URI = "SSK@ugWS2VICgMcQ5ptmEE1mAvHgUn2OSCOogJIUAvbL090,ZKO1pZRI9oaBuBQuWFL4bK3K0blvmEdqYgiIJF5GcjQ,AQACAAE/jar-"
+			+ TRANSITION_VERSION;
+
+	/**
+	 * The URI for freenet.jar before the updater was rekeyed. Unless both the EoL and modern keys rekey this is
+	 * LEGACY_UPDATE_URI.
+	 */
+	public final static String PREVIOUS_UPDATE_URI = "SSK@O~UmMwTeDcyDIW-NsobFBoEicdQcogw7yrLO2H-sJ5Y,JVU4L7m9mNppkd21UNOCzRHKuiTucd6Ldw8vylBOe5o,AQACAAE/jar-"
 			+ TRANSITION_VERSION;
 
 	public final static String REVOCATION_URI = "SSK@tHlY8BK2KFB7JiO2bgeAw~e4sWU43YdJ6kmn73gjrIw,DnQzl0BYed15V8WQn~eRJxxIA-yADuI8XW7mnzEbut8,AQACAAE/revoked";
@@ -99,10 +106,11 @@ public class NodeUpdateManager {
 
 	public static final long MAX_MAIN_JAR_LENGTH = 16 * 1024 * 1024; // 16MB
 
-	public static final FreenetURI transitionMainJarURI;
-	
-	public static final FreenetURI transitionMainJarURIAsUSK;
-	
+	static final FreenetURI legacyMainJarSSK;
+	static final FreenetURI legacyMainJarUSK;
+
+	static final FreenetURI previousMainJarSSK;
+	static final FreenetURI previousMainJarUSK;
 
 	public static final String transitionMainJarFilename = "legacy-freenet-jar-"
 			+ TRANSITION_VERSION + ".fblob";
@@ -111,8 +119,10 @@ public class NodeUpdateManager {
 
 	static {
 		try {
-			transitionMainJarURI = new FreenetURI(LEGACY_UPDATE_URI);
-			transitionMainJarURIAsUSK = transitionMainJarURI.uskForSSK();
+			legacyMainJarSSK = new FreenetURI(LEGACY_UPDATE_URI);
+			legacyMainJarUSK = legacyMainJarSSK.uskForSSK();
+			previousMainJarSSK = new FreenetURI(PREVIOUS_UPDATE_URI);
+			previousMainJarUSK = previousMainJarSSK.uskForSSK();
 		} catch (MalformedURLException e) {
 			throw new Error(e);
 		}
@@ -225,7 +235,7 @@ public class NodeUpdateManager {
 
 		// Set default update URI for new nodes depending on JVM version.
 		updaterConfig
-				.register("URI", JVMVersion.needsLegacyUpdater() ? transitionMainJarURIAsUSK.toString() : UPDATE_URI,
+				.register("URI", JVMVersion.needsLegacyUpdater() ? legacyMainJarUSK.toString() : UPDATE_URI,
 				          3, true, true,
 						"NodeUpdateManager.updateURI",
 						"NodeUpdateManager.updateURILong",
@@ -240,15 +250,16 @@ public class NodeUpdateManager {
 
 		/*
 		 * The update URI is always written, so override the existing key depending on JVM version.
-		 * Only override the official legacy URI to not interfere with unofficial update keys.
+		 * Only override official URIs to avoid interfering with unofficial update keys.
+		 *
+		 * An up-to-date JVM must update the legacy URI (in addition to the previous URI) in case a node was
+		 * run with an EoL JVM that was subsequently upgraded.
 		 */
-		if (updateURI.equalsKeypair(transitionMainJarURI) && !JVMVersion.needsLegacyUpdater()) {
-			try {
-				updaterConfig.set("URI", UPDATE_URI);
-			} catch (NodeNeedRestartException e) {
-				// UpdateURICallback.set() does not throw NodeNeedRestartException.
-				Logger.warning(this, "Unexpected failure setting update URI", e);
-			}
+		if (JVMVersion.needsLegacyUpdater()) {
+			transitionKey(updaterConfig, previousMainJarSSK, legacyMainJarUSK.toString());
+		} else {
+			transitionKey(updaterConfig, previousMainJarSSK, UPDATE_URI);
+			transitionKey(updaterConfig, legacyMainJarSSK, UPDATE_URI);
 		}
 
 		updateURI = updateURI.setSuggestedEdition(Version.buildNumber());
@@ -298,7 +309,7 @@ public class NodeUpdateManager {
 		};
 
 		transitionMainJarFile = new File(node.clientCore.getPersistentTempDir(), transitionMainJarFilename);
-		transitionMainJarFetcher = new LegacyJarFetcher(transitionMainJarURI,
+		transitionMainJarFetcher = new LegacyJarFetcher(previousMainJarSSK,
 				transitionMainJarFile, node.clientCore,
 				legacyFetcherCallback);
 
@@ -366,6 +377,19 @@ public class NodeUpdateManager {
 
 		this.uom = new UpdateOverMandatoryManager(this);
 		this.uom.removeOldTempFiles();
+	}
+
+	private void transitionKey(SubConfig updaterConfig, FreenetURI from, String to)
+			throws InvalidConfigValueException {
+
+		if (updateURI.equalsKeypair(from)) {
+			try {
+				updaterConfig.set("URI", to);
+			} catch (NodeNeedRestartException e) {
+				// UpdateURICallback.set() does not throw NodeNeedRestartException.
+				Logger.warning(this, "Unexpected failure setting update URI", e);
+			}
+		}
 	}
 
 	class SimplePuller implements ClientGetCallback {
@@ -592,7 +616,7 @@ public class NodeUpdateManager {
 	private Message getOldUOMAnnouncement() {
 		boolean mainJarAvailable = transitionMainJarFetcher == null ? false
 				: transitionMainJarFetcher.fetched();
-        return DMT.createUOMAnnouncement(transitionMainJarURIAsUSK.toString(), revocationURI
+        return DMT.createUOMAnnouncement(previousMainJarUSK.toString(), revocationURI
                 .toString(), revocationChecker.hasBlown(), 
                 mainJarAvailable ? TRANSITION_VERSION : -1,
                 revocationChecker.lastSucceededDelta(), revocationChecker

--- a/src/freenet/node/updater/UpdateOverMandatoryManager.java
+++ b/src/freenet/node/updater/UpdateOverMandatoryManager.java
@@ -1189,7 +1189,7 @@ public class UpdateOverMandatoryManager implements RequestClient {
 		if (source.getVersionNumber() < NodeUpdateManager.TRANSITION_VERSION) {
 		    data = updateManager.getTransitionMainBlob();
 		    version = NodeUpdateManager.TRANSITION_VERSION;
-		    uri = NodeUpdateManager.transitionMainJarURIAsUSK;
+		    uri = NodeUpdateManager.previousMainJarUSK;
 		} else {
 		    data = updateManager.getCurrentVersionBlobFile();
 		    version = Version.buildNumber();

--- a/src/freenet/support/JVMVersion.java
+++ b/src/freenet/support/JVMVersion.java
@@ -20,7 +20,7 @@ public class JVMVersion {
 	/**
 	 * Java version before which to use the legacy updater URI.
 	 */
-	public static final String UPDATER_THRESHOLD = "1.7";
+	public static final String UPDATER_THRESHOLD = "1.8";
 
 	/**
 	 * Pre-9 is formatted as: major.feature[.maintenance[_update]]-ident

--- a/test/freenet/support/JVMVersionTest.java
+++ b/test/freenet/support/JVMVersionTest.java
@@ -17,6 +17,8 @@ public class JVMVersionTest extends TestCase {
 		Assert.assertTrue(JVMVersion.needsLegacyUpdater("1.6.0_32"));
 		Assert.assertTrue(JVMVersion.needsLegacyUpdater("1.6"));
 		Assert.assertTrue(JVMVersion.needsLegacyUpdater("1.5"));
+		Assert.assertTrue(JVMVersion.needsLegacyUpdater("1.7.0_65"));
+		Assert.assertTrue(JVMVersion.needsLegacyUpdater("1.7"));
 	}
 
 	public void testRecentEnoughWarning() {
@@ -26,8 +28,6 @@ public class JVMVersionTest extends TestCase {
 	}
 
 	public void testRecentEnoughUpdater() {
-		Assert.assertFalse(JVMVersion.needsLegacyUpdater("1.7.0_65"));
-		Assert.assertFalse(JVMVersion.needsLegacyUpdater("1.7"));
 		Assert.assertFalse(JVMVersion.needsLegacyUpdater("1.8.0_9"));
 		Assert.assertFalse(JVMVersion.needsLegacyUpdater("9-ea"));
 		Assert.assertFalse(JVMVersion.needsLegacyUpdater("10"));


### PR DESCRIPTION
This rekeys URIs for both EoL and newer versions of Java, which is not supported by existing code. This separates the legacy URI - for EoL JVMs going forward - from the "previous URI."

Once this is reviewed and ready to merge I can distribute the private keys before merging if that seems preferable.

I tested that the key config updated as expected, but not UOM. It behaves as expected when first running Java 7, subsequently running Java 8, and first running Java 8. (The script I used, which is specific to Arch, is [here](https://gist.github.com/Thynix/8d6f1ff2526dc83d25184d8dfb48bb6b).)