### PR TITLE
fix bug7102: don't attempt to pre-allocate when we truncate

### DIFF
--- a/src/freenet/store/saltedhash/SaltedHashFreenetStore.java
+++ b/src/freenet/store/saltedhash/SaltedHashFreenetStore.java
@@ -1065,12 +1065,16 @@ public class SaltedHashFreenetStore<T extends StorableBlock> implements FreenetS
 			final long newMetaLen = Entry.METADATA_LENGTH * storeMaxEntries;
 			final long newHdLen = (headerBlockLength + dataBlockLength + hdPadding) * storeMaxEntries;
 
-			if (preallocate && (oldMetaLen < newMetaLen || currentHdLen < newHdLen)) {
+			if (preallocate) {
 				try (WrapperKeepalive wrapperKeepalive = new WrapperKeepalive();)
 				{
 					wrapperKeepalive.start();
-					Fallocate.forChannel(metaFC, newMetaLen).fromOffset(oldMetaLen).execute();
-					Fallocate.forChannel(hdFC, newHdLen).fromOffset(currentHdLen).execute();
+					if (oldMetaLen < newMetaLen) {
+						Fallocate.forChannel(metaFC, newMetaLen).fromOffset(oldMetaLen).execute();
+					}
+					if (currentHdLen < newHdLen) {
+						Fallocate.forChannel(hdFC, newHdLen).fromOffset(currentHdLen).execute();
+					}
 				}
 			}
 			storeFileOffsetReady = 1 + storeMaxEntries;


### PR DESCRIPTION
In some very specific circumstances you can have the DB grow while the metadata shrinks... according to bug7102 it happens in the real world... so this fixes it.