### PR TITLE
WIP m3u filter hardcoded hostport

### DIFF
--- a/src/freenet/client/filter/ContentFilter.java
+++ b/src/freenet/client/filter/ContentFilter.java
@@ -88,7 +88,7 @@ public class ContentFilter {
 		 * on top of that needed for the Ogg container itself.
 		 * Reference: http://xiph.org/ogg/doc/rfc3533.txt
 		 */
-		register(new FilterMIMEType("application/ogg", "ogx", new String[] {"video/ogg", "audio/ogg"}, new String[]{"ogg", "oga", "ogv"},
+		register(new FilterMIMEType("application/ogg", "ogx", new String[] {"video/ogg", "audio/ogg"}, new String[]{"ogg", "ogv", "oga"},
 				true, false, new OggFilter(), true, true, false, true, false, false,
 				l10n("containerOggReadAdvice"),false, null, null, false));
 

--- a/src/freenet/client/filter/GenericReadFilterCallback.java
+++ b/src/freenet/client/filter/GenericReadFilterCallback.java
@@ -192,7 +192,7 @@ public class GenericReadFilterCallback implements FilterCallback, URIProcessor {
 		// Convert localhost uri's to relative internal ones.
 		
 		String host = uri.getHost();
-		if(host != null && (host.equals("localhost") || host.equals("127.0.0.1")) && uri.getPort() == 8888) {
+		if(host != null && (host.equals("localhost") || host.startsWith("127."))) {
 			try {
 				uri = new URI(null, null, null, -1, uri.getPath(), uri.getQuery(), uri.getFragment());
 			} catch (URISyntaxException e) {

--- a/src/freenet/client/filter/HTMLFilter.java
+++ b/src/freenet/client/filter/HTMLFilter.java
@@ -2814,14 +2814,23 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
 			String hreflang = getHashString(h, "hreflang");
 			String charset = null;
 			String maybecharset = null;
-            /* TODO: get the type from the filename. Currently we only
-             * have a filter for mp3, so this is the simplest possible
-             * solution.*/
-            String type = "audio/mpeg";
 
 			String src = getHashString(h, "src");
 			if (src != null) {
 				src = HTMLDecoder.decode(src);
+                String type;
+                if (src.endsWith(".ogv")) {
+                    type = "video/ogg";
+                } else if (src.endsWith(".oga")) {
+                    type = "audio/ogg";
+                } else if (src.endsWith(".ogg")) {
+                    type = "application/ogg";
+                } else if (src.endsWith(".flac")) {
+                    type = "audio/flac";
+                } else { // default case plays it safe: mp3
+                    type = "audio/mpeg";
+                }
+                
                 src = htmlSanitizeURI(src, type, null, null, pc.cb, pc, false);
 				if (src != null) {
 					src = HTMLEncoder.encode(src);

--- a/src/freenet/client/filter/M3UFilter.java
+++ b/src/freenet/client/filter/M3UFilter.java
@@ -157,6 +157,10 @@ public class M3UFilter implements ContentDataFilter {
                                 if (cb instanceof GenericReadFilterCallback) {
                                     try {
                                         filtered = ((GenericReadFilterCallback)cb).makeURIAbsolute(filtered);
+                                        // FIXME: this hardcodes the address. Better get the localhost and port defined in freenet.ini. This is just to try whether it allows mpv to simply play the m3u.
+                                        if (filtered.startsWith("/")) {
+                                            filtered = "http://127.0.0.1:8888/" + filtered;
+                                        }
                                     } catch (URISyntaxException e) {
                                         filtered = badUriReplacement;
                                     }


### PR DESCRIPTION
This makes m3us playlists (aka streaming over Freenet) work for mp3, flac, ogg vorbis and theora, if Freenet uses the default host+port, but uses a hardcoded host+port combination.

To actually work for all setups it would have to include the actual host+port in the filtered m3u, but that would leak information which could be used to find out whether someone runs a node.

For reference why this would be dangerous, here’s the guide to create the most secure setup for Freenet: https://d6.gnutella2.info/freenet/USK@sUm3oJISSEU4pl2Is9qa1eRoCLyz6r2LPkEqlXc3~oc,yBEbf-IJrcB8Pe~gAd53DEEHgbugUkFSHtzzLqnYlbs,AQACAAE/random_babcom/396/#UseFreenetasproxysecureagainstspyingattacks