### PR TITLE
Bugfix/0007132 freenet uri accepts invalid usk keys

### DIFF
--- a/src/freenet/keys/FreenetURI.java
+++ b/src/freenet/keys/FreenetURI.java
@@ -459,6 +459,9 @@ public class FreenetURI implements Cloneable, Comparable<FreenetURI>, Serializab
 				if(routingKey.length != 32 && keyType.equals("CHK"))
 					throw new MalformedURLException("Bad URI: Routing key should be 32 bytes long");
 			} else {
+				if (isUSK || (isSSK && docName != null)) {
+					throw new MalformedURLException("Bad URI: Routing key missing");
+				}
 				routingKey = cryptoKey = extra = null;
 				return;
 			}

--- a/test/freenet/keys/FreenetURITest.java
+++ b/test/freenet/keys/FreenetURITest.java
@@ -1,15 +1,19 @@
 package freenet.keys;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
 import java.net.MalformedURLException;
 
-import junit.framework.TestCase;
+import org.junit.Test;
 
-public class FreenetURITest extends TestCase {
+public class FreenetURITest {
 	// Some URI for wAnnA? index
 	private static final String WANNA_USK_1 = "USK@5hH~39FtjA7A9~VXWtBKI~prUDTuJZURudDG0xFn3KA,GDgRGt5f6xqbmo-WraQtU54x4H~871Sho9Hz6hC-0RA,AQACAAE/Search/17/index_d51.xml";
 	private static final String WANNA_SSK_1 = "SSK@5hH~39FtjA7A9~VXWtBKI~prUDTuJZURudDG0xFn3KA,GDgRGt5f6xqbmo-WraQtU54x4H~871Sho9Hz6hC-0RA,AQACAAE/Search-17/index_d51.xml";
 	private static final String WANNA_CHK_1 = "CHK@DTCDUmnkKFlrJi9UlDDVqXlktsIXvAJ~ZTseyx5cAZs,PmA2rLgWZKVyMXxSn-ZihSskPYDTY19uhrMwqDV-~Sk,AAICAAI/index_d51.xml";
 
+	@Test
 	public void testSskForUSK() throws MalformedURLException {
 		FreenetURI uri1 = new FreenetURI(WANNA_USK_1);
 		FreenetURI uri2 = new FreenetURI(WANNA_SSK_1);
@@ -59,7 +63,8 @@ public class FreenetURITest extends TestCase {
 			// pass
 		}
 	}
-	
+
+	@Test
 	public void testDeriveRequestURIFromInsertURI() throws MalformedURLException {
 		final FreenetURI chk = new FreenetURI("CHK@DTCDUmnkKFlrJi9UlDDVqXlktsIXvAJ~ZTseyx5cAZs,PmA2rLgWZKVyMXxSn-ZihSskPYDTY19uhrMwqDV-~Sk,AAICAAI/index_d51.xml");
 		assertEquals(chk, chk.deriveRequestURIFromInsertURI());

--- a/test/freenet/keys/FreenetURITest.java
+++ b/test/freenet/keys/FreenetURITest.java
@@ -105,4 +105,30 @@ public class FreenetURITest {
             // Success
         }
 	}
+
+	@Test
+	public void brokenUskLinkResultsInMalformedUrlException() {
+		try {
+			new FreenetURI("USK@/broken/0");
+			fail("USK@/broken/0 is not a valid USK.");
+		} catch (MalformedURLException e) {
+			// Works.
+		}
+	}
+
+	@Test
+	public void brokenSskLinkResultsInMalformedUrlException() {
+		try {
+			new FreenetURI("SSK@/broken-0");
+			fail("SSK@/broken-0 is not a valid SSK.");
+		} catch (MalformedURLException e) {
+			// Works.
+		}
+	}
+
+	@Test
+	public void sskCanBeCreatedWithoutRoutingKey() throws MalformedURLException {
+		new FreenetURI("SSK@");
+	}
+
 }


### PR DESCRIPTION
https://freenet.mantishub.io/view.php?id=7132

USKs like “USK@/broken/0” are accepted by FreenetURI’s constructor but shouldn’t.