### PR TITLE
Travis without oracle but with more openjdk tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,12 @@ before_install: echo -e "org.gradle.parallel = true\norg.gradle.jvmargs=-Xms256m
 install: "./gradlew jar"
 
 jdk:
-  - oraclejdk8
-  - oraclejdk9
   - openjdk8
+  - openjdk9
+  - openjdk10
+  - openjdk11
+  - openjdk12
+  - openjdk13
 
 before_deploy:
   - "./gradlew javadoc ; true"


### PR DESCRIPTION
Oracle JDK tests have been failing for some time. This pull request removes them and adds openjdk 9-13.