### PR TITLE
Fix config option with dimension (duration)

### DIFF
--- a/src/freenet/config/IntOption.java
+++ b/src/freenet/config/IntOption.java
@@ -13,7 +13,7 @@ public class IntOption extends Option<Integer> {
 
 	public IntOption(SubConfig conf, String optionName, String defaultValueString, int sortOrder, boolean expert,
 					 boolean forceWrite, String shortDesc, String longDesc, IntCallback cb, Dimension dimension) {
-		this(conf, optionName, Fields.parseInt(defaultValueString, dimension), sortOrder, expert, forceWrite,
+		this(conf, optionName, parseString(defaultValueString, dimension), sortOrder, expert, forceWrite,
 				shortDesc, longDesc, cb, dimension);
 	}
 
@@ -47,13 +47,20 @@ public class IntOption extends Option<Integer> {
 
 	@Override
 	protected Integer parseString(String val) throws InvalidConfigValueException {
-		Integer x;
 		try {
-			x = Fields.parseInt(val, dimension);
+			return parseString(val, dimension);
 		} catch (NumberFormatException e) {
 			throw new InvalidConfigValueException(l10n("parseError", "val", val));
 		}
-		return x;
+	}
+
+	// can be two string representations: #toDisplayString(Integer) and #toString(Integer)
+	private static Integer parseString(String val, Dimension dimension) throws NumberFormatException {
+		try {
+			return Fields.parseInt(val, dimension);
+		} catch (NumberFormatException e) {
+			return Fields.parseInt(val, Dimension.NOT);
+		}
 	}
 
 	private String l10n(String key, String pattern, String value) {

--- a/src/freenet/support/Fields.java
+++ b/src/freenet/support/Fields.java
@@ -721,15 +721,11 @@ public abstract class Fields {
 			case SIZE:
 				return parseInt(s);
 			case DURATION:
-				try {
-					long durationInMillis = TimeUtil.toMillis(s);
-					if ((int) durationInMillis == durationInMillis) {
-						return (int) durationInMillis;
-					}
-					throw new ArithmeticException("integer overflow");
-				} catch (NumberFormatException e) {
-					return parseInt(s);
+				long durationInMillis = TimeUtil.toMillis(s);
+				if ((int) durationInMillis == durationInMillis) {
+					return (int) durationInMillis;
 				}
+				throw new ArithmeticException("integer overflow");
 		}
 		throw new AssertionError("Unknown dimension " + dimension);
 	}

--- a/src/freenet/support/Fields.java
+++ b/src/freenet/support/Fields.java
@@ -721,10 +721,15 @@ public abstract class Fields {
 			case SIZE:
 				return parseInt(s);
 			case DURATION:
-				long durationInMillis = TimeUtil.toMillis(s);
-				if ((int) durationInMillis == durationInMillis)
-					return (int) durationInMillis;
-				throw new ArithmeticException("integer overflow");
+				try {
+					long durationInMillis = TimeUtil.toMillis(s);
+					if ((int) durationInMillis == durationInMillis) {
+						return (int) durationInMillis;
+					}
+					throw new ArithmeticException("integer overflow");
+				} catch (NumberFormatException e) {
+					return parseInt(s);
+				}
 		}
 		throw new AssertionError("Unknown dimension " + dimension);
 	}

--- a/test/freenet/config/IntOptionTest.java
+++ b/test/freenet/config/IntOptionTest.java
@@ -1,0 +1,28 @@
+package freenet.config;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class IntOptionTest {
+
+    @Test
+    public void twoStringRepresentationsTest() {
+        IntOption intOption = new IntOption(null, "test",
+                "5m",
+                0, false, false, "test", "test", new NullIntCallback(),
+                Dimension.DURATION);
+
+        IntOption sameIntOption = new IntOption(null, "test",
+                intOption.toString(intOption.currentValue),
+                0, false, false, "test", "test", new NullIntCallback(),
+                Dimension.DURATION);
+        assertEquals(intOption.currentValue, sameIntOption.currentValue);
+
+        sameIntOption = new IntOption(null, "test",
+                intOption.toDisplayString(intOption.currentValue),
+                0, false, false, "test", "test", new NullIntCallback(),
+                Dimension.DURATION);
+        assertEquals(intOption.currentValue, sameIntOption.currentValue);
+    }
+}

--- a/test/freenet/support/FieldsDurationTest.java
+++ b/test/freenet/support/FieldsDurationTest.java
@@ -1,36 +1,40 @@
 package freenet.support;
 
 import freenet.config.Dimension;
-import junit.framework.TestCase;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
 
 /**
  * Tests parsing of duration value.
  */
-public class FieldsDurationTest extends TestCase {
+public class FieldsDurationTest {
 
     /**
      * Duration input with and without various d|h|min|s.
+     * With correct result in millis
      */
-    private static final String[] durations = { "2d", "3h", "20m", "56s", "1h30m" };
+    private static final Map<String, Integer> durations = new HashMap<String, Integer>() {{
+        put("2d", 172_800_000);
+        put("3h", 10_800_000);
+        put("20m", 1_200_000);
+        put("56s", 56_000);
+        put("1h30m", 5_400_000);
+    }};
 
-    /**
-     * Correct result in millis matched by index with input.
-     */
-    private static final int[] durationsInMillis = { 172800000, 10800000, 1200000, 56000, 5400000 };
-
+    @Test
     public void test() {
-        assert durations.length == durationsInMillis.length;
+        durations.forEach((duration, millis) -> {
+            Integer parsed = Fields.parseInt(Fields.trimPerSecond(duration), Dimension.DURATION);
+            assertEquals(String.format("Input: %s; Intended: %d; Parsed: %d", duration, millis, parsed),
+                    millis, parsed);
 
-        int parsed;
-        String packed;
-        for (int i = 0; i < durations.length; i++) {
-            parsed = Fields.parseInt(Fields.trimPerSecond(durations[i]), Dimension.DURATION);
-            System.out.format("Input: %s\tParsed: %d\tIntended: %d\n", durations[i], parsed, durationsInMillis[i]);
-            assertEquals(parsed, durationsInMillis[i]);
-
-            packed = Fields.intToString(durationsInMillis[i], Dimension.DURATION);
-            System.out.format("Input: %d\tPacked: %s\tIntended: %s\n", durationsInMillis[i], packed, durations[i]);
-            assertEquals(packed, durations[i]);
-        }
+            String packed = Fields.intToString(millis, Dimension.DURATION);
+            assertEquals(String.format("Input: %d; Intended: %s; Packed: %s", millis, duration, packed),
+                    duration, packed);
+        });
     }
 }


### PR DESCRIPTION
I noticed a bug that I added. This is a fix, but not ideal. Therefore, I will be glad of any help.
Related points:
- Two toString
  - config.IntOption#toDisplayString
  - config.IntOption#toString
- Single toInt - config.IntOption#parseString
- ConfigToadlet#L329