### PR TITLE
Use FCPConnectionHandler.send instead of .outputHandler.queue

### DIFF
--- a/src/freenet/clients/fcp/AddPeer.java
+++ b/src/freenet/clients/fcp/AddPeer.java
@@ -184,7 +184,7 @@ public class AddPeer extends FCPMessage {
 			}
 			System.out.println("Added darknet peer: "+pn);
 		}
-		handler.outputHandler.queue(new PeerMessage(pn, true, true, identifier));
+		handler.send(new PeerMessage(pn, true, true, identifier));
 	}
 
 }

--- a/src/freenet/clients/fcp/ClientHelloMessage.java
+++ b/src/freenet/clients/fcp/ClientHelloMessage.java
@@ -45,7 +45,7 @@ public class ClientHelloMessage extends FCPMessage {
 	public void run(FCPConnectionHandler handler, Node node) {
 		// We know the Hello is valid.
 		FCPMessage msg = new NodeHelloMessage(handler.connectionIdentifier);
-		handler.outputHandler.queue(msg);
+		handler.send(msg);
 		handler.setClientName(clientName);
 	}
 

--- a/src/freenet/clients/fcp/ClientPutBase.java
+++ b/src/freenet/clients/fcp/ClientPutBase.java
@@ -262,7 +262,7 @@ public abstract class ClientPutBase extends ClientRequest implements ClientPutCa
 		// notify client that request was removed
 		FCPMessage msg = new PersistentRequestRemovedMessage(getIdentifier(), global);
 		if(persistence == Persistence.CONNECTION)
-			origHandler.outputHandler.queue(msg);
+			origHandler.send(msg);
 		else
 		client.queueClientRequestMessage(msg, 0);
 

--- a/src/freenet/clients/fcp/FCPServer.java
+++ b/src/freenet/clients/fcp/FCPServer.java
@@ -586,7 +586,7 @@ public class FCPServer implements Runnable, DownloadCache {
 				} else {
 					// Kill old connection
 					oldConn.setKilledDupe();
-					oldConn.outputHandler.queue(new CloseConnectionDuplicateClientNameMessage());
+					oldConn.send(new CloseConnectionDuplicateClientNameMessage());
 					oldConn.close();
 					oldClient.setConnection(handler);
 					return oldClient;

--- a/src/freenet/clients/fcp/FilterMessage.java
+++ b/src/freenet/clients/fcp/FilterMessage.java
@@ -189,7 +189,7 @@ public class FilterMessage extends DataCarryingMessage {
 			Closer.close(output);
 		}
 		FilterResultMessage response = new FilterResultMessage(identifier, resultCharset, resultMimeType, unsafe, resultBucket);
-		handler.outputHandler.queue(response);
+		handler.send(response);
 	}
 	
 	private FilterStatus applyFilter(InputStream input, OutputStream output, ClientContext clientContext) throws MessageInvalidException, UnsafeContentTypeException, IOException {

--- a/src/freenet/clients/fcp/GenerateSSKMessage.java
+++ b/src/freenet/clients/fcp/GenerateSSKMessage.java
@@ -37,7 +37,7 @@ public class GenerateSSKMessage extends FCPMessage {
     	FreenetURI insertURI = key.getInsertURI();
     	FreenetURI requestURI = key.getURI();
     	SSKKeypairMessage msg = new SSKKeypairMessage(insertURI, requestURI, identifier);
-    	handler.outputHandler.queue(msg);
+    	handler.send(msg);
 	}
 
 }

--- a/src/freenet/clients/fcp/GetConfig.java
+++ b/src/freenet/clients/fcp/GetConfig.java
@@ -48,7 +48,7 @@ public class GetConfig extends FCPMessage {
 		if(!handler.hasFullAccess()) {
 			throw new MessageInvalidException(ProtocolErrorMessage.ACCESS_DENIED, "GetConfig requires full access", identifier, false);
 		}
-		handler.outputHandler.queue(new ConfigData(node, withCurrent, withDefaults, withSortOrder, withExpertFlag, withForceWriteFlag, withShortDescription, withLongDescription, withDataTypes, identifier));
+		handler.send(new ConfigData(node, withCurrent, withDefaults, withSortOrder, withExpertFlag, withForceWriteFlag, withShortDescription, withLongDescription, withDataTypes, identifier));
 	}
 
 }

--- a/src/freenet/clients/fcp/GetNode.java
+++ b/src/freenet/clients/fcp/GetNode.java
@@ -41,7 +41,7 @@ public class GetNode extends FCPMessage {
 		if(!handler.hasFullAccess()) {
 			throw new MessageInvalidException(ProtocolErrorMessage.ACCESS_DENIED, "GetNode requires full access", identifier, false);
 		}
-		handler.outputHandler.queue(new NodeData(node, giveOpennetRef, withPrivate, withVolatile, identifier));
+		handler.send(new NodeData(node, giveOpennetRef, withPrivate, withVolatile, identifier));
 	}
 
 }

--- a/src/freenet/clients/fcp/GetPluginInfo.java
+++ b/src/freenet/clients/fcp/GetPluginInfo.java
@@ -48,9 +48,9 @@ public class GetPluginInfo extends FCPMessage {
 
 		PluginInfoWrapper pi = node.pluginManager.getPluginInfo(plugname);
 		if (pi == null) {
-			handler.outputHandler.queue(new ProtocolErrorMessage(ProtocolErrorMessage.NO_SUCH_PLUGIN, false, "Plugin '"+ plugname + "' does not exist or is not a FCP plugin", identifier, false));
+			handler.send(new ProtocolErrorMessage(ProtocolErrorMessage.NO_SUCH_PLUGIN, false, "Plugin '"+ plugname + "' does not exist or is not a FCP plugin", identifier, false));
 		} else {
-			handler.outputHandler.queue(new PluginInfoMessage(pi, identifier, detailed));
+			handler.send(new PluginInfoMessage(pi, identifier, detailed));
 		}
 	}
 

--- a/src/freenet/clients/fcp/GetRequestStatusMessage.java
+++ b/src/freenet/clients/fcp/GetRequestStatusMessage.java
@@ -52,7 +52,7 @@ public class GetRequestStatusMessage extends FCPMessage {
                         ClientRequest req = handler.getForeverRequest(global, handler, identifier);
                         if(req == null) {
                             ProtocolErrorMessage msg = new ProtocolErrorMessage(ProtocolErrorMessage.NO_SUCH_IDENTIFIER, false, null, identifier, global);
-                            handler.outputHandler.queue(msg);
+                            handler.send(msg);
                         } else {
                             req.sendPendingMessages(handler.outputHandler, identifier, true, onlyData);
                         }
@@ -62,7 +62,7 @@ public class GetRequestStatusMessage extends FCPMessage {
                 }, NativeThread.NORM_PRIORITY);
             } catch (PersistenceDisabledException e) {
                 ProtocolErrorMessage msg = new ProtocolErrorMessage(ProtocolErrorMessage.NO_SUCH_IDENTIFIER, false, null, identifier, global);
-                handler.outputHandler.queue(msg);
+                handler.send(msg);
             }
 		} else {
 			req.sendPendingMessages(handler.outputHandler, identifier, true, onlyData);

--- a/src/freenet/clients/fcp/ListPeerMessage.java
+++ b/src/freenet/clients/fcp/ListPeerMessage.java
@@ -42,10 +42,10 @@ public class ListPeerMessage extends FCPMessage {
 		PeerNode pn = node.getPeerNode(nodeIdentifier);
 		if(pn == null) {
 			FCPMessage msg = new UnknownNodeIdentifierMessage(nodeIdentifier, identifier);
-			handler.outputHandler.queue(msg);
+			handler.send(msg);
 			return;
 		}
-		handler.outputHandler.queue(new PeerMessage(pn, true, true, identifier));
+		handler.send(new PeerMessage(pn, true, true, identifier));
 	}
 
 }

--- a/src/freenet/clients/fcp/ListPeerNotesMessage.java
+++ b/src/freenet/clients/fcp/ListPeerNotesMessage.java
@@ -43,7 +43,7 @@ public class ListPeerNotesMessage extends FCPMessage {
 		PeerNode pn = node.getPeerNode(nodeIdentifier);
 		if(pn == null) {
 			FCPMessage msg = new UnknownNodeIdentifierMessage(nodeIdentifier, identifier);
-			handler.outputHandler.queue(msg);
+			handler.send(msg);
 			return;
 		}
 		if(!(pn instanceof DarknetPeerNode)) {
@@ -52,8 +52,8 @@ public class ListPeerNotesMessage extends FCPMessage {
 		DarknetPeerNode dpn = (DarknetPeerNode) pn;
 		// **FIXME** this should be generalized for multiple peer notes per peer, after PeerNode is similarly generalized
 		String noteText = dpn.getPrivateDarknetCommentNote();
-		handler.outputHandler.queue(new PeerNote(nodeIdentifier, noteText, Node.PEER_NOTE_TYPE_PRIVATE_DARKNET_COMMENT, identifier));
-		handler.outputHandler.queue(new EndListPeerNotesMessage(nodeIdentifier, identifier));
+		handler.send(new PeerNote(nodeIdentifier, noteText, Node.PEER_NOTE_TYPE_PRIVATE_DARKNET_COMMENT, identifier));
+		handler.send(new EndListPeerNotesMessage(nodeIdentifier, identifier));
 	}
 
 }

--- a/src/freenet/clients/fcp/ListPeersMessage.java
+++ b/src/freenet/clients/fcp/ListPeersMessage.java
@@ -39,10 +39,10 @@ public class ListPeersMessage extends FCPMessage {
 		}
 		PeerNode[] nodes = node.getPeerNodes();
 		for(PeerNode pn: nodes) {
-			handler.outputHandler.queue(new PeerMessage(pn, withMetadata, withVolatile, identifier));
+			handler.send(new PeerMessage(pn, withMetadata, withVolatile, identifier));
 		}
 		
-		handler.outputHandler.queue(new EndListPeersMessage(identifier));
+		handler.send(new EndListPeersMessage(identifier));
 	}
 
 }

--- a/src/freenet/clients/fcp/ListPersistentRequestsMessage.java
+++ b/src/freenet/clients/fcp/ListPersistentRequestsMessage.java
@@ -199,7 +199,7 @@ public class ListPersistentRequestsMessage extends FCPMessage {
                         	}
                         }, NativeThread.HIGH_PRIORITY-1);
                     } catch (PersistenceDisabledException e) {
-                        handler.outputHandler.queue(new EndListPersistentRequestsMessage(listRequestIdentifier));
+                        handler.send(new EndListPersistentRequestsMessage(listRequestIdentifier));
                     }
 			}
 			

--- a/src/freenet/clients/fcp/LoadPlugin.java
+++ b/src/freenet/clients/fcp/LoadPlugin.java
@@ -86,8 +86,8 @@ public class LoadPlugin extends FCPMessage {
 		}
 		
 		if(!node.pluginManager.isEnabled()) {
-		    handler.outputHandler.queue(new ProtocolErrorMessage(ProtocolErrorMessage.PLUGINS_DISABLED, false, "Plugins disabled", identifier, false));
-		    return;
+			handler.send(new ProtocolErrorMessage(ProtocolErrorMessage.PLUGINS_DISABLED, false, "Plugins disabled", identifier, false));
+			return;
 		}
 
 		node.executor.execute(new Runnable() {
@@ -116,7 +116,7 @@ public class LoadPlugin extends FCPMessage {
 						}
 					}
 					if (type == null) {
-						handler.outputHandler.queue(new ProtocolErrorMessage(ProtocolErrorMessage.INVALID_FIELD, false, "Was not able to guess the URL type from URL, check the URL or add a 'URLType' field", identifier, false));
+						handler.send(new ProtocolErrorMessage(ProtocolErrorMessage.INVALID_FIELD, false, "Was not able to guess the URL type from URL, check the URL or add a 'URLType' field", identifier, false));
 						return;
 					}
 				} else {
@@ -133,13 +133,13 @@ public class LoadPlugin extends FCPMessage {
 					pi = node.pluginManager.startPluginURL(pluginURL, store);
 				} else {
 					Logger.error(this, "This should really not happen!", new Exception("FIXME"));
-					handler.outputHandler.queue(new ProtocolErrorMessage(ProtocolErrorMessage.INTERNAL_ERROR, false, "This should really not happen! See logs for details.", identifier, false));
+					handler.send(new ProtocolErrorMessage(ProtocolErrorMessage.INTERNAL_ERROR, false, "This should really not happen! See logs for details.", identifier, false));
 					return;
 				}
 				if (pi == null) {
-					handler.outputHandler.queue(new ProtocolErrorMessage(ProtocolErrorMessage.NO_SUCH_PLUGIN, false, "Plugin '"+ pluginURL + "' does not exist or is not a FCP plugin", identifier, false));
+					handler.send(new ProtocolErrorMessage(ProtocolErrorMessage.NO_SUCH_PLUGIN, false, "Plugin '"+ pluginURL + "' does not exist or is not a FCP plugin", identifier, false));
 				} else {
-					handler.outputHandler.queue(new PluginInfoMessage(pi, identifier, true));
+					handler.send(new PluginInfoMessage(pi, identifier, true));
 				}
 			}
 		}, "Load Plugin");

--- a/src/freenet/clients/fcp/ModifyConfig.java
+++ b/src/freenet/clients/fcp/ModifyConfig.java
@@ -65,7 +65,7 @@ public class ModifyConfig extends FCPMessage {
 			}
 		}
 		node.clientCore.storeConfig();
-		handler.outputHandler.queue(new ConfigData(node, true, false, false, false, false, false, false, false, identifier));
+		handler.send(new ConfigData(node, true, false, false, false, false, false, false, false, identifier));
 	}
 
 }

--- a/src/freenet/clients/fcp/ModifyPeer.java
+++ b/src/freenet/clients/fcp/ModifyPeer.java
@@ -44,7 +44,7 @@ public class ModifyPeer extends FCPMessage {
 		PeerNode pn = node.getPeerNode(nodeIdentifier);
 		if(pn == null) {
 			FCPMessage msg = new UnknownNodeIdentifierMessage(nodeIdentifier, identifier);
-			handler.outputHandler.queue(msg);
+			handler.send(msg);
 			return;
 		}
 		if(!(pn instanceof DarknetPeerNode)) {
@@ -85,7 +85,7 @@ public class ModifyPeer extends FCPMessage {
 				dpn.setAllowLocalAddresses(Fields.stringToBool(allowLocalAddressesString, false));
 			}
 		}
-		handler.outputHandler.queue(new PeerMessage(pn, true, true, identifier));
+		handler.send(new PeerMessage(pn, true, true, identifier));
 	}
 
 }

--- a/src/freenet/clients/fcp/ModifyPeerNote.java
+++ b/src/freenet/clients/fcp/ModifyPeerNote.java
@@ -47,7 +47,7 @@ public class ModifyPeerNote extends FCPMessage {
 		PeerNode pn = node.getPeerNode(nodeIdentifier);
 		if(pn == null) {
 			FCPMessage msg = new UnknownNodeIdentifierMessage(nodeIdentifier, identifier);
-			handler.outputHandler.queue(msg);
+			handler.send(msg);
 			return;
 		}
 		if(!(pn instanceof DarknetPeerNode)) {
@@ -76,10 +76,10 @@ public class ModifyPeerNote extends FCPMessage {
 			dpn.setPrivateDarknetCommentNote(noteText);
 		} else {
 			FCPMessage msg = new UnknownPeerNoteTypeMessage(peerNoteType, identifier);
-			handler.outputHandler.queue(msg);
+			handler.send(msg);
 			return;
 		}
-		handler.outputHandler.queue(new PeerNote(nodeIdentifier, noteText, peerNoteType, identifier));
+		handler.send(new PeerNote(nodeIdentifier, noteText, peerNoteType, identifier));
 	}
 
 }

--- a/src/freenet/clients/fcp/ModifyPersistentRequest.java
+++ b/src/freenet/clients/fcp/ModifyPersistentRequest.java
@@ -84,7 +84,7 @@ public class ModifyPersistentRequest extends FCPMessage {
                         if(req==null){
                             Logger.error(this, "Huh ? the request is null!");
                             ProtocolErrorMessage msg = new ProtocolErrorMessage(ProtocolErrorMessage.NO_SUCH_IDENTIFIER, false, null, identifier, global);
-                            handler.outputHandler.queue(msg);
+                            handler.send(msg);
                             return false;
                         } else {
                             req.modifyRequest(clientToken, priorityClass, handler.server);
@@ -95,7 +95,7 @@ public class ModifyPersistentRequest extends FCPMessage {
                 }, NativeThread.NORM_PRIORITY);
             } catch (PersistenceDisabledException e) {
                 ProtocolErrorMessage msg = new ProtocolErrorMessage(ProtocolErrorMessage.NO_SUCH_IDENTIFIER, false, null, identifier, global);
-                handler.outputHandler.queue(msg);
+                handler.send(msg);
             }
 		} else {
 			req.modifyRequest(clientToken, priorityClass, node.clientCore.getFCPServer());

--- a/src/freenet/clients/fcp/PersistentRequestClient.java
+++ b/src/freenet/clients/fcp/PersistentRequestClient.java
@@ -374,7 +374,7 @@ public class PersistentRequestClient {
 			return;
 		FCPConnectionHandler conn = getConnection();
 		if(conn != null) {
-			conn.outputHandler.queue(msg);
+			conn.send(msg);
 		}
 		PersistentRequestClient[] clients;
 		if(isGlobalQueue) {

--- a/src/freenet/clients/fcp/ProbeRequest.java
+++ b/src/freenet/clients/fcp/ProbeRequest.java
@@ -79,58 +79,58 @@ public class ProbeRequest extends FCPMessage {
 		Listener listener = new Listener() {
 			@Override
 			public void onError(Error error, Byte code, boolean local) {
-				handler.outputHandler.queue(new ProbeError(identifier, error, code, local));
+				handler.send(new ProbeError(identifier, error, code, local));
 			}
 
 			@Override
 			public void onRefused() {
-				handler.outputHandler.queue(new ProbeRefused(identifier));
+				handler.send(new ProbeRefused(identifier));
 			}
 
 			@Override
 			public void onOutputBandwidth(float outputBandwidth) {
-				handler.outputHandler.queue(new ProbeBandwidth(identifier, outputBandwidth));
+				handler.send(new ProbeBandwidth(identifier, outputBandwidth));
 			}
 
 			@Override
 			public void onBuild(int build) {
-				handler.outputHandler.queue(new ProbeBuild(identifier, build));
+				handler.send(new ProbeBuild(identifier, build));
 			}
 
 			@Override
 			public void onIdentifier(long probeIdentifier, byte percentageUptime) {
-				handler.outputHandler.queue(new ProbeIdentifier(identifier, probeIdentifier, percentageUptime));
+				handler.send(new ProbeIdentifier(identifier, probeIdentifier, percentageUptime));
 			}
 
 			@Override
 			public void onLinkLengths(float[] linkLengths) {
-				handler.outputHandler.queue(new ProbeLinkLengths(identifier, linkLengths));
+				handler.send(new ProbeLinkLengths(identifier, linkLengths));
 			}
 
 			@Override
 			public void onLocation(float location) {
-				handler.outputHandler.queue(new ProbeLocation(identifier, location));
+				handler.send(new ProbeLocation(identifier, location));
 			}
 
 			@Override
 			public void onStoreSize(float storeSize) {
-				handler.outputHandler.queue(new ProbeStoreSize(identifier, storeSize));
+				handler.send(new ProbeStoreSize(identifier, storeSize));
 			}
 
 			@Override
 			public void onUptime(float uptimePercent) {
-				handler.outputHandler.queue(new ProbeUptime(identifier, uptimePercent));
+				handler.send(new ProbeUptime(identifier, uptimePercent));
 			}
 
 			@Override
 			public void onRejectStats(byte[] stats) {
-				handler.outputHandler.queue(new ProbeRejectStats(identifier, stats));
+				handler.send(new ProbeRejectStats(identifier, stats));
 			}
 
 			@Override
 			public void onOverallBulkOutputCapacity(
 					byte bandwidthClassForCapacityUsage, float capacityUsage) {
-				handler.outputHandler.queue(new ProbeOverallBulkOutputCapacityUsage(identifier, bandwidthClassForCapacityUsage, capacityUsage));
+				handler.send(new ProbeOverallBulkOutputCapacityUsage(identifier, bandwidthClassForCapacityUsage, capacityUsage));
 			}
 		};
 		node.startProbe(htl, node.random.nextLong(), type, listener);

--- a/src/freenet/clients/fcp/ReloadPlugin.java
+++ b/src/freenet/clients/fcp/ReloadPlugin.java
@@ -54,7 +54,7 @@ public class ReloadPlugin extends FCPMessage {
 			public void run() {
 				PluginInfoWrapper pi = node.pluginManager.getPluginInfo(plugname);
 				if (pi == null) {
-					handler.outputHandler.queue(new ProtocolErrorMessage(ProtocolErrorMessage.NO_SUCH_PLUGIN, false, "Plugin '"+ plugname + "' does not exist or is not a FCP plugin", identifier, false));
+					handler.send(new ProtocolErrorMessage(ProtocolErrorMessage.NO_SUCH_PLUGIN, false, "Plugin '"+ plugname + "' does not exist or is not a FCP plugin", identifier, false));
 				} else {
 					String source = pi.getFilename();
 					pi.stopPlugin(node.pluginManager, maxWaitTime, true);
@@ -63,9 +63,9 @@ public class ReloadPlugin extends FCPMessage {
 					}
 					pi = node.pluginManager.startPluginAuto(source, store);
 					if (pi == null) {
-						handler.outputHandler.queue(new ProtocolErrorMessage(ProtocolErrorMessage.NO_SUCH_PLUGIN, false, "Plugin '"+ plugname + "' does not exist or is not a FCP plugin", identifier, false));
+						handler.send(new ProtocolErrorMessage(ProtocolErrorMessage.NO_SUCH_PLUGIN, false, "Plugin '"+ plugname + "' does not exist or is not a FCP plugin", identifier, false));
 					} else {
-						handler.outputHandler.queue(new PluginInfoMessage(pi, identifier, true));
+						handler.send(new PluginInfoMessage(pi, identifier, true));
 					}
 				}
 			}

--- a/src/freenet/clients/fcp/RemovePeer.java
+++ b/src/freenet/clients/fcp/RemovePeer.java
@@ -42,12 +42,12 @@ public class RemovePeer extends FCPMessage {
 		PeerNode pn = node.getPeerNode(nodeIdentifier);
 		if(pn == null) {
 			FCPMessage msg = new UnknownNodeIdentifierMessage(nodeIdentifier, identifier);
-			handler.outputHandler.queue(msg);
+			handler.send(msg);
 			return;
 		}
 		String identity = pn.getIdentityString();
 		node.removePeerConnection(pn);
-		handler.outputHandler.queue(new PeerRemoved(identity, nodeIdentifier, identifier));
+		handler.send(new PeerRemoved(identity, nodeIdentifier, identifier));
 	}
 
 }

--- a/src/freenet/clients/fcp/RemovePersistentRequest.java
+++ b/src/freenet/clients/fcp/RemovePersistentRequest.java
@@ -63,7 +63,7 @@ public class RemovePersistentRequest extends FCPMessage {
                             return true;
                         } catch (MessageInvalidException e) {
                             FCPMessage err = new ProtocolErrorMessage(e.protocolCode, false, e.getMessage(), e.ident, e.global);
-                            handler.outputHandler.queue(err);
+                            handler.send(err);
                             return false;
                         }
                     }
@@ -71,7 +71,7 @@ public class RemovePersistentRequest extends FCPMessage {
                 }, NativeThread.HIGH_PRIORITY);
             } catch (PersistenceDisabledException e) {
                 FCPMessage err = new ProtocolErrorMessage(ProtocolErrorMessage.PERSISTENCE_DISABLED, false, "Persistence disabled and non-persistent request not found", identifier, global);
-                handler.outputHandler.queue(err);
+                handler.send(err);
             }
 		}
 	}

--- a/src/freenet/clients/fcp/RemovePlugin.java
+++ b/src/freenet/clients/fcp/RemovePlugin.java
@@ -52,13 +52,13 @@ public class RemovePlugin extends FCPMessage {
 			public void run() {
 				PluginInfoWrapper pi = node.pluginManager.getPluginInfo(plugname);
 				if (pi == null) {
-					handler.outputHandler.queue(new ProtocolErrorMessage(ProtocolErrorMessage.NO_SUCH_PLUGIN, false, "Plugin '"+ plugname + "' does not exist or is not a FCP plugin", identifier, false));
+					handler.send(new ProtocolErrorMessage(ProtocolErrorMessage.NO_SUCH_PLUGIN, false, "Plugin '"+ plugname + "' does not exist or is not a FCP plugin", identifier, false));
 				} else {
 					pi.stopPlugin(node.pluginManager, maxWaitTime, false);
 					if (purge) {
 						node.pluginManager.removeCachedCopy(pi.getFilename());
 					}
-					handler.outputHandler.queue(new PluginRemovedMessage(plugname, identifier));
+					handler.send(new PluginRemovedMessage(plugname, identifier));
 				}
 			}
 		}, "Remove Plugin");

--- a/src/freenet/clients/fcp/SendPeerMessage.java
+++ b/src/freenet/clients/fcp/SendPeerMessage.java
@@ -43,13 +43,13 @@ public abstract class SendPeerMessage extends DataCarryingMessage {
 		PeerNode pn = node.getPeerNode(nodeIdentifier);
 		if (pn == null) {
 			FCPMessage msg = new UnknownNodeIdentifierMessage(nodeIdentifier, identifier);
-			handler.outputHandler.queue(msg);
+			handler.send(msg);
 		} else if (!(pn instanceof DarknetPeerNode)) {
 			throw new MessageInvalidException(ProtocolErrorMessage.DARKNET_ONLY,
 					getName() + " only available for darknet peers", identifier, false);
 		} else {
 			int nodeStatus = handleFeed(((DarknetPeerNode) pn));
-			handler.outputHandler.queue(new SentPeerMessage(identifier, nodeStatus));
+			handler.send(new SentPeerMessage(identifier, nodeStatus));
 		}
 	}
 

--- a/src/freenet/clients/fcp/ShutdownMessage.java
+++ b/src/freenet/clients/fcp/ShutdownMessage.java
@@ -29,7 +29,7 @@ public class ShutdownMessage extends FCPMessage{
 			throw new MessageInvalidException(ProtocolErrorMessage.ACCESS_DENIED, "Shutdown requires full access", null, false);
 		}
 		FCPMessage msg = new ProtocolErrorMessage(ProtocolErrorMessage.SHUTTING_DOWN,true,"The node is shutting down","Node",false);
-		handler.outputHandler.queue(msg);
+		handler.send(msg);
 		node.exit("Received FCP shutdown message");
 	}
 

--- a/src/freenet/clients/fcp/SubscribeUSK.java
+++ b/src/freenet/clients/fcp/SubscribeUSK.java
@@ -48,7 +48,7 @@ public class SubscribeUSK implements USKProgressCallback {
 		}
 		//if(newKnownGood && !newSlotToo) return;
 		FCPMessage msg = new SubscribedUSKUpdate(identifier, l, key, newKnownGood, newSlotToo);
-		handler.outputHandler.queue(msg);
+		handler.send(msg);
 	}
 
 	@Override
@@ -67,12 +67,12 @@ public class SubscribeUSK implements USKProgressCallback {
 
 	@Override
 	public void onSendingToNetwork(ClientContext context) {
-		handler.outputHandler.queue(new SubscribedUSKSendingToNetworkMessage(identifier));
+		handler.send(new SubscribedUSKSendingToNetworkMessage(identifier));
 	}
 
 	@Override
 	public void onRoundFinished(ClientContext context) {
-		handler.outputHandler.queue(new SubscribedUSKRoundFinishedMessage(identifier));
+		handler.send(new SubscribedUSKRoundFinishedMessage(identifier));
 	}
 
 }

--- a/src/freenet/clients/fcp/SubscribeUSKMessage.java
+++ b/src/freenet/clients/fcp/SubscribeUSKMessage.java
@@ -79,11 +79,11 @@ public class SubscribeUSKMessage extends FCPMessage {
 		try {
 			new SubscribeUSK(this, node.clientCore, handler);
 		} catch (IdentifierCollisionException e) {
-			handler.outputHandler.queue(new IdentifierCollisionMessage(identifier, false));
+			handler.send(new IdentifierCollisionMessage(identifier, false));
 			return;
 		}
 		SubscribedUSKMessage reply = new SubscribedUSKMessage(this);
-		handler.outputHandler.queue(reply);
+		handler.send(reply);
 	}
 
 }

--- a/src/freenet/clients/fcp/TestDDARequestMessage.java
+++ b/src/freenet/clients/fcp/TestDDARequestMessage.java
@@ -60,7 +60,7 @@ public class TestDDARequestMessage extends FCPMessage {
 			throw new MessageInvalidException(ProtocolErrorMessage.INVALID_FIELD, e.getMessage(), identifier, false);
 		}
 		TestDDAReplyMessage reply = new TestDDAReplyMessage(job);
-		handler.outputHandler.queue(reply);
+		handler.send(reply);
 	}
 	
 }

--- a/src/freenet/clients/fcp/TestDDAResponseMessage.java
+++ b/src/freenet/clients/fcp/TestDDAResponseMessage.java
@@ -57,7 +57,7 @@ public class TestDDAResponseMessage extends FCPMessage {
 			throw new MessageInvalidException(ProtocolErrorMessage.MISSING_FIELD, "You need to send " + READ_CONTENT + " back to the node if you specify " + TestDDARequestMessage.WANT_READ + " in " + TestDDARequestMessage.NAME + '.', identifier, false);
 		
 		TestDDACompleteMessage reply = new TestDDACompleteMessage(handler, job, readContent);
-		handler.outputHandler.queue(reply);
+		handler.send(reply);
 	}
 
 }

--- a/src/freenet/clients/fcp/WatchGlobal.java
+++ b/src/freenet/clients/fcp/WatchGlobal.java
@@ -43,7 +43,7 @@ public class WatchGlobal extends FCPMessage {
 			throws MessageInvalidException {
 		if(!handler.getRebootClient().setWatchGlobal(enabled, verbosityMask, node.clientCore.getFCPServer())) {
 			FCPMessage err = new ProtocolErrorMessage(ProtocolErrorMessage.PERSISTENCE_DISABLED, false, "Persistence disabled", null, true);
-			handler.outputHandler.queue(err);
+			handler.send(err);
 		}
 		PersistentRequestClient client = handler.getForeverClient();
 		if(client != null)

--- a/src/freenet/node/useralerts/UserAlertManager.java
+++ b/src/freenet/node/useralerts/UserAlertManager.java
@@ -81,7 +81,7 @@ public class UserAlertManager implements Comparator<UserAlert> {
 			@Override
 			public void run() {
 				for (FCPConnectionHandler subscriber : subscribers)
-					subscriber.outputHandler.queue(alert.getFCPMessage());
+					subscriber.send(alert.getFCPMessage());
 			}
 		}, "UserAlertManager callback executor");
 	}
@@ -384,15 +384,15 @@ public class UserAlertManager implements Comparator<UserAlert> {
 	}
 
 	public void watch(final FCPConnectionHandler subscriber) {
-                subscribers.add(subscriber);
+		subscribers.add(subscriber);
 		// Run off-thread, because of locking, and because client
 		// callbacks may take some time
 		core.clientContext.mainExecutor.execute(new Runnable() {
 			@Override
 			public void run() {
 				for (UserAlert alert : getAlerts())
-                                        if(alert.isValid())
-					    subscriber.outputHandler.queue(alert.getFCPMessage());
+					if(alert.isValid())
+						subscriber.send(alert.getFCPMessage());
 			}
 		}, "UserAlertManager callback executor");
 		subscribers.add(subscriber);

--- a/src/freenet/pluginmanager/PluginReplySenderFCP.java
+++ b/src/freenet/pluginmanager/PluginReplySenderFCP.java
@@ -34,6 +34,6 @@ public class PluginReplySenderFCP extends PluginReplySender {
 		// instead fcp connection errors 
 		if (handler.isClosed()) throw new PluginNotFoundException("FCP connection closed");
         FCPPluginServerMessage reply = new FCPPluginServerMessage(pluginname, clientSideIdentifier, params, bucket);
-		handler.outputHandler.queue(reply);
+		handler.send(reply);
 	}
 }


### PR DESCRIPTION
FCPConnectionOutputHandler.queue [was deprecated](https://github.com/freenet/fred/blob/49914bd709002348dcb35fb73d1ce866bda51f24/src/freenet/clients/fcp/FCPConnectionOutputHandler.java#L123) with a note saying
> Replace <code>fcpConnectionHandler.outputHandler.queue(...)</code> with <code>fcpConnectionHandler.send(...)</code>

I just did those replacements everywhere I could. FCPConnectionHandler.outputHandler still can't be made private though, as it's used for other stuff.