### PR TITLE
Replaces deprecated Constructors like Byte() or Integer()  with Byte.…

### DIFF
--- a/src/freenet/client/filter/FlacFilter.java
+++ b/src/freenet/client/filter/FlacFilter.java
@@ -54,8 +54,8 @@ public class FlacFilter implements ContentDataFilter {
 					boolean firstHalfOfSyncHeaderFound = false;
 					ArrayList<Byte> buffer = new ArrayList<Byte>();
 					int data = 0;
-					buffer.add(new Byte((byte) ((frameHeader & 0xFF00) >>> 8)));
-					buffer.add(new Byte((byte) ((frameHeader & 0x00FF))));
+					buffer.add(Byte.valueOf((byte) ((frameHeader & 0xFF00) >>> 8)));
+					buffer.add(Byte.valueOf((byte) (frameHeader & 0x00FF)));
 					boolean running = true;
 					while(running) {
 						try {
@@ -88,10 +88,10 @@ public class FlacFilter implements ContentDataFilter {
 								packet = new FlacFrame(payload);
 							} else {
 								firstHalfOfSyncHeaderFound = false;
-								buffer.add(new Byte((byte)0xFF));
+								buffer.add(Byte.valueOf((byte) 0xFF));
 							}
 						}
-						buffer.add(new Byte((byte) (data&0xFF)));
+						buffer.add(Byte.valueOf((byte) (data & 0xFF)));
 					}
 				}
 				if(currentState == State.UNINITIALIZED && packet instanceof FlacMetadataBlock && ((FlacMetadataBlock) packet).isLastMetadataBlock()) {

--- a/src/freenet/client/filter/OggPage.java
+++ b/src/freenet/client/filter/OggPage.java
@@ -145,10 +145,10 @@ public class OggPage {
 			int concludingPartialSegment = packet.payload.length % 255;
 			Logger.minor(this, "Whole segments: "+wholeSegments+" Partial: "+concludingPartialSegment);
 			for(int i = 0; i < wholeSegments; i++) {
-				segmentSizes.add(new Byte(intToUnsignedByte(255)));
+				segmentSizes.add(Byte.valueOf(intToUnsignedByte(255)));
 			}
 			if(concludingPartialSegment != 0) {
-				segmentSizes.add(new Byte(intToUnsignedByte(concludingPartialSegment)));
+				segmentSizes.add(Byte.valueOf(intToUnsignedByte(concludingPartialSegment)));
 			}
 			Logger.minor(this, "Writing packet sized: "+packet.payload.length);
 			payloadStream.write(packet.payload);

--- a/src/freenet/node/PeerManager.java
+++ b/src/freenet/node/PeerManager.java
@@ -1109,7 +1109,7 @@ public class PeerManager {
 						leastRecentlyTimedOutBackedOffDistance = diff;
 					}
 			if(addUnpickedLocsTo != null && !chosen) {
-				Double d = new Double(loc);
+				Double d = loc;
 				// Here we can directly compare double's because they aren't processed in any way, and are finite and (probably) nonzero.
 				if(!addUnpickedLocsTo.contains(d))
 					addUnpickedLocsTo.add(d);
@@ -1242,7 +1242,7 @@ public class PeerManager {
 			if(addUnpickedLocsTo != null)
 				//Add the location which we did not pick, if it exists.
 				if(closestNotBackedOff != null && closestBackedOff != null)
-					addUnpickedLocsTo.add(new Double(closestBackedOff.getLocation()));
+					addUnpickedLocsTo.add(closestBackedOff.getLocation());
 					
 		}
 		

--- a/test/freenet/support/LRUMapTest.java
+++ b/test/freenet/support/LRUMapTest.java
@@ -134,8 +134,8 @@ public class LRUMapTest extends TestCase {
 	public void testPushSameKey() {
 		LRUMap<Object, Object> methodLRUht = createSampleHashTable(sampleElemsNumber);
 		Object[][] sampleObj = {
-				{ new Integer(sampleElemsNumber), new Object() }, 
-				{ new Integer(sampleElemsNumber+1), new Object() } };
+				{ sampleElemsNumber, new Object() }, 
+				{ sampleElemsNumber + 1, new Object() } };
 		
 		methodLRUht.push(sampleObj[0][0],sampleObj[0][1]);
 		methodLRUht.push(sampleObj[1][0],sampleObj[1][1]);


### PR DESCRIPTION
…valueOf() or autoboxing

As of Java 9 the constructors to wrap a native type within the corresponding Object Class have been deprecated.
Replaces those calls with the long existing valueOf static methods or through autoboxing.
