### PR TITLE
Add small padding for flags

### DIFF
--- a/src/freenet/clients/http/geoip/IPConverter.java
+++ b/src/freenet/clients/http/geoip/IPConverter.java
@@ -143,7 +143,7 @@ public class IPConverter {
 		public void renderFlagIcon(HTMLNode parent) {
 			String flagPath = getFlagIconPath();
 			if(flagPath != null)
-				parent.addChild("img", new String[] { "src", "title" }, new String[] { StaticToadlet.ROOT_URL + flagPath, getName()});
+				parent.addChild("img", new String[] { "src", "class", "title" }, new String[] { StaticToadlet.ROOT_URL + flagPath, "flag", getName()});
 		}
 		
 		public boolean hasFlagIcon() {

--- a/src/freenet/clients/http/staticfiles/baseelements.css
+++ b/src/freenet/clients/http/staticfiles/baseelements.css
@@ -482,6 +482,11 @@ table.darknet_connections span.peer_disconnected {
 	text-transform: uppercase;
 }
 
+/* add some space between flag and IP address */
+.peer-address .flag {
+	padding-right: 0.5ex;
+}
+
 /*FIXME magic keystone - remove these rules and the entire
  * page collapses */
 div.infobox-content ul {


### PR DESCRIPTION
The IP address is really, _really_ close to the flag on the connection pages. I can’t be having with this.