### PR TITLE
[PATCH] Fix memory leak with BouncyCastleProvider

### DIFF
--- a/src/freenet/crypt/KeyGenUtils.java
+++ b/src/freenet/crypt/KeyGenUtils.java
@@ -36,6 +36,10 @@ import freenet.support.Fields;
  */
 public final class KeyGenUtils {
 
+    static {
+        java.security.Security.insertProviderAt(new BouncyCastleProvider(), 1);
+    }
+
     /**
      * Generates a public/private key pair formatted for the algorithm specified
      * and stores the keys in a KeyPair. Can not handle DSA keys.
@@ -47,7 +51,7 @@ public final class KeyGenUtils {
             throw new UnsupportedTypeException(type);
         }
         try {
-            KeyPairGenerator kg = KeyPairGenerator.getInstance(type.alg, new BouncyCastleProvider());
+            KeyPairGenerator kg = KeyPairGenerator.getInstance(type.alg);
             kg.initialize(type.spec);
             return kg.generateKeyPair();
         } catch (NoSuchAlgorithmException e) {
@@ -68,7 +72,7 @@ public final class KeyGenUtils {
             throw new UnsupportedTypeException(type);
         }
         try {
-            KeyFactory kf = KeyFactory.getInstance(type.alg, new BouncyCastleProvider());
+            KeyFactory kf = KeyFactory.getInstance(type.alg);
             X509EncodedKeySpec xks = new X509EncodedKeySpec(pub);
             return kf.generatePublic(xks);
         } catch (NoSuchAlgorithmException e) {
@@ -123,7 +127,7 @@ public final class KeyGenUtils {
             throw new UnsupportedTypeException(type);
         }
         try {
-            KeyFactory kf = KeyFactory.getInstance(type.alg, new BouncyCastleProvider());
+            KeyFactory kf = KeyFactory.getInstance(type.alg);
 
             PublicKey pubK = getPublicKey(type, pub);
 
@@ -170,7 +174,7 @@ public final class KeyGenUtils {
      */
     public static SecretKey genSecretKey(KeyType type){
         try{
-            KeyGenerator kg = KeyGenerator.getInstance(type.alg, new BouncyCastleProvider());
+            KeyGenerator kg = KeyGenerator.getInstance(type.alg);
             kg.init(type.keySize);
             return kg.generateKey();
         } catch (NoSuchAlgorithmException e) {


### PR DESCRIPTION
Fix issue with BounceCastleProvider introduced in abad64d133ed9a674d5f666f48db178a85652b9e causing node shutdown with OOM error.

It was opted to use a static initialization method to setup provider using the `static` initializer.

I've a node running on this branch and it seems to be OK following the reproduction steps provided in the mailing list.