### PR TITLE
Hotfixes for 1481: Reduce peer count scaling to reduce CPU load during routing

### DIFF
--- a/src/freenet/node/OpennetManager.java
+++ b/src/freenet/node/OpennetManager.java
@@ -190,16 +190,16 @@ public class OpennetManager {
 	/** Enable scaling of peers with bandwidth? */
 	public static final boolean ENABLE_PEERS_PER_KB_OUTPUT = true;
 	/** Constant for scaling peers: we multiply bandwidth in kB/sec by this
-	 * and then take the square root. 
+	 * and then take the square root. Minimum is MIN_PEERs_FOR_SCALING.
      * 
      * (define (peers kbps) (sqrt (* kbps scaling)))
      * 
-     * Scaling at 2.5 gives 3-4 peers at 5K,
-	 * 4 at 7K, 5 at 10K, 7 at 20K, 9 at 30K, 12 at 60K, 
-     * 15 at 100K, 19 at 140K, 79 at 2500K.
-	 * 97 at 30mbit/s (the mean upload in Japan in 2014) and
-	 * 166 at 88mbit/s (the mean upload in Hong Kong in 2014).*/
-	public static final double SCALING_CONSTANT = 2.5;
+     * Scaling at 2.5 gives 4 peers at 5K (min peers),
+	 * 4 at 7K, 4 at 10K, 6 at 20K, 7 at 30K, 10 at 60K, 
+     * 13 at 100K, 15 at 140K, 63 at 2500K.
+	 * 78 at 30mbit/s (the mean upload in Japan in 2014) and
+	 * 133 at 88mbit/s (the mean upload in Hong Kong in 2014).*/
+	public static final double SCALING_CONSTANT = 1.61803; // for Euclid and Pythagoras!
 	/**
 	 * Minimum number of peers. As a rough estimate, because the vast majority
 	 * of requests complete in 5 hops, 10 peers give just one binary decision

--- a/src/freenet/node/OpennetManager.java
+++ b/src/freenet/node/OpennetManager.java
@@ -190,12 +190,16 @@ public class OpennetManager {
 	/** Enable scaling of peers with bandwidth? */
 	public static final boolean ENABLE_PEERS_PER_KB_OUTPUT = true;
 	/** Constant for scaling peers: we multiply bandwidth in kB/sec by this
-	 * and then take the square root. scaling at 4 gives 4 peers at 5K,
-	 * 5 at 7K, 6 at 10K, 9 at 20K, 11 at
-	 * 30K, 15 at 60K, 20 at 100K, 24 at 140K, 100 at 2500K.
-	 * 122 at 30mbit/s (the mean upload in Japan in 2014) and
-	 * 210 at 88mbit/s (the mean upload in Hong Kong in 2014).*/
-	public static final double SCALING_CONSTANT = 4.0;
+	 * and then take the square root. 
+     * 
+     * (define (peers kbps) (sqrt (* kbps scaling)))
+     * 
+     * Scaling at 2.5 gives 3-4 peers at 5K,
+	 * 4 at 7K, 5 at 10K, 7 at 20K, 9 at 30K, 12 at 60K, 
+     * 15 at 100K, 19 at 140K, 79 at 2500K.
+	 * 97 at 30mbit/s (the mean upload in Japan in 2014) and
+	 * 166 at 88mbit/s (the mean upload in Hong Kong in 2014).*/
+	public static final double SCALING_CONSTANT = 2.5;
 	/**
 	 * Minimum number of peers. As a rough estimate, because the vast majority
 	 * of requests complete in 5 hops, 10 peers give just one binary decision

--- a/src/freenet/node/OpennetManager.java
+++ b/src/freenet/node/OpennetManager.java
@@ -194,7 +194,7 @@ public class OpennetManager {
      * 
      * (define (peers kbps) (sqrt (* kbps scaling)))
      * 
-     * Scaling at 2.5 gives 4 peers at 5K (min peers),
+     * Scaling at 1.61803 gives 4 peers at 5K (min peers),
 	 * 4 at 7K, 4 at 10K, 6 at 20K, 7 at 30K, 10 at 60K, 
      * 13 at 100K, 15 at 140K, 63 at 2500K.
 	 * 78 at 30mbit/s (the mean upload in Japan in 2014) and

--- a/src/freenet/node/UIDTag.java
+++ b/src/freenet/node/UIDTag.java
@@ -158,13 +158,18 @@ public abstract class UIDTag {
 	 * @param next The node we are no longer routing to.
 	 */
 	public void removeRoutingTo(PeerNode next) {
-		if(logMINOR)
+		if(logMINOR) {
 			Logger.minor(this, "No longer routing to "+next+" on "+this, new Exception("debug"));
+		}
 		boolean noRecordUnlock;
 		synchronized(this) {
-			if(currentlyRoutingTo == null) return;
+			if(currentlyRoutingTo == null) {
+				return;
+			}
 			if(!currentlyRoutingTo.remove(next)) {
-				Logger.warning(this, "Removing wrong node or removing twice? on "+this+" : "+next, new Exception("debug"));
+				if(logMINOR) {
+					Logger.minor(this, "Removing wrong node or removing twice? on "+this+" : "+next, new Exception("debug"));
+				}
 			}
 			if(handlingTimeouts != null) {
 				handlingTimeouts.remove(next);
@@ -172,7 +177,9 @@ public abstract class UIDTag {
 			if(!mustUnlock()) return;
 			noRecordUnlock = this.noRecordUnlock;
 		}
-		if(logMINOR) Logger.minor(this, "Unlocking "+this);
+		if(logMINOR) {
+			Logger.minor(this, "Unlocking "+this);
+		}
 		innerUnlock(noRecordUnlock);
 	}
 	


### PR DESCRIPTION
This is an emergency fix because some of our users with the biggest bandwidth report big problems with CPU load. They report that the update from 1480 to 1481 increased their CPU load by factor 2 to factor 3. Since in the merge from master to merge we kept the min bandwidth requirements of 10kB/s, the lowest peer count will be 4, which still suffices for scaling (as shown by the link length fix).

Risk: Users might complain that their target peers are reduced, because they don’t understand that this does not reduce the bandwidth they can use (because the bandwidth per peer is increased if the peer-count decreases network-wide, and caching should actually become more effective, countering potential problems due to longer paths).