### PR TITLE
Fix error on compressing due to a missing implementation in OldLZMA

### DIFF
--- a/src/freenet/client/async/ClientPutState.java
+++ b/src/freenet/client/async/ClientPutState.java
@@ -3,15 +3,17 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.client.async;
 
+import java.io.Serializable;
+
 import freenet.client.InsertException;
 import freenet.support.io.ResumeFailedException;
 
 /**
  * ClientPutState
- * 
+ *
  * Represents a state in the insert process.
  */
-public interface ClientPutState {
+public interface ClientPutState extends Serializable {
 
 	/** Get the BaseClientPutter responsible for this request state. */
 	public abstract BaseClientPutter getParent();
@@ -21,17 +23,17 @@ public interface ClientPutState {
 
 	/** Schedule the request. */
 	public abstract void schedule(ClientContext context) throws InsertException;
-	
+
 	/**
 	 * Get the token, an object which is passed around with the insert and may be
 	 * used by callers.
 	 */
 	public Object getToken();
-	
-    /** Called on restarting the node for a persistent request. The request must re-schedule 
+
+    /** Called on restarting the node for a persistent request. The request must re-schedule
      * itself. Caller must ensure that it is safe to call this method more than once, as we recurse
      * through the graph of dependencies.
-     * @throws InsertException 
+     * @throws InsertException
      * @throws ResumeFailedException */
     public void onResume(ClientContext context) throws InsertException, ResumeFailedException;
 

--- a/src/freenet/clients/http/bookmark/BookmarkManager.java
+++ b/src/freenet/clients/http/bookmark/BookmarkManager.java
@@ -410,35 +410,39 @@ public class BookmarkManager implements RequestClient {
 			if(!isRoot)
 				putPaths(prefix + category.name + '/', category);
 
-			try {
-				int nbBookmarks = sfs.getInt(BookmarkItem.NAME);
-				int nbCategories = sfs.getInt(BookmarkCategory.NAME);
-
-				for(int i = 0; i < nbBookmarks; i++) {
-					SimpleFieldSet subset = sfs.getSubset(BookmarkItem.NAME + i);
-					try {
-						BookmarkItem item = new BookmarkItem(subset, this, node.alerts);
-						String name = (isRoot ? "" : prefix + category.name) + '/' + item.name;
-						putPaths(name, item);
-						category.addBookmark(item);
-						item.registerUserAlert();
-						subscribeToUSK(item);
-					} catch(MalformedURLException e) {
-						throw new FSParseException(e);
-					}
-				}
-
-				for(int i = 0; i < nbCategories; i++) {
-					SimpleFieldSet subset = sfs.getSubset(BookmarkCategory.NAME + i);
-					BookmarkCategory currentCategory = new BookmarkCategory(subset);
-					category.addBookmark(currentCategory);
-					String name = (isRoot ? "/" : (prefix + category.name + '/'));
-					_innerReadBookmarks(name, currentCategory, subset.getSubset("Content"));
-				}
-
-			} catch(FSParseException e) {
-				Logger.error(this, "Error parsing the bookmarks file!", e);
+			if (sfs == null) {
 				hasBeenParsedWithoutAnyProblem = false;
+			} else {
+				try {
+					int nbBookmarks = sfs.getInt(BookmarkItem.NAME);
+					int nbCategories = sfs.getInt(BookmarkCategory.NAME);
+
+					for (int i = 0; i < nbBookmarks; i++) {
+						SimpleFieldSet subset = sfs.getSubset(BookmarkItem.NAME + i);
+						try {
+							BookmarkItem item = new BookmarkItem(subset, this, node.alerts);
+							String name = (isRoot ? "" : prefix + category.name) + '/' + item.name;
+							putPaths(name, item);
+							category.addBookmark(item);
+							item.registerUserAlert();
+							subscribeToUSK(item);
+						} catch (MalformedURLException e) {
+							throw new FSParseException(e);
+						}
+					}
+
+					for (int i = 0; i < nbCategories; i++) {
+						SimpleFieldSet subset = sfs.getSubset(BookmarkCategory.NAME + i);
+						BookmarkCategory currentCategory = new BookmarkCategory(subset);
+						category.addBookmark(currentCategory);
+						String name = (isRoot ? "/" : (prefix + category.name + '/'));
+						_innerReadBookmarks(name, currentCategory, subset.getSubset("Content"));
+					}
+
+				} catch (FSParseException e) {
+					Logger.error(this, "Error parsing the bookmarks file!", e);
+					hasBeenParsedWithoutAnyProblem = false;
+				}
 			}
 
 		}

--- a/src/freenet/support/compress/Bzip2Compressor.java
+++ b/src/freenet/support/compress/Bzip2Compressor.java
@@ -52,8 +52,13 @@ public class Bzip2Compressor extends AbstractCompressor {
 	public long compress(InputStream is, OutputStream os, long maxReadLength, long maxWriteLength,
 						 long amountOfDataToCheckCompressionRatio, int minimumCompressionPercentage)
 			throws IOException, CompressionRatioException {
-		if(maxReadLength <= 0)
+		if (maxReadLength <= 0) {
 			throw new IllegalArgumentException();
+		}
+		if (amountOfDataToCheckCompressionRatio == Long.MAX_VALUE && minimumCompressionPercentage == 0) {
+			return compress(is, os, maxReadLength, maxWriteLength);
+		}
+
 		BZip2CompressorOutputStream bz2os = null;
 		try {
 			CountedOutputStream cos = new CountedOutputStream(os);

--- a/src/freenet/support/compress/GzipCompressor.java
+++ b/src/freenet/support/compress/GzipCompressor.java
@@ -40,9 +40,13 @@ public class GzipCompressor extends AbstractCompressor {
 	public long compress(InputStream is, OutputStream os, long maxReadLength, long maxWriteLength,
 						 long amountOfDataToCheckCompressionRatio, int minimumCompressionPercentage)
 			throws IOException, CompressionRatioException {
-		if(maxReadLength < 0)
-			throw new IllegalArgumentException();
-		GZIPOutputStream gos = null;
+		if(maxReadLength < 0) {
+      throw new IllegalArgumentException();
+    }
+    if (amountOfDataToCheckCompressionRatio == Long.MAX_VALUE && minimumCompressionPercentage == 0) {
+      return compress(is, os, maxReadLength, maxWriteLength);
+    }
+    GZIPOutputStream gos = null;
 		CountedOutputStream cos = new CountedOutputStream(os);
 		try {
 			gos = new GZIPOutputStream(cos);

--- a/src/freenet/support/compress/NewLZMACompressor.java
+++ b/src/freenet/support/compress/NewLZMACompressor.java
@@ -66,9 +66,9 @@ public class NewLZMACompressor extends AbstractCompressor {
 	public long compress(InputStream is, OutputStream os, long maxReadLength, long maxWriteLength,
 						 final long amountOfDataToCheckCompressionRatio, final int minimumCompressionPercentage)
 			throws IOException, CompressionRatioException {
-	  if (amountOfDataToCheckCompressionRatio == Long.MAX_VALUE && minimumCompressionPercentage == 0) {
-	    return compress(is, os, maxReadLength, maxWriteLength);
-    }
+		if (amountOfDataToCheckCompressionRatio == Long.MAX_VALUE && minimumCompressionPercentage == 0) {
+		  return compress(is, os, maxReadLength, maxWriteLength);
+		}
 		CountedInputStream cis = null;
 		CountedOutputStream cos = null;
 		cis = new CountedInputStream(is);

--- a/src/freenet/support/compress/NewLZMACompressor.java
+++ b/src/freenet/support/compress/NewLZMACompressor.java
@@ -66,6 +66,9 @@ public class NewLZMACompressor extends AbstractCompressor {
 	public long compress(InputStream is, OutputStream os, long maxReadLength, long maxWriteLength,
 						 final long amountOfDataToCheckCompressionRatio, final int minimumCompressionPercentage)
 			throws IOException, CompressionRatioException {
+	  if (amountOfDataToCheckCompressionRatio == Long.MAX_VALUE && minimumCompressionPercentage == 0) {
+	    return compress(is, os, maxReadLength, maxWriteLength);
+    }
 		CountedInputStream cis = null;
 		CountedOutputStream cos = null;
 		cis = new CountedInputStream(is);


### PR DESCRIPTION
TODO: 

    <ArneBab> if the compressors to try are given, it will try them
    <ArneBab> so fcpupload still sets LZMA as an option to try
    --> Ai9zO5AP (~BQcdf9eiZ@41.140.229.121) hat #freenet betreten
    <ArneBab> and any other third party tool which tried to insert with LZMA would fail, too
    <nextgens> build1254 is roughly a decade old, if you ask me it qualifies and that code should be dropped
    <nextgens> we should just make it clear that we do not support inserts with LZMA anymore
    <ArneBab> I agree, it just shouldn’t break the insert
    <nextgens> it absolutely should
    <ArneBab> at least not without a good warning
    <nextgens> we should let people craft a fblob we would insert
    <nextgens> but we should reject the insert with LZMA in the codec list
    <ArneBab> currently freenet says "disk full error"
    <nextgens> (or ignore it)
    <ArneBab> we should ignore the LZMA, if there are other codecs in the list
    <nextgens> I'm okay with that
    <nextgens> ArneBab> and please take that opportunity to simplify/drop the preXXXX flag
    <nextgens> possibly in a different commit, to make review easier :)
    <ArneBab> I’ll look into that this evening
    <ArneBab> thank you for the review!
