### PR TITLE
Turn CompressionRatioException into a checked exception to ensure tha…

### DIFF
--- a/src/freenet/keys/Key.java
+++ b/src/freenet/keys/Key.java
@@ -23,6 +23,7 @@ import freenet.support.Logger.LogLevel;
 import freenet.support.api.Bucket;
 import freenet.support.api.BucketFactory;
 import freenet.support.compress.CompressionOutputSizeException;
+import freenet.support.compress.CompressionRatioException;
 import freenet.support.compress.InvalidCompressionCodecException;
 import freenet.support.compress.Compressor.COMPRESSOR_TYPE;
 import freenet.support.io.ArrayBucket;
@@ -33,8 +34,8 @@ import freenet.support.io.BucketTools;
  * @author amphibian
  *
  * Base class for node keys.
- * 
- * WARNING: Changing non-transient members on classes that are Serializable can result in 
+ *
+ * WARNING: Changing non-transient members on classes that are Serializable can result in
  * restarting downloads or losing uploads.
  */
 public abstract class Key implements WritableToDataOutputStream, Comparable<Key> {
@@ -262,7 +263,7 @@ public abstract class Key implements WritableToDataOutputStream, Comparable<Key>
 						try {
 							compressedData = (ArrayBucket) comp.compress(
 									sourceData, new ArrayBucketFactory(), Long.MAX_VALUE, maxCompressedDataLength);
-						} catch (CompressionOutputSizeException e) {
+						} catch (CompressionOutputSizeException | CompressionRatioException e) {
 							continue;
 						}
 						if (compressedData.size() <= maxCompressedDataLength) {

--- a/src/freenet/support/compress/AbstractCompressor.java
+++ b/src/freenet/support/compress/AbstractCompressor.java
@@ -6,11 +6,13 @@ import java.io.OutputStream;
 
 abstract class AbstractCompressor implements Compressor {
 
-    public long compress(InputStream input, OutputStream output, long maxReadLength, long maxWriteLength) throws IOException {
+    public long compress(InputStream input, OutputStream output, long maxReadLength, long maxWriteLength)
+        throws IOException, CompressionRatioException {
         return compress(input, output, maxReadLength, maxWriteLength, Long.MAX_VALUE, 0);
     }
 
-    void checkCompressionEffect(long rawDataVolume, long compressedDataVolume, int minimumCompressionPercentage) {
+    void checkCompressionEffect(long rawDataVolume, long compressedDataVolume, int minimumCompressionPercentage)
+        throws CompressionRatioException {
         long compressionPercentage = 100 - compressedDataVolume * 100 / rawDataVolume;
         if (compressionPercentage < minimumCompressionPercentage) {
             throw new CompressionRatioException("Compression has no effect. Compression percentage: " + compressionPercentage);

--- a/src/freenet/support/compress/Bzip2Compressor.java
+++ b/src/freenet/support/compress/Bzip2Compressor.java
@@ -16,7 +16,6 @@ import org.apache.commons.compress.compressors.bzip2.BZip2CompressorOutputStream
 import freenet.support.Logger;
 import freenet.support.api.Bucket;
 import freenet.support.api.BucketFactory;
-import freenet.support.io.Closer;
 import freenet.support.io.CountedOutputStream;
 import freenet.support.io.HeaderStreams;
 
@@ -29,7 +28,7 @@ import freenet.support.io.HeaderStreams;
 */
 public class Bzip2Compressor extends AbstractCompressor {
 
-	final public static byte[] BZ_HEADER;
+	public static final byte[] BZ_HEADER;
 	static {
 		try {
 			BZ_HEADER = "BZ".getBytes("ISO-8859-1");
@@ -39,7 +38,8 @@ public class Bzip2Compressor extends AbstractCompressor {
 	}
 
 	@Override
-	public Bucket compress(Bucket data, BucketFactory bf, long maxReadLength, long maxWriteLength) throws IOException, CompressionOutputSizeException {
+	public Bucket compress(Bucket data, BucketFactory bf, long maxReadLength, long maxWriteLength)
+			throws IOException, CompressionOutputSizeException, CompressionRatioException {
 		Bucket output = bf.makeBucket(maxWriteLength);
 		try (InputStream is = data.getInputStream();
 			 OutputStream os = output.getOutputStream()) {
@@ -47,10 +47,11 @@ public class Bzip2Compressor extends AbstractCompressor {
 		}
 		return output;
 	}
-	
+
 	@Override
 	public long compress(InputStream is, OutputStream os, long maxReadLength, long maxWriteLength,
-						 long amountOfDataToCheckCompressionRatio, int minimumCompressionPercentage) throws IOException {
+						 long amountOfDataToCheckCompressionRatio, int minimumCompressionPercentage)
+			throws IOException, CompressionRatioException {
 		if(maxReadLength <= 0)
 			throw new IllegalArgumentException();
 		BZip2CompressorOutputStream bz2os = null;
@@ -90,10 +91,10 @@ public class Bzip2Compressor extends AbstractCompressor {
 				bz2os.flush();
 				bz2os.close();
 			}
-			
+
 		}
 	}
-	
+
 	@Override
 	public long decompress(InputStream is, OutputStream os, long maxLength, long maxCheckSizeBytes) throws IOException, CompressionOutputSizeException {
 		BZip2CompressorInputStream bz2is = new BZip2CompressorInputStream(HeaderStreams.augInput(BZ_HEADER, is));

--- a/src/freenet/support/compress/CompressionRatioException.java
+++ b/src/freenet/support/compress/CompressionRatioException.java
@@ -1,6 +1,6 @@
 package freenet.support.compress;
 
-public class CompressionRatioException extends RuntimeException {
+public class CompressionRatioException extends Exception {
 
     CompressionRatioException(String message) {
         super(message);

--- a/src/freenet/support/compress/CompressionRatioRuntimeException.java
+++ b/src/freenet/support/compress/CompressionRatioRuntimeException.java
@@ -1,0 +1,8 @@
+package freenet.support.compress;
+
+public class CompressionRatioRuntimeException extends RuntimeException {
+
+    CompressionRatioRuntimeException(CompressionRatioException cause) {
+        super(cause);
+    }
+}

--- a/src/freenet/support/compress/Compressor.java
+++ b/src/freenet/support/compress/Compressor.java
@@ -16,13 +16,13 @@ import freenet.support.api.BucketFactory;
  * This is for single-file compression (gzip, bzip2) as opposed to archives.
  */
 public interface Compressor {
-	
+
 	String DEFAULT_COMPRESSORDESCRIPTOR = null;
 
 	enum COMPRESSOR_TYPE implements Compressor {
-	    // WARNING: Changing non-transient members on classes that are Serializable can result in 
+	    // WARNING: Changing non-transient members on classes that are Serializable can result in
 	    // restarting downloads or losing uploads.
-	    
+
 		// Codecs will be tried in order: put the less resource consuming first
 		GZIP("GZIP", new GzipCompressor(), (short) 0),
 		BZIP2("BZIP2", new Bzip2Compressor(), (short) 1),
@@ -34,7 +34,7 @@ public interface Compressor {
 		public final short metadataID;
 
 		/** cached values(). Never modify or pass this array to outside code! */
-		private final static COMPRESSOR_TYPE[] values = values();
+		private static final COMPRESSOR_TYPE[] values = values();
 
 		COMPRESSOR_TYPE(String name, Compressor c, short metadataID) {
 			this.name = name;
@@ -91,7 +91,7 @@ public interface Compressor {
 		 * if the string is null/empty, it returns COMPRESSOR_TYPE.values() as default
 		 * @param compressordescriptor
 		 * @return
-		 * @throws InvalidCompressionCodecException 
+		 * @throws InvalidCompressionCodecException
 		 */
 		public static COMPRESSOR_TYPE[] getCompressorsArray(String compressordescriptor, boolean pre1254) throws InvalidCompressionCodecException {
 			COMPRESSOR_TYPE[] result = getCompressorsArrayNoDefault(compressordescriptor);
@@ -132,22 +132,25 @@ public interface Compressor {
 				}
 				result.add(ct);
 			}
-			return result.toArray(new COMPRESSOR_TYPE[result.size()]);
+			return result.toArray(new COMPRESSOR_TYPE[0]);
 		}
 
 		@Override
-		public Bucket compress(Bucket data, BucketFactory bf, long maxReadLength, long maxWriteLength) throws IOException, CompressionOutputSizeException {
+		public Bucket compress(Bucket data, BucketFactory bf, long maxReadLength, long maxWriteLength)
+				throws IOException, CompressionOutputSizeException, CompressionRatioException {
 			return compressor.compress(data, bf, maxReadLength, maxWriteLength);
 		}
 
 		@Override
-		public long compress(InputStream is, OutputStream os, long maxReadLength, long maxWriteLength) throws IOException, CompressionOutputSizeException {
+		public long compress(InputStream is, OutputStream os, long maxReadLength, long maxWriteLength)
+				throws IOException, CompressionOutputSizeException, CompressionRatioException {
 			return compressor.compress(is, os, maxReadLength, maxWriteLength);
 		}
 
 		@Override
 		public long compress(InputStream is, OutputStream os, long maxReadLength, long maxWriteLength,
-							 long amountOfDataToCheckCompressionRatio, int minimumCompressionPercentage) throws IOException {
+							 long amountOfDataToCheckCompressionRatio, int minimumCompressionPercentage)
+				throws IOException, CompressionRatioException {
 			return compressor.compress(is, os, maxReadLength, maxWriteLength, amountOfDataToCheckCompressionRatio, minimumCompressionPercentage);
 		}
 
@@ -175,9 +178,10 @@ public interface Compressor {
 	 * @param maxWriteLength The maximum number of bytes to write to the output bucket. If this is exceeded, throw a CompressionOutputSizeException.
 	 * @return The compressed data.
 	 * @throws IOException If an error occurs reading or writing data.
-	 * @throws CompressionOutputSizeException If the compressed data is larger than maxWriteLength. 
+	 * @throws CompressionOutputSizeException If the compressed data is larger than maxWriteLength.
 	 */
-	Bucket compress(Bucket data, BucketFactory bf, long maxReadLength, long maxWriteLength) throws IOException, CompressionOutputSizeException;
+	Bucket compress(Bucket data, BucketFactory bf, long maxReadLength, long maxWriteLength)
+			throws IOException, CompressionOutputSizeException, CompressionRatioException;
 
 	/**
 	 * Compress the data.
@@ -187,9 +191,10 @@ public interface Compressor {
 	 * @param maxWriteLength The maximum number of bytes to write to the output bucket. If this is exceeded, throw a CompressionOutputSizeException.
 	 * @return The compressed data.
 	 * @throws IOException If an error occurs reading or writing data.
-	 * @throws CompressionOutputSizeException If the compressed data is larger than maxWriteLength. 
+	 * @throws CompressionOutputSizeException If the compressed data is larger than maxWriteLength.
 	 */
-	long compress(InputStream input, OutputStream output, long maxReadLength, long maxWriteLength) throws IOException, CompressionOutputSizeException;
+	long compress(InputStream input, OutputStream output, long maxReadLength, long maxWriteLength)
+			throws IOException, CompressionOutputSizeException, CompressionRatioException;
 
 	/**
 	 * Compress the data (@see {@link #compress(InputStream, OutputStream, long, long)}) with checking of compression effect.
@@ -198,7 +203,8 @@ public interface Compressor {
 	 * @throws CompressionRatioException If the desired compression effect is not achieved.
 	 */
 	long compress(InputStream input, OutputStream output, long maxReadLength, long maxWriteLength,
-				  long amountOfDataToCheckCompressionRatio, int minimumCompressionPercentage) throws IOException;
+				  long amountOfDataToCheckCompressionRatio, int minimumCompressionPercentage)
+			throws IOException, CompressionRatioException;
 
 	/**
 	 * Decompress data.
@@ -217,8 +223,8 @@ public interface Compressor {
 	 * @param i Offset to start reading from.
 	 * @param j Number of bytes to read.
 	 * @param output Output buffer.
-	 * @throws DecompressException 
-	 * @throws CompressionOutputSizeException 
+	 * @throws DecompressException
+	 * @throws CompressionOutputSizeException
 	 * @returns The number of bytes actually written.
 	 */
 	int decompress(byte[] dbuf, int i, int j, byte[] output) throws CompressionOutputSizeException;

--- a/src/freenet/support/compress/GzipCompressor.java
+++ b/src/freenet/support/compress/GzipCompressor.java
@@ -17,7 +17,8 @@ import freenet.support.io.CountedOutputStream;
 public class GzipCompressor extends AbstractCompressor {
 
 	@Override
-	public Bucket compress(Bucket data, BucketFactory bf, long maxReadLength, long maxWriteLength) throws IOException, CompressionOutputSizeException {
+	public Bucket compress(Bucket data, BucketFactory bf, long maxReadLength, long maxWriteLength)
+			throws IOException, CompressionOutputSizeException, CompressionRatioException {
 		Bucket output = bf.makeBucket(maxWriteLength);
 		InputStream is = null;
 		OutputStream os = null;
@@ -34,10 +35,11 @@ public class GzipCompressor extends AbstractCompressor {
 		}
 		return output;
 	}
-	
+
 	@Override
 	public long compress(InputStream is, OutputStream os, long maxReadLength, long maxWriteLength,
-						 long amountOfDataToCheckCompressionRatio, int minimumCompressionPercentage) throws IOException {
+						 long amountOfDataToCheckCompressionRatio, int minimumCompressionPercentage)
+			throws IOException, CompressionRatioException {
 		if(maxReadLength < 0)
 			throw new IllegalArgumentException();
 		GZIPOutputStream gos = null;

--- a/test/freenet/support/compress/Bzip2CompressorTest.java
+++ b/test/freenet/support/compress/Bzip2CompressorTest.java
@@ -48,7 +48,7 @@ public class Bzip2CompressorTest extends TestCase {
 		assertEquals(bz2compressor, compressorZero);
 	}
 
-	public void testCompress() throws IOException {
+	public void testCompress() throws IOException, CompressionRatioException {
 
 		// do bzip2 compression
 		byte[] compressedData = doCompress(UNCOMPRESSED_DATA_1.getBytes());
@@ -74,7 +74,7 @@ public class Bzip2CompressorTest extends TestCase {
 		assertEquals(uncompressedString, UNCOMPRESSED_DATA_1);
 	}
 
-	public void testByteArrayDecompress() throws IOException {
+	public void testByteArrayDecompress() throws IOException, CompressionRatioException {
 
         // build 5k array
 		byte[] originalUncompressedData = new byte[5 * 1024];
@@ -98,7 +98,7 @@ public class Bzip2CompressorTest extends TestCase {
 		}
 	}
 
-	public void testCompressException() throws IOException {
+	public void testCompressException() throws IOException, CompressionRatioException {
 
 		byte[] uncompressedData = UNCOMPRESSED_DATA_1.getBytes();
 		Bucket inBucket = new ArrayBucket(uncompressedData);
@@ -115,7 +115,7 @@ public class Bzip2CompressorTest extends TestCase {
 
 	}
 
-	public void testDecompressException() throws IOException {
+	public void testDecompressException() throws IOException, CompressionRatioException {
 		// build 5k array
 		byte[] uncompressedData = new byte[5 * 1024];
 		for(int i = 0; i < uncompressedData.length; i++) {
@@ -166,7 +166,7 @@ public class Bzip2CompressorTest extends TestCase {
 		return outBuf;
 	}
 
-	private byte[] doCompress(byte[] uncompressedData) throws IOException {
+	private byte[] doCompress(byte[] uncompressedData) throws IOException, CompressionRatioException {
 		Bucket inBucket = new ArrayBucket(uncompressedData);
 		BucketFactory factory = new ArrayBucketFactory();
 		Bucket outBucket = null;

--- a/test/freenet/support/compress/GzipCompressorTest.java
+++ b/test/freenet/support/compress/GzipCompressorTest.java
@@ -59,7 +59,7 @@ public class GzipCompressorTest extends TestCase {
 		assertEquals(gzipCompressor, compressorZero);
 	}
 
-	public void testCompress() throws IOException {
+	public void testCompress() throws IOException, CompressionRatioException {
 
 		// do gzip compression
 		byte[] compressedData = doCompress(UNCOMPRESSED_DATA_1.getBytes());
@@ -85,7 +85,7 @@ public class GzipCompressorTest extends TestCase {
 		assertEquals(uncompressedString, UNCOMPRESSED_DATA_1);
 	}
 
-	public void testByteArrayDecompress() throws IOException {
+	public void testByteArrayDecompress() throws IOException, CompressionRatioException {
 		// build 5k array
 		byte[] originalUncompressedData = new byte[5 * 1024];
 		for(int i = 0; i < originalUncompressedData.length; i++) {
@@ -108,7 +108,7 @@ public class GzipCompressorTest extends TestCase {
 		}
 	}
 
-	public void testCompressException() throws IOException {
+	public void testCompressException() throws IOException, CompressionRatioException {
 
 		byte[] uncompressedData = UNCOMPRESSED_DATA_1.getBytes();
 		Bucket inBucket = new ArrayBucket(uncompressedData);
@@ -124,7 +124,7 @@ public class GzipCompressorTest extends TestCase {
 		//fail("did not throw expected CompressionOutputSizeException");
 	}
 
-	public void testDecompressException() throws IOException {
+	public void testDecompressException() throws IOException, CompressionRatioException {
 		// build 5k array
 		byte[] uncompressedData = new byte[5 * 1024];
 		for(int i = 0; i < uncompressedData.length; i++) {
@@ -173,7 +173,7 @@ public class GzipCompressorTest extends TestCase {
 		return outBuf;
 	}
 
-	private byte[] doCompress(byte[] uncompressedData) throws IOException {
+	private byte[] doCompress(byte[] uncompressedData) throws IOException, CompressionRatioException {
 		Bucket inBucket = new ArrayBucket(uncompressedData);
 		BucketFactory factory = new ArrayBucketFactory();
 		Bucket outBucket = null;

--- a/test/freenet/support/compress/NewLzmaCompressorTest.java
+++ b/test/freenet/support/compress/NewLzmaCompressorTest.java
@@ -62,7 +62,7 @@ public class NewLzmaCompressorTest extends TestCase {
 //		assertEquals(uncompressedString, UNCOMPRESSED_DATA_1);
 //	}
 //
-	public void testByteArrayDecompress() throws IOException {
+	public void testByteArrayDecompress() throws IOException, CompressionRatioException {
 
         // build 5k array
 		byte[] originalUncompressedData = new byte[5 * 1024];
@@ -86,7 +86,7 @@ public class NewLzmaCompressorTest extends TestCase {
 		}
 	}
 
-	public void testRandomByteArrayDecompress() throws IOException {
+	public void testRandomByteArrayDecompress() throws IOException, CompressionRatioException {
 
 		Random random = new Random(1234);
 
@@ -115,7 +115,7 @@ public class NewLzmaCompressorTest extends TestCase {
 		}
 	}
 
-	public void testCompressException() throws IOException {
+	public void testCompressException() throws IOException, CompressionRatioException {
 
 		byte[] uncompressedData = UNCOMPRESSED_DATA_1.getBytes();
 		Bucket inBucket = new ArrayBucket(uncompressedData);
@@ -131,7 +131,7 @@ public class NewLzmaCompressorTest extends TestCase {
 		//fail("did not throw expected CompressionOutputSizeException");
 	}
 
-	public void testDecompressException() throws IOException {
+	public void testDecompressException() throws IOException, CompressionRatioException {
 
 		// build 5k array
 		byte[] uncompressedData = new byte[5 * 1024];
@@ -165,7 +165,7 @@ public class NewLzmaCompressorTest extends TestCase {
 		//fail("did not throw expected CompressionOutputSizeException");
 	}
 
-	private byte[] doCompress(byte[] uncompressedData) throws IOException {
+	private byte[] doCompress(byte[] uncompressedData) throws IOException, CompressionRatioException {
 		Bucket inBucket = new ArrayBucket(uncompressedData);
 		BucketFactory factory = new ArrayBucketFactory();
 		Bucket outBucket = null;


### PR DESCRIPTION
…t it gets handled wherever it could appear.

Handle it in Key.java.

This extends upon https://github.com/freenet/fred/pull/662 — which kept to the style that was there before.

Using an exception for control flow isn’t nice, but with a checked exception we can at least be sure that it does not pollute other code.

It is caught in the InsertCompressor and in Key (Key was missing).