### PR TITLE
fix: switch to theme sky static had not worked

### DIFF
--- a/src/freenet/clients/http/SimpleToadletServer.java
+++ b/src/freenet/clients/http/SimpleToadletServer.java
@@ -464,7 +464,7 @@ public final class SimpleToadletServer implements ToadletContainer, Runnable, Li
 				new FProxyPortCallback(), false);
 		fproxyConfig.register("bindTo", NetworkInterface.DEFAULT_BIND_TO, configItemOrder++, true, true, "SimpleToadletServer.bindTo", "SimpleToadletServer.bindToLong",
 				new FProxyBindtoCallback());
-		fproxyConfig.register("css", "clean-dropdown", configItemOrder++, false, false, "SimpleToadletServer.cssName", "SimpleToadletServer.cssNameLong",
+		fproxyConfig.register("css", PageMaker.THEME.getDefault().code, configItemOrder++, false, false, "SimpleToadletServer.cssName", "SimpleToadletServer.cssNameLong",
 				new FProxyCSSNameCallback());
 		fproxyConfig.register("CSSOverride", "", configItemOrder++, true, false, "SimpleToadletServer.cssOverride", "SimpleToadletServer.cssOverrideLong",
 				new FProxyCSSOverrideCallback());


### PR DESCRIPTION
This change should make fproxy use the default theme as starting theme; which is sky-static.

sky-static is much nicer to use than clean-dropdown, but still not Winterfacey level. But its CSS is optimized for faster load times.

The switch to sky-static as default already happened Oct 20, 2015, but did not have an effect because of the override this commit removes.