### PR TITLE
gradle: apply compatibility mode to all classes, not just to Version.java

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,9 @@ task buildInfo {
     }
 }
 
+sourceCompatibility = 1.7
+targetCompatibility = 1.7
+
 task compileVersion (type: JavaCompile) {
     copy {
         from sourceSets.main.java.srcDirs


### PR DESCRIPTION
previously the created jar-file would not have run with Java 7, because the compatibility mode was only set on the javaVersion task. To test:

javap -verbose -classpath build/classes/java/main freenet.client.async.DownloadCache | grep major