### PR TITLE
Added definition that source code is encoded in UTF-8  to gradl build definition

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,14 @@ task buildInfo {
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
+tasks.withType(JavaCompile) {
+    options.encoding = "UTF-8"
+}
+
+tasks.withType(Javadoc) {
+    options.encoding = "UTF-8"
+}
+
 task compileVersion (type: JavaCompile) {
     copy {
         from sourceSets.main.java.srcDirs


### PR DESCRIPTION
The source code is encoded in utf-8, which is currently not specified.

This causes several issues:

- The following tests fail (at least under windows)
  - Base64Test.testDecodeStandard 
  - Base64Test.testEncodeStandard  

- The compiler generates several parsing errors during the compilation:
  - error: unmappable character (0x9D) for encoding windows-1252
  -...

Defining the source code encoding fixes these issues.