### PR TITLE
Run sanity checks against given value

### DIFF
--- a/src/freenet/node/updater/NodeUpdateManager.java
+++ b/src/freenet/node/updater/NodeUpdateManager.java
@@ -1736,9 +1736,9 @@ public class NodeUpdateManager {
 						"invalidUpdateURI", "error",
 						e.getLocalizedMessage()));
 			}
-			if(updateURI.hasMetaStrings())
+			if(uri.hasMetaStrings())
 				throw new InvalidConfigValueException(l10n("updateURIMustHaveNoMetaStrings"));
-			if(!updateURI.isUSK())
+			if(!uri.isUSK())
 				throw new InvalidConfigValueException(l10n("updateURIMustBeAUSK"));
 			setURI(uri);
 		}


### PR DESCRIPTION
- hasMetaStrings and isUSK check were being performed over the previous value (due to code duplication)
- It may cause the node to not be able to restart properly

Should fix https://freenet.mantishub.io/view.php?id=7128 and https://freenet.mantishub.io/view.php?id=7038