### PR TITLE
Hand in request client directly

### DIFF
--- a/src/freenet/client/async/BaseClientGetter.java
+++ b/src/freenet/client/async/BaseClientGetter.java
@@ -3,6 +3,7 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.client.async;
 
+import freenet.node.RequestClient;
 import java.io.Serializable;
 
 public abstract class BaseClientGetter extends ClientRequester implements
@@ -10,8 +11,8 @@ public abstract class BaseClientGetter extends ClientRequester implements
 	
     private static final long serialVersionUID = 1L;
 
-    protected BaseClientGetter(short priorityClass, ClientBaseCallback cb) {
-		super(priorityClass, cb);
+    protected BaseClientGetter(short priorityClass, RequestClient requestClient) {
+		super(priorityClass, requestClient);
 	}
 	
 	/** Required because we implement {@link Serializable}. */

--- a/src/freenet/client/async/BaseClientPutter.java
+++ b/src/freenet/client/async/BaseClientPutter.java
@@ -3,6 +3,7 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.client.async;
 
+import freenet.node.RequestClient;
 import java.io.Serializable;
 
 /** Base class for inserts, including site inserts, at the level of a ClientRequester.
@@ -18,8 +19,8 @@ public abstract class BaseClientPutter extends ClientRequester {
 	protected BaseClientPutter() {
 	}
 
-	protected BaseClientPutter(short priorityClass, ClientBaseCallback cb) {
-		super(priorityClass, cb);
+	protected BaseClientPutter(short priorityClass, RequestClient requestClient) {
+		super(priorityClass, requestClient);
 	}
 
 	public void dump() {

--- a/src/freenet/client/async/BaseManifestPutter.java
+++ b/src/freenet/client/async/BaseManifestPutter.java
@@ -361,7 +361,7 @@ public abstract class BaseManifestPutter extends ManifestPutter {
 
         // run me
 		private PutHandler(final BaseManifestPutter bmp, PutHandler parent, String name, ClientMetadata cm, HashSet<PutHandler> runningMap) {
-			super(bmp.priorityClass, bmp.cb);
+			super(bmp.priorityClass, bmp.cb.getRequestClient());
 			this.persistent = bmp.persistent();
 			this.cm = cm;
 			this.itemName = name;
@@ -397,7 +397,7 @@ public abstract class BaseManifestPutter extends ManifestPutter {
 
 		// place holder, don't run it
 		private PutHandler(final BaseManifestPutter bmp, PutHandler parent, String name, String nameInArchive, Metadata md, ClientMetadata cm) {
-			super(bmp.priorityClass, bmp.cb);
+			super(bmp.priorityClass, bmp.cb.getRequestClient());
 			this.persistent = bmp.persistent();
 			this.cm = cm;
 			this.itemName = name;
@@ -769,7 +769,7 @@ public abstract class BaseManifestPutter extends ManifestPutter {
 	public BaseManifestPutter(ClientPutCallback cb,
 			HashMap<String, Object> manifestElements, short prioClass, FreenetURI target, String defaultName,
 			InsertContext ctx, boolean randomiseCryptoKeys, byte [] forceCryptoKey, ClientContext context) throws TooManyFilesInsertException {
-		super(prioClass, cb);
+		super(prioClass, cb.getRequestClient());
 		this.targetURI = target;
 		this.cb = cb;
 		this.ctx = ctx;

--- a/src/freenet/client/async/ClientGetter.java
+++ b/src/freenet/client/async/ClientGetter.java
@@ -154,7 +154,7 @@ implements WantsCooldownCallback, FileGetCompletionCallback, Serializable {
 	 */
 	public ClientGetter(ClientGetCallback client,
 			FreenetURI uri, FetchContext ctx, short priorityClass, Bucket returnBucket, BinaryBlobWriter binaryBlobWriter, boolean dontFinalizeBlobWriter, Bucket initialMetadata, String forceCompatibleExtension) {
-		super(priorityClass, client);
+		super(priorityClass, client.getRequestClient());
 		this.clientCallback = client;
 		this.returnBucket = returnBucket;
 		this.uri = uri;

--- a/src/freenet/client/async/ClientPutter.java
+++ b/src/freenet/client/async/ClientPutter.java
@@ -92,7 +92,7 @@ public class ClientPutter extends BaseClientPutter implements PutCompletionCallb
 			short priorityClass,
 			boolean isMetadata, String targetFilename, boolean binaryBlob, ClientContext context, byte[] overrideSplitfileCrypto,
 			long metadataThreshold) {
-		super(priorityClass, client);
+		super(priorityClass, client.getRequestClient());
 		this.cm = cm;
 		this.isMetadata = isMetadata;
 		this.client = client;

--- a/src/freenet/client/async/ClientRequester.java
+++ b/src/freenet/client/async/ClientRequester.java
@@ -65,9 +65,9 @@ public abstract class ClientRequester implements Serializable, ClientRequestSche
 		hashCode = 0;
 	}
 
-	protected ClientRequester(short priorityClass, ClientBaseCallback cb) {
+	protected ClientRequester(short priorityClass, RequestClient requestClient) {
 		this.priorityClass = priorityClass;
-		this.client = cb.getRequestClient();
+		this.client = requestClient;
 		this.realTimeFlag = client.realTimeFlag();
 		if(client == null)
 			throw new NullPointerException();

--- a/src/freenet/client/async/ManifestPutter.java
+++ b/src/freenet/client/async/ManifestPutter.java
@@ -3,6 +3,7 @@
  * http://www.gnu.org/ for further details of the GPL. */
 package freenet.client.async;
 
+import freenet.node.RequestClient;
 import java.io.Serializable;
 
 import freenet.client.InsertException;
@@ -15,8 +16,8 @@ public abstract class ManifestPutter extends BaseClientPutter {
 	protected ManifestPutter() {
 	}
 
-	protected ManifestPutter(short priorityClass, ClientBaseCallback cb) {
-		super(priorityClass, cb);
+	protected ManifestPutter(short priorityClass, RequestClient requestClient) {
+		super(priorityClass, requestClient);
 	}
 
 	public abstract int countFiles();

--- a/src/freenet/client/async/SimpleHealingQueue.java
+++ b/src/freenet/client/async/SimpleHealingQueue.java
@@ -39,21 +39,8 @@ public class SimpleHealingQueue extends BaseClientPutter implements HealingQueue
 
 	static final RequestClient REQUEST_CLIENT = new RequestClientBuilder().build();
 
-    static final ClientBaseCallback BOGUS_CALLBACK = 
-        new ClientBaseCallback() {
-            @Override
-            public void onResume(ClientContext context) {
-                throw new IllegalStateException(); // Impossible.
-            }
-
-            @Override
-            public RequestClient getRequestClient() {
-                return REQUEST_CLIENT;
-            }
-    };
-
 	public SimpleHealingQueue(InsertContext context, short prio, int maxRunning) {
-		super(prio, BOGUS_CALLBACK);
+		super(prio, REQUEST_CLIENT);
 		this.ctx = context;
 		this.runningInserters = new HashMap<Bucket, SingleBlockInserter>();
 		this.maxRunning = maxRunning;

--- a/src/freenet/client/async/USKFetcherWrapper.java
+++ b/src/freenet/client/async/USKFetcherWrapper.java
@@ -24,19 +24,7 @@ public class USKFetcherWrapper extends BaseClientGetter {
 	final USK usk;
 	
 	public USKFetcherWrapper(USK usk, short prio, final RequestClient client) {
-		super(prio, new ClientBaseCallback() {
-
-            @Override
-            public void onResume(ClientContext context) {
-                throw new IllegalStateException();
-            }
-
-            @Override
-            public RequestClient getRequestClient() {
-                return client;
-            }
-		    
-		});
+		super(prio, client);
 		this.usk = usk;
 	}
 

--- a/src/freenet/client/async/USKRetriever.java
+++ b/src/freenet/client/async/USKRetriever.java
@@ -63,16 +63,7 @@ public class USKRetriever extends BaseClientGetter implements USKCallback {
 
 	public USKRetriever(FetchContext fctx, short prio,  
 			final RequestClient client, USKRetrieverCallback cb, USK origUSK) {
-		super(prio, new ClientBaseCallback() {
-            @Override
-            public void onResume(ClientContext context) {
-                throw new IllegalStateException();
-            }
-            @Override
-            public RequestClient getRequestClient() {
-                return client;
-            }
-		});
+		super(prio, client);
 		if(client.persistent()) throw new UnsupportedOperationException("USKRetriever cannot be persistent");
 		this.ctx = fctx;
 		this.cb = cb;


### PR DESCRIPTION
As the `ClientCallback`’s only used functionality is to return a `RequestClient`, the client can simply be handed in instead of the callback, removing the need for fake callbacks.