### PR TITLE
Fix peer options box

### DIFF
--- a/src/freenet/clients/http/ConnectionsToadlet.java
+++ b/src/freenet/clients/http/ConnectionsToadlet.java
@@ -903,8 +903,8 @@ public abstract class ConnectionsToadlet extends Toadlet {
 		peerAdditionForm.addChild("input", new String[] { "id", "type", "name" }, new String[] { "reffile", "file", "reffile" });
 		peerAdditionForm.addChild("br");
 		if(!isOpennet) {
-			peerAdditionForm.addChild(new PeerTrustInputForAddPeerBoxNode(l10n("")));
-			peerAdditionForm.addChild(new PeerVisibilityInputForAddPeerBoxNode(l10n("")));
+			peerAdditionForm.addChild(new PeerTrustInputForAddPeerBoxNode("DarknetConnectionsToadlet."));
+			peerAdditionForm.addChild(new PeerVisibilityInputForAddPeerBoxNode("DarknetConnectionsToadlet."));
 		}
 		
 		if(!isOpennet) {

--- a/src/freenet/clients/http/ConnectionsToadlet.java
+++ b/src/freenet/clients/http/ConnectionsToadlet.java
@@ -903,8 +903,8 @@ public abstract class ConnectionsToadlet extends Toadlet {
 		peerAdditionForm.addChild("input", new String[] { "id", "type", "name" }, new String[] { "reffile", "file", "reffile" });
 		peerAdditionForm.addChild("br");
 		if(!isOpennet) {
-			peerAdditionForm.addChild(new PeerTrustInputForAddPeerBoxNode("DarknetConnectionsToadlet."));
-			peerAdditionForm.addChild(new PeerVisibilityInputForAddPeerBoxNode("DarknetConnectionsToadlet."));
+			peerAdditionForm.addChild(new PeerTrustInputForAddPeerBoxNode());
+			peerAdditionForm.addChild(new PeerVisibilityInputForAddPeerBoxNode());
 		}
 		
 		if(!isOpennet) {

--- a/src/freenet/clients/http/complexhtmlnodes/PeerTrustInputForAddPeerBoxNode.java
+++ b/src/freenet/clients/http/complexhtmlnodes/PeerTrustInputForAddPeerBoxNode.java
@@ -6,12 +6,12 @@ import freenet.support.HTMLNode;
 
 public class PeerTrustInputForAddPeerBoxNode extends HTMLNode {
 
-    public PeerTrustInputForAddPeerBoxNode(String l10nPrefix) {
+    public PeerTrustInputForAddPeerBoxNode() {
         super("div");
 
-        this.addChild("b", l10n(l10nPrefix + "peerTrustTitle"));
+        this.addChild("b", l10n("DarknetConnectionsToadlet.peerTrustTitle"));
         this.addChild("#", " ");
-        this.addChild("#", l10n(l10nPrefix + "peerTrustIntroduction"));
+        this.addChild("#", l10n("DarknetConnectionsToadlet.peerTrustIntroduction"));
         for (DarknetPeerNode.FRIEND_TRUST trust : DarknetPeerNode.FRIEND_TRUST.valuesBackwards()) { // FIXME reverse order
             HTMLNode input = this.addChild("br")
                     .addChild("input",
@@ -19,9 +19,9 @@ public class PeerTrustInputForAddPeerBoxNode extends HTMLNode {
                             new String[] { "radio", "trust", trust.name() });
             if (trust.isDefaultValue())
                 input.addAttribute("checked", "checked");
-            input.addChild("b", l10n(l10nPrefix + "peerTrust."+trust.name()));
+            input.addChild("b", l10n("DarknetConnectionsToadlet.peerTrust." + trust.name()));
             input.addChild("#", ": ");
-            input.addChild("#", l10n(l10nPrefix + "peerTrustExplain."+trust.name()));
+            input.addChild("#", l10n("DarknetConnectionsToadlet.peerTrustExplain." + trust.name()));
         }
         this.addChild("br");
     }

--- a/src/freenet/clients/http/complexhtmlnodes/PeerVisibilityInputForAddPeerBoxNode.java
+++ b/src/freenet/clients/http/complexhtmlnodes/PeerVisibilityInputForAddPeerBoxNode.java
@@ -6,12 +6,12 @@ import freenet.support.HTMLNode;
 
 public class PeerVisibilityInputForAddPeerBoxNode extends HTMLNode {
 
-    public PeerVisibilityInputForAddPeerBoxNode(String l10nPrefix) {
+    public PeerVisibilityInputForAddPeerBoxNode() {
         super("div");
 
-        this.addChild("b", l10n(l10nPrefix + "peerVisibilityTitle"));
+        this.addChild("b", l10n("DarknetConnectionsToadlet.peerVisibilityTitle"));
         this.addChild("#", " ");
-        this.addChild("#", l10n(l10nPrefix + "peerVisibilityIntroduction"));
+        this.addChild("#", l10n("DarknetConnectionsToadlet.peerVisibilityIntroduction"));
         for (DarknetPeerNode.FRIEND_VISIBILITY visibility : DarknetPeerNode.FRIEND_VISIBILITY.values()) { // FIXME reverse order
             HTMLNode input = this.addChild("br")
                     .addChild("input",
@@ -19,9 +19,9 @@ public class PeerVisibilityInputForAddPeerBoxNode extends HTMLNode {
                             new String[] { "radio", "visibility", visibility.name() });
             if (visibility.isDefaultValue())
                 input.addAttribute("checked", "checked");
-            input.addChild("b", l10n(l10nPrefix + "peerVisibility."+visibility.name()));
+            input.addChild("b", l10n("DarknetConnectionsToadlet.peerVisibility." + visibility.name()));
             input.addChild("#", ": ");
-            input.addChild("#", l10n(l10nPrefix + "peerVisibilityExplain."+visibility.name()));
+            input.addChild("#", l10n("DarknetConnectionsToadlet.peerVisibilityExplain." + visibility.name()));
         }
         this.addChild("br");
     }

--- a/src/freenet/node/useralerts/PeersOffersUserAlert.java
+++ b/src/freenet/node/useralerts/PeersOffersUserAlert.java
@@ -60,8 +60,8 @@ public class PeersOffersUserAlert extends AbstractUserAlert {
                 new String[] {"type", "name", "value"},
                 new String[] {"hidden", "peers-offers-files", "true"});
 
-        form.addChild(new PeerTrustInputForAddPeerBoxNode("DarknetConnectionsToadlet."));
-        form.addChild(new PeerVisibilityInputForAddPeerBoxNode("DarknetConnectionsToadlet."));
+        form.addChild(new PeerTrustInputForAddPeerBoxNode());
+        form.addChild(new PeerVisibilityInputForAddPeerBoxNode());
 
         form.addChild("input",
                         new String[] {"type", "name", "value"},


### PR DESCRIPTION
The incorrect l10n prefix was used to render the boxes, and it’s not necessary anyway, as trust and visibility only ever apply to darknet peers, anyway, so the prefix was removed entirely.