### PR TITLE
add m3u filter again

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,22 @@ of the archive it downloads from `https://services.gradle.org`.
 
 ## Testing
 
-To test your version of Freenet, stop your node, replace `freenet.jar` in your
+### Run Tests
+
+To run all unit tests, use
+
+    ./gradlew --parallel test
+
+You can run specifics tests with a test filter similar to the following:
+
+    ./gradlew --parallel test --tests *M3UFilterTest
+
+TODO: how to run integration tests.
+
+### Run your changes as node
+
+To test your version of Freenet, build it with ,./gradlew jar`,
+stop your node, replace `freenet.jar` in your
 Freenet directory with `build/libs/freenet.jar`, and start your node again.
 
 To override values set in `build.gradle` put them into [the file](https://docs.gradle.org/3.2/userguide/build_environment.html)

--- a/src/freenet/client/filter/ContentFilter.java
+++ b/src/freenet/client/filter/ContentFilter.java
@@ -83,6 +83,13 @@ public class ContentFilter {
 				false, null, null, false));	
 
 
+		// M3U - strict filter
+		register(new FilterMIMEType("audio/mpegurl", "m3u", new String[] {"application/vnd.apple.mpegurl","application/mpegurl","application/x-mpegurl","audio/x-mpegurl"}, new String[] {"m3u8"},
+				true, false, new M3UFilter(), false, false, false, false, false, false,
+				l10n("audioM3UReadAdvice"),
+				false, "utf-8", null, false));
+
+
 		/* MP3
 		 *
 		 * Reference: http://www.mp3-tech.org/programmer/frame_header.html

--- a/src/freenet/client/filter/ContentFilter.java
+++ b/src/freenet/client/filter/ContentFilter.java
@@ -85,7 +85,7 @@ public class ContentFilter {
 
 		// M3U - strict filter
 		register(new FilterMIMEType("audio/mpegurl", "m3u", new String[] {"application/vnd.apple.mpegurl","application/mpegurl","application/x-mpegurl","audio/x-mpegurl"}, new String[] {"m3u8"},
-				true, false, new M3UFilter(), true, true, false, false, false, false,
+				false, false, new M3UFilter(), false, false, false, false, false, false,
 				l10n("audioM3UReadAdvice"),
 				false, "utf-8", null, false));
 

--- a/src/freenet/client/filter/ContentFilter.java
+++ b/src/freenet/client/filter/ContentFilter.java
@@ -85,7 +85,7 @@ public class ContentFilter {
 
 		// M3U - strict filter
 		register(new FilterMIMEType("audio/mpegurl", "m3u", new String[] {"application/vnd.apple.mpegurl","application/mpegurl","application/x-mpegurl","audio/x-mpegurl"}, new String[] {"m3u8"},
-				true, false, new M3UFilter(), false, false, false, false, false, false,
+				true, false, new M3UFilter(), true, true, false, false, false, false,
 				l10n("audioM3UReadAdvice"),
 				false, "utf-8", null, false));
 
@@ -277,7 +277,7 @@ public class ContentFilter {
 					byte[] charsetBuffer = new byte[bufferSize];
 					int bytesRead = 0, offset = 0, toread=0;
 					while(true) {
-                                                toread = bufferSize - offset;
+						toread = bufferSize - offset;
 						bytesRead = input.read(charsetBuffer, offset, toread);
 						if(bytesRead == -1 || toread == 0) break;
 						offset += bytesRead;

--- a/src/freenet/client/filter/FilterCallback.java
+++ b/src/freenet/client/filter/FilterCallback.java
@@ -20,6 +20,8 @@ public interface FilterCallback {
 	 * Process a URI.
 	 * If it cannot be turned into something sufficiently safe, then return null.
 	 * @param overrideType Force the return type.
+	 * @param noRelative TODO
+	 * @param inline TODO
 	 * @throws CommentException If the URI is nvalid or unacceptable in some way.
 	 */
 	public String processURI(String uri, String overrideType, boolean noRelative, boolean inline) throws CommentException;

--- a/src/freenet/client/filter/M3UFilter.java
+++ b/src/freenet/client/filter/M3UFilter.java
@@ -15,6 +15,7 @@ import java.util.HashMap;
 
 import freenet.l10n.NodeL10n;
 import freenet.support.io.FileUtil;
+import freenet.clients.http.ExternalLinkToadlet;
 
 /**
  * Content filter for M3Us
@@ -52,6 +53,7 @@ public class M3UFilter implements ContentDataFilter {
         { (byte)'\r' };
     static final int MAX_URI_LENGTH = 16384;
     static final String badUriReplacement = "#bad-uri-removed";
+    private final long MAX_LENGTH_NO_PROGRESS = (100*1024*1024 * 11) / 10; // 100MiB: playlists are a different usecase, and we want to allow transparent pass-through for most files accessed via a playlist, likely through an external palyer. See FProxyToadlet.MAX_LENGTH_NO_PROGRESS for the default. This value must be synchronized with the test data!
     // TODO: Add parsing of ext-comments to allow for gapless playback.
     // static final int COMMENT_EXT_SIZE = 4;
     // static final byte[] COMMENT_EXT_START =
@@ -151,7 +153,22 @@ public class M3UFilter implements ContentDataFilter {
                                             filtered = badUriReplacement;
                                         }
                                     }
-
+                                    // allow transparent pass through
+                                    // for all but the largest files,
+                                    // but not for external
+                                    // links. This check is safe,
+                                    // since false positives will just
+                                    // lead to a file to not be played
+                                    // (players will get progress-bar
+                                    // HTML content instead).
+                                    if (!filtered.contains(ExternalLinkToadlet.PATH) && !filtered.contains(ExternalLinkToadlet.magicHTTPEscapeString)) {
+                                        if (filtered.contains("?")) {
+                                            filtered += "&";
+                                        } else {
+                                            filtered += "?";
+                                        }
+                                        filtered += "max-size=" + Long.valueOf(MAX_LENGTH_NO_PROGRESS).toString();
+                                    }
 
                                 } catch (CommentException e) {
                                     filtered = badUriReplacement;

--- a/src/freenet/client/filter/M3UFilter.java
+++ b/src/freenet/client/filter/M3UFilter.java
@@ -1,0 +1,179 @@
+/* This code is part of Freenet. It is distributed under the GNU General
+ * Public License, version 2 (or at your option any later version). See
+ * http://www.gnu.org/ for further details of the GPL. */
+package freenet.client.filter;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.BufferedReader;
+import java.util.Arrays;
+import java.util.HashMap;
+
+import freenet.l10n.NodeL10n;
+import freenet.support.io.FileUtil;
+
+/**
+ * Content filter for M3Us
+ *
+ * This one kills every comment and ensures that every file is a safe
+ * URL. Currently far too strict: allows only relative paths with as
+ * letters alphanumeric or - and exactly one dot.
+ *
+ * The structure of a simple M3U is just a list of valid relative
+ * URLs.  The structure of an extended M3U is as follows (taken from
+ * http://schworak.com/blog/e39/m3u-play-list-specification/ ):
+ *
+ * #EXTM3U
+ * #EXTINF:233,Title 1
+ * Somewhere\title1.mp3
+ * #EXTINF:129,Title 2
+ * http://www.site.com/~user/title2.mp3
+ * #EXTINF:-1,Stream
+ * stream-2016-01-03.m3u
+ *
+ * #EXTM3U starts the File
+ * #EXTINF:<length in seconds>,<title>
+ * <path>
+ *
+ * Might be useful to extend to m3u8:
+ * https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/StreamingMediaGuide/HTTPStreamingArchitecture/HTTPStreamingArchitecture.html#//apple_ref/doc/uid/TP40008332-CH101-SW10
+ */
+public class M3UFilter implements ContentDataFilter {
+
+    static final byte[] CHAR_COMMENT_START =
+        { (byte)'#' };
+    static final byte[] CHAR_NEWLINE =
+        { (byte)'\n' };
+    static final byte[] CHAR_CARRIAGE_RETURN =
+        { (byte)'\r' };
+    static final int MAX_URI_LENGTH = 16384;
+    static final String badUriReplacement = "#bad-uri-removed";
+    // TODO: Add parsing of ext-comments to allow for gapless playback.
+    // static final int COMMENT_EXT_SIZE = 4;
+    // static final byte[] COMMENT_EXT_START =
+    //  { (byte)'#', (byte)'E', (byte)'X', (byte)'T' };
+    // static final int EXT_HEADER_SIZE = 7;
+    // static final byte[] EXT_HEADER =
+    // { (byte)'#', (byte)'E', (byte)'X', (byte)'T', (byte)'M', (byte)'3', (byte)'U' };
+
+    @Override
+    public void readFilter(InputStream input, OutputStream output, String charset, HashMap<String, String> otherParams,
+            FilterCallback cb) throws DataFilterException, IOException {
+        // TODO: Check the header whether this is an ext m3u.
+        // TODO: Check the EXTINF headers instead of killing comments.
+        // Check whether the line is a comment
+        boolean isComment = false;
+        boolean isBadUri = false;
+        int numberOfDotsInUri = 0;
+        int readcount;
+        byte[] nextbyte = new byte[1];
+        byte[] fileUri;
+        int fileIndex;
+        /* TODO: select the type per suffix. Right now we can get away
+         * with just forcing mbp3 since we only have a filter for
+         * that.*/
+        /* We need to force the type, because browsers might use
+         * content type sniffing in the media tag and audio-players,
+         * so people could insert as text/plain to circumvent the
+         * filter.*/
+        String uriForcetypeMp3Suffix = "?type=audio/mpeg";
+        try (DataInputStream dis = new DataInputStream(input);
+             DataOutputStream dos = new DataOutputStream(output)) {
+            readcount = dis.read(nextbyte);
+            // read each line manually
+            while (readcount != -1) {
+                if (isCommentStart(nextbyte)) {
+                    isComment = true;
+                } else {
+                    isComment = false;
+                }
+                // skip empty lines
+                if (isNewline(nextbyte)) {
+                    readcount = dis.read(nextbyte);
+                    continue;
+                }
+                // read one line as a fileUri
+                numberOfDotsInUri = 0;
+                isBadUri = false;
+                fileIndex = 0;
+                fileUri = new byte[MAX_URI_LENGTH];
+                while (readcount != -1) {
+                    if (!isComment &&
+                        // do not include carriage return in filenames
+                        !isCarriageReturn(nextbyte) &&
+                        // enforce maximum path length to avoid OOM attacks
+                        fileIndex <= MAX_URI_LENGTH) {
+                        // store the read byte
+                        fileUri[fileIndex] = nextbyte[0];
+                        fileIndex += readcount;
+                    }
+                    readcount = dis.read(nextbyte);
+                    if (isNewline(nextbyte) || readcount == -1) {
+                        if (!isComment) {
+                            // remove too long paths
+                            if (fileIndex <= MAX_URI_LENGTH) {
+                                String uriold = new String(fileUri, 0, fileIndex, "UTF-8");
+                                // System.out.println(uriold);
+                                String filtered;
+                                try {
+                                    if (uriold.endsWith(".m3u") || uriold.endsWith(".m3u8")) {
+                                        filtered = cb.processURI(uriold, "audio/mpegurl");
+                                    } else {
+                                        filtered = cb.processURI(uriold, "audio/mpeg");
+                                    }
+                                    // TODO: add prefix for the host
+                                    // name for absolute path names,
+                                    // because otherwise external
+                                    // clients could be tricked into
+                                    // accessing local files. This can
+                                    // however leak information about
+                                    // the local setup (host and port).
+
+                                    // String withbaseref = cb.processURI(uriold, "audio/mpegurl", true, false);
+                                    // if (withbaseref != null) { // absolute path
+                                    //  // add host prefix
+                                    //  filtered =
+                                    // }
+
+                                } catch (CommentException e) {
+                                    filtered = badUriReplacement;
+                                }
+                                if (filtered == null) {
+                                    filtered = badUriReplacement;
+                                }
+                                dos.write(filtered.getBytes("UTF-8"));
+                                // write the newline if we're not at EOF
+                                if (readcount != -1){
+                                    dos.write(nextbyte);
+                                }
+                            }
+                        }
+                        // skip the newline
+                        readcount = dis.read(nextbyte);
+                        break; // skip to next line
+                    }
+                }
+            }
+        }
+    }
+
+    private static boolean isCommentStart(byte[] nextbyte) {
+        return Arrays.equals(nextbyte, CHAR_COMMENT_START);
+    }
+
+    private static boolean isNewline(byte[] nextbyte) {
+        return Arrays.equals(nextbyte, CHAR_NEWLINE);
+    }
+
+    private static boolean isCarriageReturn(byte[] nextbyte) {
+        return Arrays.equals(nextbyte, CHAR_CARRIAGE_RETURN);
+    }
+
+    private static String l10n(String key) {
+        return NodeL10n.getBase().getString("M3UFilter."+key);
+    }
+
+}

--- a/src/freenet/clients/http/ExternalLinkToadlet.java
+++ b/src/freenet/clients/http/ExternalLinkToadlet.java
@@ -18,7 +18,7 @@ public class ExternalLinkToadlet extends Toadlet {
 
 	private static final int MAX_URL_LENGTH = 1024 * 1024;
 	public static final String PATH = "/external-link/";
-	private static final String magicHTTPEscapeString = "_CHECKED_HTTP_";
+	public static final String magicHTTPEscapeString = "_CHECKED_HTTP_";
 
 	private final Node node;
 

--- a/src/freenet/l10n/freenet.l10n.en.properties
+++ b/src/freenet/l10n/freenet.l10n.en.properties
@@ -1349,6 +1349,7 @@ NodeUpdateManager.updateFailedInternalError=FAILED TO UPDATE FREENET. INTERNAL E
 NotEnoughNiceLevelsUserAlert.title=Not enough Nice levels available!
 NotEnoughNiceLevelsUserAlert.short=Not enough Nice levels available! Please run Freenet at a lower nice level.
 NotEnoughNiceLevelsUserAlert.content=Your node has detected that it is running at a high nice level. It can't perform well if they aren't enough levels available. Please lower the nice level you're node is running at (Look for PRIORITY in the run.sh file and lower its value)! Currently your node has ${available} levels to play with whereas it would need ${required}.
+M3UFilter.notM3u=The file you tried to fetch is not an M3U file or it is invalid. It might be some other file format, and your browser may do something dangerous with it, therefore we have blocked it.
 OpennetManager.oneConnectionPerIP=Limit to one connection per address? (strangers)
 OpennetManager.oneConnectionPerIPLong=Don't allow more than one stranger connection per address? This will make it slightly harder for an attacker to connect more than once to your node as different identities, in order to dominate your routing or make harvesting easier. Also prevents having the same node connected on as a friend and stranger simultaneously.
 OpennetConnectionsToadlet.successTimeTitle=Last success

--- a/test/freenet/client/filter/M3UFilterTest.java
+++ b/test/freenet/client/filter/M3UFilterTest.java
@@ -1,0 +1,76 @@
+package freenet.client.filter;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.io.InputStream;
+import java.io.ByteArrayOutputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+
+import junit.framework.TestCase;
+import freenet.support.api.Bucket;
+import freenet.support.io.ArrayBucket;
+import freenet.support.io.BucketTools;
+import freenet.support.io.NullBucket;
+
+public class M3UFilterTest extends TestCase {
+    protected static String[][] testPlaylists = {
+        { "./m3u/safe.m3u", "./m3u/safe_madesafe.m3u" },
+        { "./m3u/unsafe.m3u", "./m3u/unsafe_madesafe.m3u" },
+    };
+
+    private static final String BASE_URI_PROTOCOL = "http";
+    private static final String BASE_URI_CONTENT = "localhost:8888";
+    private static final String BASE_KEY = "USK@0I8gctpUE32CM0iQhXaYpCMvtPPGfT4pjXm01oid5Zc,3dAcn4fX2LyxO6uCnWFTx-2HKZ89uruurcKwLSCxbZ4,AQACAAE/Ultimate-Freenet-Index/55/";
+    private static final String BASE_URI = BASE_URI_PROTOCOL+"://"+BASE_URI_CONTENT+'/'+BASE_KEY;
+
+    public void testSuiteTest() throws IOException {
+        M3UFilter filter = new M3UFilter();
+
+        for (String[] test : testPlaylists) {
+            String original = test[0];
+            String correct = test[1];
+            Bucket ibo;
+            Bucket ibprocessed = new ArrayBucket();
+            Bucket ibc;
+            try {
+                ibo = resourceToBucket(original);
+            } catch (IOException e) {
+                System.out.println(original + " not found, test skipped");
+                continue;
+            }
+            try {
+                ibc = resourceToBucket(correct);
+            } catch (IOException e) {
+                System.out.println(correct + " not found, test skipped");
+                continue;
+            }
+
+            try {
+                filter.readFilter(ibo.getInputStream(), ibprocessed.getOutputStream(), "UTF-8", null,
+                          new GenericReadFilterCallback(new URI(BASE_URI), null, null, null));
+                String result = ibprocessed.toString();
+
+                assertTrue(original + " should be filtered as " + correct + " but was filtered as\n" + result + "\ninstead of the correct\n" + bucketToString((ArrayBucket)ibc), result.equals(bucketToString((ArrayBucket)ibc)));
+            } catch (DataFilterException dfe) {
+                assertTrue("Filtering " + original + " failed", false);
+            } catch (URISyntaxException use) {
+                assertTrue("Creating URI from BASE_URI " + BASE_URI + " failed", false);
+            }
+        }
+    }
+
+    protected ArrayBucket resourceToBucket(String filename) throws IOException {
+        InputStream is = getClass().getResourceAsStream(filename);
+        if (is == null) throw new java.io.FileNotFoundException();
+        ArrayBucket ab = new ArrayBucket();
+        BucketTools.copyFrom(ab, is, Long.MAX_VALUE);
+        return ab;
+    }
+
+    protected String bucketToString(ArrayBucket bucket) throws IOException {
+        return new String(bucket.toByteArray());
+    }
+
+}

--- a/test/freenet/client/filter/M3UFilterTest.java
+++ b/test/freenet/client/filter/M3UFilterTest.java
@@ -22,7 +22,7 @@ public class M3UFilterTest extends TestCase {
 
     private static final String BASE_URI_PROTOCOL = "http";
     private static final String BASE_URI_CONTENT = "localhost:8888";
-    private static final String BASE_KEY = "USK@0I8gctpUE32CM0iQhXaYpCMvtPPGfT4pjXm01oid5Zc,3dAcn4fX2LyxO6uCnWFTx-2HKZ89uruurcKwLSCxbZ4,AQACAAE/Ultimate-Freenet-Index/55/";
+    private static final String BASE_KEY = "USK@0I8gctpUE32CM0iQhXaYpCMvtPPGfT4pjXm01oid5Zc,3dAcn4fX2LyxO6uCnWFTx-2HKZ89uruurcKwLSCxbZ4,AQACAAE/FakeM3UHostingFreesite/23/";
     private static final String BASE_URI = BASE_URI_PROTOCOL+"://"+BASE_URI_CONTENT+'/'+BASE_KEY;
 
     public void testSuiteTest() throws IOException {

--- a/test/freenet/client/filter/m3u/safe.m3u
+++ b/test/freenet/client/filter/m3u/safe.m3u
@@ -1,0 +1,13 @@
+
+# initial and later empty lines should disappear
+
+# some comment
+simplepathname.mp3
+# unimportant comment
+simplepathname2.mp3
+simplepathname3.m3u
+http://127.0.0.1:8888/CHK@qtpnyOzrg~aiAbnw6AoKbX8ZlTCwznjY4G1y-JiiCgg,b0wkEgRPKWMvedueAKLkyv0S83xOrGUT4S7FaN5J3nI,AAMC--8/Infinite-Hands-free-software.mp3
+http://127.0.0.1:8888/CHK@qtpnyOzrg~aiAbnw6AoKbX8ZlTCwznjY4G1y-JiiCgg,b0wkEgRPKWMvedueAKLkyv0S83xOrGUT4S7FaN5J3nI,AAMC--8/next.m3u
+/CHK@qtpnyOzrg~aiAbnw6AoKbX8ZlTCwznjY4G1y-JiiCgg,b0wkEgRPKWMvedueAKLkyv0S83xOrGUT4S7FaN5J3nI,AAMC--8/Infinite-Hands-free-software.mp3
+/CHK@qtpnyOzrg~aiAbnw6AoKbX8ZlTCwznjY4G1y-JiiCgg,b0wkEgRPKWMvedueAKLkyv0S83xOrGUT4S7FaN5J3nI,AAMC--8/next.m3u
+CHK@qtpnyOzrg~aiAbnw6AoKbX8ZlTCwznjY4G1y-JiiCgg,b0wkEgRPKWMvedueAKLkyv0S83xOrGUT4S7FaN5J3nI,AAMC--8/Infinite-Hands-free-software.mp3

--- a/test/freenet/client/filter/m3u/safe.m3u
+++ b/test/freenet/client/filter/m3u/safe.m3u
@@ -6,6 +6,7 @@ simplepathname.mp3
 # unimportant comment
 simplepathname2.mp3
 simplepathname3.m3u
+# absolute links are shifted to the host and port of the visitor
 http://127.0.0.1:8888/CHK@qtpnyOzrg~aiAbnw6AoKbX8ZlTCwznjY4G1y-JiiCgg,b0wkEgRPKWMvedueAKLkyv0S83xOrGUT4S7FaN5J3nI,AAMC--8/Infinite-Hands-free-software.mp3
 http://127.0.0.1:8888/CHK@qtpnyOzrg~aiAbnw6AoKbX8ZlTCwznjY4G1y-JiiCgg,b0wkEgRPKWMvedueAKLkyv0S83xOrGUT4S7FaN5J3nI,AAMC--8/next.m3u
 /CHK@qtpnyOzrg~aiAbnw6AoKbX8ZlTCwznjY4G1y-JiiCgg,b0wkEgRPKWMvedueAKLkyv0S83xOrGUT4S7FaN5J3nI,AAMC--8/Infinite-Hands-free-software.mp3

--- a/test/freenet/client/filter/m3u/safe.m3u
+++ b/test/freenet/client/filter/m3u/safe.m3u
@@ -12,3 +12,19 @@ http://127.0.0.1:8888/CHK@qtpnyOzrg~aiAbnw6AoKbX8ZlTCwznjY4G1y-JiiCgg,b0wkEgRPKW
 /CHK@qtpnyOzrg~aiAbnw6AoKbX8ZlTCwznjY4G1y-JiiCgg,b0wkEgRPKWMvedueAKLkyv0S83xOrGUT4S7FaN5J3nI,AAMC--8/Infinite-Hands-free-software.mp3
 /CHK@qtpnyOzrg~aiAbnw6AoKbX8ZlTCwznjY4G1y-JiiCgg,b0wkEgRPKWMvedueAKLkyv0S83xOrGUT4S7FaN5J3nI,AAMC--8/next.m3u
 CHK@qtpnyOzrg~aiAbnw6AoKbX8ZlTCwznjY4G1y-JiiCgg,b0wkEgRPKWMvedueAKLkyv0S83xOrGUT4S7FaN5J3nI,AAMC--8/Infinite-Hands-free-software.mp3
+
+
+# https://soundcloud.com/conniptions/mr-tsa-man-coming-into-los cc by-sa
+/CHK@aYtI6p96mfkDrIXQdnGZWeTxLm~hEjFy8xz~Bw5oZSw,6gcO31K9NqkpyXk4kTfZbwBp0LvvN5NFLIfDnQ8uEXo,AAMC--8/mrtsaman3.mp3
+# https://soundcloud.com/lelu-starlite/home-at-the-grange cc by-sa
+/CHK@ONyIPZXETM4dDiObUZkyfQzaOtHxmGIDcB0Eofo9UGA,C85PHfP~LjC~uxntvUi~H9cjXx7poU6wLOu8YEwDKTw,AAMC--8/Home-At-The-Grange.mp3
+# https://soundcloud.com/kristina-couch/i-should-leave cc by
+/CHK@q74q2YCWmxGFOivrnLJt3ysXeN3mGJANFQQYt34K3Ag,ISATE9J8ah0V65IZE1H8MENt5U8K9~2DthcPirqh4sk,AAMC--8/cecilos-song-v2.0.mp3
+# https://soundcloud.com/kristina-couch/i-should-leave-improved cc by
+/CHK@0FbKGEpOeRN1VEXRlg~o855V9B6OxeV5h4UEHiq3ngw,oEPkK1k0XWvY82ZlmpGF7jGWuIcNbozwiYnhtEnqWzg,AAMC--8/cecilos-songbest-version.mp3
+# https://soundcloud.com/sorcha_ni/bonnie-alba cc by
+/CHK@ZcvI6zgqtQtV65sI9gntyhIJYNEP5X3I2ylmia0FiOg,aDL29QdbwzipSELt~1jsHqgqZ5YA9sZ-34I8~ZFWrwA,AAMC--8/BonnieAlba.mp3
+# https://soundcloud.com/sorcha_ni/albananthem cc by
+/CHK@~A-SETPFf0jekBWw06yNxsfcsoj-v6V1tT8ntd7ns7I,Cy33kB2jkDR7eeqP54DjHLhILOTw253dUVYrTmO3f90,AAMC--8/AlbanAnthem.mp3
+# https://soundcloud.com/sorcha_ni/a-drop-of-bereks-blood cc by
+/CHK@dq~3Ojv3QItpqNhp7b8W8QrKQo~66duficuXXofHeYY,advGQWcuQbogNX~Kq2to8bWZi7w~YW2aravk1fC4T5M,AAMC--8/BereksBlood.mp3

--- a/test/freenet/client/filter/m3u/safe_madesafe.m3u
+++ b/test/freenet/client/filter/m3u/safe_madesafe.m3u
@@ -1,0 +1,8 @@
+simplepathname.mp3?type=audio/mpeg
+simplepathname2.mp3?type=audio/mpeg
+simplepathname3.m3u?type=audio/mpegurl
+/CHK@qtpnyOzrg~aiAbnw6AoKbX8ZlTCwznjY4G1y-JiiCgg,b0wkEgRPKWMvedueAKLkyv0S83xOrGUT4S7FaN5J3nI,AAMC--8/Infinite-Hands-free-software.mp3?type=audio/mpeg
+/CHK@qtpnyOzrg~aiAbnw6AoKbX8ZlTCwznjY4G1y-JiiCgg,b0wkEgRPKWMvedueAKLkyv0S83xOrGUT4S7FaN5J3nI,AAMC--8/next.m3u?type=audio/mpegurl
+/CHK@qtpnyOzrg~aiAbnw6AoKbX8ZlTCwznjY4G1y-JiiCgg,b0wkEgRPKWMvedueAKLkyv0S83xOrGUT4S7FaN5J3nI,AAMC--8/Infinite-Hands-free-software.mp3?type=audio/mpeg
+/CHK@qtpnyOzrg~aiAbnw6AoKbX8ZlTCwznjY4G1y-JiiCgg,b0wkEgRPKWMvedueAKLkyv0S83xOrGUT4S7FaN5J3nI,AAMC--8/next.m3u?type=audio/mpegurl
+/CHK@qtpnyOzrg~aiAbnw6AoKbX8ZlTCwznjY4G1y-JiiCgg,b0wkEgRPKWMvedueAKLkyv0S83xOrGUT4S7FaN5J3nI,AAMC--8/Infinite-Hands-free-software.mp3?type=audio/mpeg

--- a/test/freenet/client/filter/m3u/safe_madesafe.m3u
+++ b/test/freenet/client/filter/m3u/safe_madesafe.m3u
@@ -1,8 +1,8 @@
-http://localhost:8888/USK@0I8gctpUE32CM0iQhXaYpCMvtPPGfT4pjXm01oid5Zc,3dAcn4fX2LyxO6uCnWFTx-2HKZ89uruurcKwLSCxbZ4,AQACAAE/FakeM3UHostingFreesite/23/simplepathname.mp3?type=audio/mpeg
-http://localhost:8888/USK@0I8gctpUE32CM0iQhXaYpCMvtPPGfT4pjXm01oid5Zc,3dAcn4fX2LyxO6uCnWFTx-2HKZ89uruurcKwLSCxbZ4,AQACAAE/FakeM3UHostingFreesite/23/simplepathname2.mp3?type=audio/mpeg
-http://localhost:8888/USK@0I8gctpUE32CM0iQhXaYpCMvtPPGfT4pjXm01oid5Zc,3dAcn4fX2LyxO6uCnWFTx-2HKZ89uruurcKwLSCxbZ4,AQACAAE/FakeM3UHostingFreesite/23/simplepathname3.m3u?type=audio/mpegurl
-http://localhost:8888/CHK@qtpnyOzrg~aiAbnw6AoKbX8ZlTCwznjY4G1y-JiiCgg,b0wkEgRPKWMvedueAKLkyv0S83xOrGUT4S7FaN5J3nI,AAMC--8/Infinite-Hands-free-software.mp3?type=audio/mpeg
-http://localhost:8888/CHK@qtpnyOzrg~aiAbnw6AoKbX8ZlTCwznjY4G1y-JiiCgg,b0wkEgRPKWMvedueAKLkyv0S83xOrGUT4S7FaN5J3nI,AAMC--8/next.m3u?type=audio/mpegurl
-http://localhost:8888/CHK@qtpnyOzrg~aiAbnw6AoKbX8ZlTCwznjY4G1y-JiiCgg,b0wkEgRPKWMvedueAKLkyv0S83xOrGUT4S7FaN5J3nI,AAMC--8/Infinite-Hands-free-software.mp3?type=audio/mpeg
-http://localhost:8888/CHK@qtpnyOzrg~aiAbnw6AoKbX8ZlTCwznjY4G1y-JiiCgg,b0wkEgRPKWMvedueAKLkyv0S83xOrGUT4S7FaN5J3nI,AAMC--8/next.m3u?type=audio/mpegurl
-http://localhost:8888/CHK@qtpnyOzrg~aiAbnw6AoKbX8ZlTCwznjY4G1y-JiiCgg,b0wkEgRPKWMvedueAKLkyv0S83xOrGUT4S7FaN5J3nI,AAMC--8/Infinite-Hands-free-software.mp3?type=audio/mpeg
+http://localhost:8888/USK@0I8gctpUE32CM0iQhXaYpCMvtPPGfT4pjXm01oid5Zc,3dAcn4fX2LyxO6uCnWFTx-2HKZ89uruurcKwLSCxbZ4,AQACAAE/FakeM3UHostingFreesite/23/simplepathname.mp3?type=audio/mpeg&max-size=115343360
+http://localhost:8888/USK@0I8gctpUE32CM0iQhXaYpCMvtPPGfT4pjXm01oid5Zc,3dAcn4fX2LyxO6uCnWFTx-2HKZ89uruurcKwLSCxbZ4,AQACAAE/FakeM3UHostingFreesite/23/simplepathname2.mp3?type=audio/mpeg&max-size=115343360
+http://localhost:8888/USK@0I8gctpUE32CM0iQhXaYpCMvtPPGfT4pjXm01oid5Zc,3dAcn4fX2LyxO6uCnWFTx-2HKZ89uruurcKwLSCxbZ4,AQACAAE/FakeM3UHostingFreesite/23/simplepathname3.m3u?type=audio/mpegurl&max-size=115343360
+http://localhost:8888/CHK@qtpnyOzrg~aiAbnw6AoKbX8ZlTCwznjY4G1y-JiiCgg,b0wkEgRPKWMvedueAKLkyv0S83xOrGUT4S7FaN5J3nI,AAMC--8/Infinite-Hands-free-software.mp3?type=audio/mpeg&max-size=115343360
+http://localhost:8888/CHK@qtpnyOzrg~aiAbnw6AoKbX8ZlTCwznjY4G1y-JiiCgg,b0wkEgRPKWMvedueAKLkyv0S83xOrGUT4S7FaN5J3nI,AAMC--8/next.m3u?type=audio/mpegurl&max-size=115343360
+http://localhost:8888/CHK@qtpnyOzrg~aiAbnw6AoKbX8ZlTCwznjY4G1y-JiiCgg,b0wkEgRPKWMvedueAKLkyv0S83xOrGUT4S7FaN5J3nI,AAMC--8/Infinite-Hands-free-software.mp3?type=audio/mpeg&max-size=115343360
+http://localhost:8888/CHK@qtpnyOzrg~aiAbnw6AoKbX8ZlTCwznjY4G1y-JiiCgg,b0wkEgRPKWMvedueAKLkyv0S83xOrGUT4S7FaN5J3nI,AAMC--8/next.m3u?type=audio/mpegurl&max-size=115343360
+http://localhost:8888/CHK@qtpnyOzrg~aiAbnw6AoKbX8ZlTCwznjY4G1y-JiiCgg,b0wkEgRPKWMvedueAKLkyv0S83xOrGUT4S7FaN5J3nI,AAMC--8/Infinite-Hands-free-software.mp3?type=audio/mpeg&max-size=115343360

--- a/test/freenet/client/filter/m3u/safe_madesafe.m3u
+++ b/test/freenet/client/filter/m3u/safe_madesafe.m3u
@@ -6,3 +6,10 @@ http://localhost:8888/CHK@qtpnyOzrg~aiAbnw6AoKbX8ZlTCwznjY4G1y-JiiCgg,b0wkEgRPKW
 http://localhost:8888/CHK@qtpnyOzrg~aiAbnw6AoKbX8ZlTCwznjY4G1y-JiiCgg,b0wkEgRPKWMvedueAKLkyv0S83xOrGUT4S7FaN5J3nI,AAMC--8/Infinite-Hands-free-software.mp3?type=audio/mpeg&max-size=115343360
 http://localhost:8888/CHK@qtpnyOzrg~aiAbnw6AoKbX8ZlTCwznjY4G1y-JiiCgg,b0wkEgRPKWMvedueAKLkyv0S83xOrGUT4S7FaN5J3nI,AAMC--8/next.m3u?type=audio/mpegurl&max-size=115343360
 http://localhost:8888/CHK@qtpnyOzrg~aiAbnw6AoKbX8ZlTCwznjY4G1y-JiiCgg,b0wkEgRPKWMvedueAKLkyv0S83xOrGUT4S7FaN5J3nI,AAMC--8/Infinite-Hands-free-software.mp3?type=audio/mpeg&max-size=115343360
+http://localhost:8888/CHK@aYtI6p96mfkDrIXQdnGZWeTxLm~hEjFy8xz~Bw5oZSw,6gcO31K9NqkpyXk4kTfZbwBp0LvvN5NFLIfDnQ8uEXo,AAMC--8/mrtsaman3.mp3?type=audio/mpeg&max-size=115343360
+http://localhost:8888/CHK@ONyIPZXETM4dDiObUZkyfQzaOtHxmGIDcB0Eofo9UGA,C85PHfP~LjC~uxntvUi~H9cjXx7poU6wLOu8YEwDKTw,AAMC--8/Home-At-The-Grange.mp3?type=audio/mpeg&max-size=115343360
+http://localhost:8888/CHK@q74q2YCWmxGFOivrnLJt3ysXeN3mGJANFQQYt34K3Ag,ISATE9J8ah0V65IZE1H8MENt5U8K9~2DthcPirqh4sk,AAMC--8/cecilos-song-v2.0.mp3?type=audio/mpeg&max-size=115343360
+http://localhost:8888/CHK@0FbKGEpOeRN1VEXRlg~o855V9B6OxeV5h4UEHiq3ngw,oEPkK1k0XWvY82ZlmpGF7jGWuIcNbozwiYnhtEnqWzg,AAMC--8/cecilos-songbest-version.mp3?type=audio/mpeg&max-size=115343360
+http://localhost:8888/CHK@ZcvI6zgqtQtV65sI9gntyhIJYNEP5X3I2ylmia0FiOg,aDL29QdbwzipSELt~1jsHqgqZ5YA9sZ-34I8~ZFWrwA,AAMC--8/BonnieAlba.mp3?type=audio/mpeg&max-size=115343360
+http://localhost:8888/CHK@~A-SETPFf0jekBWw06yNxsfcsoj-v6V1tT8ntd7ns7I,Cy33kB2jkDR7eeqP54DjHLhILOTw253dUVYrTmO3f90,AAMC--8/AlbanAnthem.mp3?type=audio/mpeg&max-size=115343360
+http://localhost:8888/CHK@dq~3Ojv3QItpqNhp7b8W8QrKQo~66duficuXXofHeYY,advGQWcuQbogNX~Kq2to8bWZi7w~YW2aravk1fC4T5M,AAMC--8/BereksBlood.mp3?type=audio/mpeg&max-size=115343360

--- a/test/freenet/client/filter/m3u/safe_madesafe.m3u
+++ b/test/freenet/client/filter/m3u/safe_madesafe.m3u
@@ -1,8 +1,8 @@
-simplepathname.mp3?type=audio/mpeg
-simplepathname2.mp3?type=audio/mpeg
-simplepathname3.m3u?type=audio/mpegurl
-/CHK@qtpnyOzrg~aiAbnw6AoKbX8ZlTCwznjY4G1y-JiiCgg,b0wkEgRPKWMvedueAKLkyv0S83xOrGUT4S7FaN5J3nI,AAMC--8/Infinite-Hands-free-software.mp3?type=audio/mpeg
-/CHK@qtpnyOzrg~aiAbnw6AoKbX8ZlTCwznjY4G1y-JiiCgg,b0wkEgRPKWMvedueAKLkyv0S83xOrGUT4S7FaN5J3nI,AAMC--8/next.m3u?type=audio/mpegurl
-/CHK@qtpnyOzrg~aiAbnw6AoKbX8ZlTCwznjY4G1y-JiiCgg,b0wkEgRPKWMvedueAKLkyv0S83xOrGUT4S7FaN5J3nI,AAMC--8/Infinite-Hands-free-software.mp3?type=audio/mpeg
-/CHK@qtpnyOzrg~aiAbnw6AoKbX8ZlTCwznjY4G1y-JiiCgg,b0wkEgRPKWMvedueAKLkyv0S83xOrGUT4S7FaN5J3nI,AAMC--8/next.m3u?type=audio/mpegurl
-/CHK@qtpnyOzrg~aiAbnw6AoKbX8ZlTCwznjY4G1y-JiiCgg,b0wkEgRPKWMvedueAKLkyv0S83xOrGUT4S7FaN5J3nI,AAMC--8/Infinite-Hands-free-software.mp3?type=audio/mpeg
+http://localhost:8888/USK@0I8gctpUE32CM0iQhXaYpCMvtPPGfT4pjXm01oid5Zc,3dAcn4fX2LyxO6uCnWFTx-2HKZ89uruurcKwLSCxbZ4,AQACAAE/FakeM3UHostingFreesite/23/simplepathname.mp3?type=audio/mpeg
+http://localhost:8888/USK@0I8gctpUE32CM0iQhXaYpCMvtPPGfT4pjXm01oid5Zc,3dAcn4fX2LyxO6uCnWFTx-2HKZ89uruurcKwLSCxbZ4,AQACAAE/FakeM3UHostingFreesite/23/simplepathname2.mp3?type=audio/mpeg
+http://localhost:8888/USK@0I8gctpUE32CM0iQhXaYpCMvtPPGfT4pjXm01oid5Zc,3dAcn4fX2LyxO6uCnWFTx-2HKZ89uruurcKwLSCxbZ4,AQACAAE/FakeM3UHostingFreesite/23/simplepathname3.m3u?type=audio/mpegurl
+http://localhost:8888/CHK@qtpnyOzrg~aiAbnw6AoKbX8ZlTCwznjY4G1y-JiiCgg,b0wkEgRPKWMvedueAKLkyv0S83xOrGUT4S7FaN5J3nI,AAMC--8/Infinite-Hands-free-software.mp3?type=audio/mpeg
+http://localhost:8888/CHK@qtpnyOzrg~aiAbnw6AoKbX8ZlTCwznjY4G1y-JiiCgg,b0wkEgRPKWMvedueAKLkyv0S83xOrGUT4S7FaN5J3nI,AAMC--8/next.m3u?type=audio/mpegurl
+http://localhost:8888/CHK@qtpnyOzrg~aiAbnw6AoKbX8ZlTCwznjY4G1y-JiiCgg,b0wkEgRPKWMvedueAKLkyv0S83xOrGUT4S7FaN5J3nI,AAMC--8/Infinite-Hands-free-software.mp3?type=audio/mpeg
+http://localhost:8888/CHK@qtpnyOzrg~aiAbnw6AoKbX8ZlTCwznjY4G1y-JiiCgg,b0wkEgRPKWMvedueAKLkyv0S83xOrGUT4S7FaN5J3nI,AAMC--8/next.m3u?type=audio/mpegurl
+http://localhost:8888/CHK@qtpnyOzrg~aiAbnw6AoKbX8ZlTCwznjY4G1y-JiiCgg,b0wkEgRPKWMvedueAKLkyv0S83xOrGUT4S7FaN5J3nI,AAMC--8/Infinite-Hands-free-software.mp3?type=audio/mpeg

--- a/test/freenet/client/filter/m3u/unsafe.m3u
+++ b/test/freenet/client/filter/m3u/unsafe.m3u
@@ -1,0 +1,9 @@
+# access external resource
+http://betray.user/simplepathname.mp3
+# access other parts of Freenet
+/Sone/post?I_am=simplepathname2.mp3
+# same with a relative link
+../../seclevels/?fakefile=foo.mp3
+# fake filetype
+simplepathname.mp3?type=text/plain
+../../betray.user/simplepathname.mp3

--- a/test/freenet/client/filter/m3u/unsafe.m3u
+++ b/test/freenet/client/filter/m3u/unsafe.m3u
@@ -1,9 +1,11 @@
-# access external resource
+# accessing external resource must be secured with /external-link/
 http://betray.user/simplepathname.mp3
 # access other parts of Freenet
 /Sone/post?I_am=simplepathname2.mp3
 # same with a relative link
 ../../seclevels/?fakefile=foo.mp3
-# fake filetype
+# fake filetype must be corrected to keep players safe
 simplepathname.mp3?type=text/plain
+# relative paths moving to higher levels could be dangerous
 ../../betray.user/simplepathname.mp3
+../betray.user/simplepathname.mp3

--- a/test/freenet/client/filter/m3u/unsafe_madesafe.m3u
+++ b/test/freenet/client/filter/m3u/unsafe_madesafe.m3u
@@ -1,0 +1,5 @@
+/external-link/?_CHECKED_HTTP_=http://betray.user/simplepathname.mp3
+#bad-uri-removed
+#bad-uri-removed
+simplepathname.mp3?type=audio/mpeg
+#bad-uri-removed

--- a/test/freenet/client/filter/m3u/unsafe_madesafe.m3u
+++ b/test/freenet/client/filter/m3u/unsafe_madesafe.m3u
@@ -1,6 +1,6 @@
 http://localhost:8888/external-link/?_CHECKED_HTTP_=http://betray.user/simplepathname.mp3
 #bad-uri-removed
 #bad-uri-removed
-http://localhost:8888/USK@0I8gctpUE32CM0iQhXaYpCMvtPPGfT4pjXm01oid5Zc,3dAcn4fX2LyxO6uCnWFTx-2HKZ89uruurcKwLSCxbZ4,AQACAAE/FakeM3UHostingFreesite/23/simplepathname.mp3?type=audio/mpeg
+http://localhost:8888/USK@0I8gctpUE32CM0iQhXaYpCMvtPPGfT4pjXm01oid5Zc,3dAcn4fX2LyxO6uCnWFTx-2HKZ89uruurcKwLSCxbZ4,AQACAAE/FakeM3UHostingFreesite/23/simplepathname.mp3?type=audio/mpeg&max-size=115343360
 #bad-uri-removed
 #bad-uri-removed

--- a/test/freenet/client/filter/m3u/unsafe_madesafe.m3u
+++ b/test/freenet/client/filter/m3u/unsafe_madesafe.m3u
@@ -1,5 +1,6 @@
-/external-link/?_CHECKED_HTTP_=http://betray.user/simplepathname.mp3
+http://localhost:8888/external-link/?_CHECKED_HTTP_=http://betray.user/simplepathname.mp3
 #bad-uri-removed
 #bad-uri-removed
-simplepathname.mp3?type=audio/mpeg
+http://localhost:8888/USK@0I8gctpUE32CM0iQhXaYpCMvtPPGfT4pjXm01oid5Zc,3dAcn4fX2LyxO6uCnWFTx-2HKZ89uruurcKwLSCxbZ4,AQACAAE/FakeM3UHostingFreesite/23/simplepathname.mp3?type=audio/mpeg
+#bad-uri-removed
 #bad-uri-removed


### PR DESCRIPTION
This now makes all links absolute so the M3U list plays in more external players.

See the tests for details.

Once you run this code, the following should play the files in the tests:

cvlc http://127.0.0.1:8888/SSK@EjDPYvqYf9TKeo1w8k6YnrZRpwvYpUCNUo1jP40pV4g,m6AGnwlGbR8ZkNK6xEYsriGi-UUl4NjJKnIqSIF5iPQ,AQACAAE/stream.m3u

To see copyright notes for the played songs, open the unfiltered file:

http://127.0.0.1:8888/SSK@EjDPYvqYf9TKeo1w8k6YnrZRpwvYpUCNUo1jP40pV4g,m6AGnwlGbR8ZkNK6xEYsriGi-UUl4NjJKnIqSIF5iPQ,AQACAAE/stream.m3u?forcedownload=true