### PR TITLE
Revert hiding tempfiles

### DIFF
--- a/src/freenet/client/async/SplitFileFetcher.java
+++ b/src/freenet/client/async/SplitFileFetcher.java
@@ -5,9 +5,6 @@ import java.io.DataOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
-import java.nio.file.FileSystemException;
-import java.nio.file.Files;
-import java.nio.file.LinkOption;
 import java.util.List;
 
 import freenet.client.ClientMetadata;
@@ -133,10 +130,7 @@ public class SplitFileFetcher implements ClientGetState, SplitFileFetcherStorage
                 File targetFile = fileCallback.getCompletionFile();
                 if(targetFile != null) {
                     callbackCompleteViaTruncation = fileCallback;
-                    fileCompleteViaTruncation = File.createTempFile("."+targetFile.getName(), ".freenet-tmp", targetFile.getParentFile());
-                    try {
-                        Files.setAttribute(fileCompleteViaTruncation.toPath(), "dos:hidden", true, LinkOption.NOFOLLOW_LINKS);
-                    } catch (FileSystemException e) { } //at least we've tried.
+                    fileCompleteViaTruncation = File.createTempFile(targetFile.getName(), ".freenet-tmp", targetFile.getParentFile());
                     // Storage must actually create the RAF since it knows the length.
                 } else {
                     callbackCompleteViaTruncation = null;

--- a/src/freenet/support/io/BaseFileBucket.java
+++ b/src/freenet/support/io/BaseFileBucket.java
@@ -165,7 +165,7 @@ public abstract class BaseFileBucket implements RandomAccessBucket {
 		File f = File.createTempFile("."+file.getName(), ".freenet-tmp", file.getParentFile());
 		try {
 			Files.setAttribute(f.toPath(), "dos:hidden", true, LinkOption.NOFOLLOW_LINKS);
-		} catch (FileSystemException|UnsupportedOperationException e) { } //at least we've tried.
+		} catch (FileSystemException e) { } //at least we've tried.
 		if(deleteOnExit()) f.deleteOnExit();
 		return f;
 	}

--- a/src/freenet/support/io/BaseFileBucket.java
+++ b/src/freenet/support/io/BaseFileBucket.java
@@ -1,7 +1,5 @@
 package freenet.support.io;
 
-import org.tanukisoftware.wrapper.WrapperManager;
-
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.Closeable;
@@ -14,11 +12,10 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.nio.file.FileSystemException;
-import java.nio.file.Files;
-import java.nio.file.LinkOption;
 import java.util.Arrays;
 import java.util.Vector;
+
+import org.tanukisoftware.wrapper.WrapperManager;
 
 import freenet.client.async.ClientContext;
 import freenet.support.LogThresholdCallback;
@@ -162,10 +159,7 @@ public abstract class BaseFileBucket implements RandomAccessBucket {
 	 */
 	protected File getTempfile() throws IOException {
 		File file = getFile();
-		File f = File.createTempFile("."+file.getName(), ".freenet-tmp", file.getParentFile());
-		try {
-			Files.setAttribute(f.toPath(), "dos:hidden", true, LinkOption.NOFOLLOW_LINKS);
-		} catch (FileSystemException e) { } //at least we've tried.
+		File f = File.createTempFile(file.getName(), ".freenet-tmp", file.getParentFile());
 		if(deleteOnExit()) f.deleteOnExit();
 		return f;
 	}


### PR DESCRIPTION
The reverted change made Freenet fail under Windows 8.1, as reported in FMS:

> TS-Pi@8kCqlpKwsXackbaIm7PI71gTfgRzZZScud4qfg8qcEU wrote :
>> dark_mater@aiiPp9iU6YYQprBhtmTW4QpXU6OUh-EOb6eThYhmmqs wrote :
>>> The lastest version of freenet is barely functional on windows 8.1 (see disclaimer at end). The problem is that java is not able to either see or edit the hidden files (AKA dot-files). One can surf websites if they load quickly but browsing is slow due to frequent restarts and the inability to download anything via the freenet web proxy, that takes longer to download then the time before freenet crashes/resets. 
>>> 
>>> It might be usable with external download tools such as Thaw but regardless the preformance will be poor. 
>>> 
>>> I don't know if anyone else has experienced simmiar issues but the workaround is to run freent in a virtualbox with linux as the guest. Poor perfomance like this will likely deter many new freenet users that aren't proficient with either virtual machines or linux. 
>>> 
>>> A google search will revel that I'm not alone in regards to java having problems editing dot-files on windows. I don't know if this is fixed in later versions of windows but if not then one might need to consider renaming the files on windows so that they don't begin with a dot. 
>>> 
>>> **Disclaimer, I only tested this on a windows account which was the local user (aka local administrator). Perhaps it would work with a less privlaged user account. If this happens to be the case then freenet should issue a warning. 
>> 
>> Some digging shows that this isn't to do with the file starting with a dot, but with setting the attribute to hidden. see this related eclipse bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=194216#c33
>> 
>> "Java has made all hidden file in the file system on windows also write protected. Therefore to be able to change the file descriptor then file system hidden attribute needs to be cleared on windows systems."
>> 
>> This was precipitated by some users that were annoyed by seeing temp files in their downloads dir: https://freenet.mantishub.io/view.php?id=6562

See:

> Under Windows you can set the hidden flag on any file (e.g. text.txt). And if it is set, but the writeable flag is not set then you can edit the file but never save it until the hidden flag is cleared. And the error message is not very clear in what was wrong. 
https://bugs.eclipse.org/bugs/show_bug.cgi?id=194216

I’ll revert this change until we have a tested version.

This is a pull-request against master for code-review, because I accidentally pushed this to next due to a git-mess-up.