### PR TITLE
Fixed unreliable store store test cases

### DIFF
--- a/src/freenet/store/caching/CachingFreenetStore.java
+++ b/src/freenet/store/caching/CachingFreenetStore.java
@@ -33,6 +33,7 @@ public class CachingFreenetStore<T extends StorableBlock> extends ProxyFreenetSt
 	 * True if close() has been called
 	 */
 	private AtomicBoolean closeCalled = new AtomicBoolean(false);
+
 	private final LRUMap<ByteArrayWrapper, Block<T>> blocksByRoutingKey;
 	private final StoreCallback<T> callback;
 	private final boolean collisionPossible;

--- a/test/freenet/store/RAMSaltMigrationTest.java
+++ b/test/freenet/store/RAMSaltMigrationTest.java
@@ -2,7 +2,10 @@ package freenet.store;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Random;
+import java.util.UUID;
 
 import junit.framework.TestCase;
 
@@ -35,13 +38,18 @@ public class RAMSaltMigrationTest extends TestCase {
 	private Random weakPRNG = new Random(12340);
 	private PooledExecutor exec = new PooledExecutor();
 	private Ticker ticker = new TrivialTicker(exec);
-	private File tempDir;
+	private final File tempDir = new File("tmp-slashdotstoretest");
 
 	@Override
 	protected void setUp() throws java.lang.Exception {
-		tempDir = new File("tmp-slashdotstoretest");
-		tempDir.mkdir();
 		exec.start();
+
+		// Make sure each test starts with a nice clean temp directory
+		if( ! FileUtil.removeAll(tempDir) ) {
+			throw new RuntimeException("Could not clean temporary directory for running clean tests");
+		}
+		tempDir.mkdir();
+
 		ResizablePersistentIntBuffer.setPersistenceTime(-1);
 	}
 
@@ -50,14 +58,122 @@ public class RAMSaltMigrationTest extends TestCase {
 		FileUtil.removeAll(tempDir);
 	}
 
-	public void testRAMStore() throws IOException, CHKEncodeException, CHKVerifyException, CHKDecodeException {
+	private File getTempStoreFile() {
+		return new File(tempDir, "saltstore_" + UUID.randomUUID());
+	}
+
+	private void sleep(int time) {
+		if (time <= 0) {
+			return;
+		}
+		try {
+			Thread.sleep(time);
+		} catch (InterruptedException e) {
+			// Ignore
+		}
+	}
+
+	/**
+	 * Insert Standard testing data
+	 * @param keycount Number of keys to insert
+	 * @param store Store to put data to
+	 * @param dummyValueInserted The inserted values will be added to this list
+	 * @param blocksInserted The inserted Blocks will be added to this list
+	 * @return number of collisions during the insert
+	 * @throws CHKEncodeException
+	 * @throws IOException
+	 */
+	private int insertStandardTestBlocksIntoStore(int keycount, CHKStore store, List<String> dummyValueInsertedList, List<ClientCHKBlock> blockInsertedList)
+			throws CHKEncodeException, IOException {
+		
+		int collisions = 0;
+		for (int i = 0; i < keycount; i++) {
+			String dummyValueInserted = "test" + i;
+			ClientCHKBlock blockInserted = encodeBlock(dummyValueInserted, true);
+			store.put(blockInserted.getBlock(), true);
+
+			dummyValueInsertedList.add(dummyValueInserted);
+			blockInsertedList.add(blockInserted);
+			
+			// Did we have a collision during the put and the actual size did not increase?
+			if (store.keyCount() + collisions == i) {
+				collisions++;
+			}
+		}
+		return collisions;
+	}
+
+	/**
+	 * Probe all inserted keys and see what is actually there, after collisions might
+	 * have happend during insert or resize
+	 * 
+	 * @param store to check for keys
+	 * @param dummyValueInsertedList to check for in store
+	 * @param blockInsertedList to check for in store
+	 * @param dummyValueActuallyStoredList found values will be added to this list
+	 * @param blockActuallyStoredList found blocks will be added to this list
+	 * @throws IOException
+	 */
+	private void probeStoreBlocks(CHKStore store, List<String> dummyValueInsertedList, List<ClientCHKBlock> blockInsertedList, List<String> dummyValueActuallyStoredList, List<ClientCHKBlock> blockActuallyStoredList)
+			throws IOException {
+		for (int i = 0; i < dummyValueInsertedList.size(); i++) {
+
+			CHKBlock verify = store.fetch(blockInsertedList.get(i).getClientKey().getNodeCHK(), false, false, null);
+			if (verify != null) {
+				dummyValueActuallyStoredList.add(dummyValueInsertedList.get(i));
+				blockActuallyStoredList.add(blockInsertedList.get(i));
+			}
+		}
+		assertTrue("Inserts failed, not a single key stored", dummyValueActuallyStoredList.size() > 0);
+	}
+
+	/**
+	 * Checks if the store contains the given blocks and values
+	 * @param store to check
+	 * @param dummyValueActuallyStoredList of values expected
+	 * @param blockActuallyStoredList of blocks expecte
+	 * @param expectAll true, if all keys must be in the store, or at least one will be sufficient to succeed
+	 * @throws CHKVerifyException
+	 * @throws CHKDecodeException
+	 * @throws IOException
+	 */
+	private void checkStandardTestBlocks(CHKStore store, List<String> dummyValueActuallyStoredList, List<ClientCHKBlock> blockActuallyStoredList, boolean expectAll)
+			throws CHKVerifyException, CHKDecodeException, IOException {
+
+		int numberOfHits = 0;
+		for (int i = 0; i < blockActuallyStoredList.size(); i++) {
+
+			String value = dummyValueActuallyStoredList.get(i);
+			ClientCHK key = blockActuallyStoredList.get(i).getClientKey();
+			CHKBlock verify = store.fetch(key.getNodeCHK(), false, false, null);
+
+			if (expectAll) {
+				assertNotNull("Expect all keys to be in store. Not found: " + value, verify);
+			} else if (verify == null) {
+				continue;
+			}
+
+			String decodedValue = decodeBlock(verify, key);
+			assertEquals(value, decodedValue);
+			numberOfHits++;
+		}
+		
+		assertTrue("Not all keys in store were a hit", numberOfHits > 0);
+	}
+
+	public void testRAMStore_newFormat() throws IOException, CHKEncodeException, CHKVerifyException, CHKDecodeException {
 		checkRAMStore(true);
+	}
+
+	public void testRAMStore_oldFormat() throws IOException, CHKEncodeException, CHKVerifyException, CHKDecodeException {
 		checkRAMStore(false);
 	}
-	
-	private void checkRAMStore(boolean newFormat) throws IOException, CHKEncodeException, CHKVerifyException, CHKDecodeException {
+
+	private void checkRAMStore(boolean newFormat)
+			throws IOException, CHKEncodeException, CHKVerifyException, CHKDecodeException {
 		CHKStore store = new CHKStore();
-		new RAMFreenetStore<CHKBlock>(store, 10);
+		RAMFreenetStore<CHKBlock> ramFreenetStore = new RAMFreenetStore<CHKBlock>(store, 10);
+		store.setStore(ramFreenetStore);
 
 		// Encode a block
 		String test = "test";
@@ -73,7 +189,8 @@ public class RAMSaltMigrationTest extends TestCase {
 
 	public void testRAMStoreOldBlocks() throws IOException, CHKEncodeException, CHKVerifyException, CHKDecodeException {
 		CHKStore store = new CHKStore();
-		new RAMFreenetStore<CHKBlock>(store, 10);
+		RAMFreenetStore<CHKBlock> ramFreenetStore = new RAMFreenetStore<CHKBlock>(store, 10);
+		store.setStore(ramFreenetStore);
 
 		// Encode a block
 		String test = "test";
@@ -85,92 +202,99 @@ public class RAMSaltMigrationTest extends TestCase {
 		CHKBlock verify = store.fetch(key.getNodeCHK(), false, false, null);
 		String data = decodeBlock(verify, key);
 		assertEquals(test, data);
-		
+
 		// ignoreOldBlocks works.
 		assertEquals(null, store.fetch(key.getNodeCHK(), false, true, null));
-		
+
 		// Put it with oldBlock = false should unset the flag.
 		store.put(block.getBlock(), false);
-		
+
 		verify = store.fetch(key.getNodeCHK(), false, true, null);
 		data = decodeBlock(verify, key);
 		assertEquals(test, data);
 	}
 
-	public void testSaltedStore() throws IOException, CHKEncodeException, CHKVerifyException, CHKDecodeException {
+	public void testSaltedStore_oldFormat()
+			throws IOException, CHKEncodeException, CHKVerifyException, CHKDecodeException {
 		checkSaltedStore(false);
+	}
+
+	public void testSaltedStore_newFormat()
+			throws IOException, CHKEncodeException, CHKVerifyException, CHKDecodeException {
 		checkSaltedStore(true);
 	}
-	
-	public void checkSaltedStore(boolean newFormat) throws IOException, CHKEncodeException, CHKVerifyException, CHKDecodeException {
-		File f = new File(tempDir, "saltstore");
-		FileUtil.removeAll(f);
 
+	public void checkSaltedStore(boolean newFormat)
+			throws IOException, CHKEncodeException, CHKVerifyException, CHKDecodeException {
 		CHKStore store = new CHKStore();
-		SaltedHashFreenetStore<CHKBlock> saltStore = SaltedHashFreenetStore.construct(f, "teststore", store, weakPRNG, 10, false, SemiOrderedShutdownHook.get(), true, true, ticker, null);
-		saltStore.start(null, true);
 
-		for(int i=0;i<5;i++) {
-			
-			// Encode a block
-			String test = "test" + i;
-			ClientCHKBlock block = encodeBlock(test, newFormat);
-			store.put(block.getBlock(), false);
-			
-			ClientCHK key = block.getClientKey();
-			
-			CHKBlock verify = store.fetch(key.getNodeCHK(), false, false, null);
-			String data = decodeBlock(verify, key);
-			assertEquals(test, data);
-		}
-		
-		saltStore.close();
-	}
-	
-	private void innerTestSaltedStoreWithClose(int persistenceTime, int delay) throws IOException, CHKEncodeException, CHKVerifyException, CHKDecodeException {
-		ResizablePersistentIntBuffer.setPersistenceTime(persistenceTime);
-		
-		File f = new File(tempDir, "saltstore");
-		FileUtil.removeAll(f);
+		File f = getTempStoreFile();
+		try (SaltedHashFreenetStore<CHKBlock> saltStore = SaltedHashFreenetStore.construct(f, "teststore", store, weakPRNG,
+				10, false, SemiOrderedShutdownHook.get(), true, true, ticker, null)) {
+			saltStore.start(null, true);
 
-		CHKStore store = new CHKStore();
-		SaltedHashFreenetStore<CHKBlock> saltStore = SaltedHashFreenetStore.construct(f, "teststore", store, weakPRNG, 10, false, SemiOrderedShutdownHook.get(), true, true, ticker, null);
-		saltStore.start(null, true);
+			for (int i = 0; i < 5; i++) {
 
-		checkBlocks(store, true, false);
-		
-		saltStore.close();
-		
-		if(delay != 0)
-			try {
-				Thread.sleep(delay);
-			} catch (InterruptedException e) {
-				// Ignore
-			}
-		
-		saltStore = SaltedHashFreenetStore.construct(new File(tempDir, "saltstore"), "teststore", store, weakPRNG, 10, false, SemiOrderedShutdownHook.get(), true, true, ticker, null);
-		
-		checkBlocks(store, false, false);
-
-		saltStore.close();
-	}
-
-	private void checkBlocks(CHKStore store,
-			boolean write, boolean expectFailure) throws CHKEncodeException, IOException, CHKVerifyException, CHKDecodeException {
-		
-		for(int i=0;i<5;i++) {
-			
-			// Encode a block
-			String test = "test" + i;
-			// Use new format for every other block to ensure they are mixed in the same store.
-			ClientCHKBlock block = encodeBlock(test, (i & 1) == 1);
-			if(write)
+				// Encode a block
+				String test = "test" + i;
+				ClientCHKBlock block = encodeBlock(test, newFormat);
 				store.put(block.getBlock(), false);
-			
+
+				ClientCHK key = block.getClientKey();
+
+				CHKBlock verify = store.fetch(key.getNodeCHK(), false, false, null);
+				String data = decodeBlock(verify, key);
+				assertEquals(test, data);
+			}
+		}
+	}
+
+	private void innerTestSaltedStoreWithClose(int persistenceTime, int delay)
+			throws IOException, CHKEncodeException, CHKVerifyException, CHKDecodeException {
+		ResizablePersistentIntBuffer.setPersistenceTime(persistenceTime);
+
+		int keycount = 5;
+
+		CHKStore store = new CHKStore();
+		File f = getTempStoreFile();
+		List<String> dummyValueActuallyStoredList = new ArrayList<String>(keycount);
+		List<ClientCHKBlock> blockActuallyStoredList = new ArrayList<ClientCHKBlock>(keycount);
+		try (SaltedHashFreenetStore<CHKBlock> saltStore = SaltedHashFreenetStore.construct(f, "teststore", store, weakPRNG,
+				10, false, SemiOrderedShutdownHook.get(), true, true, ticker, null)) {
+			saltStore.start(null, true);
+
+			List<String> dummyValueInsertedList = new ArrayList<String>(keycount);
+			List<ClientCHKBlock> blockInsertedList = new ArrayList<ClientCHKBlock>(keycount);
+			int collisions = insertStandardTestBlocksIntoStore(keycount, store, dummyValueInsertedList, blockInsertedList);
+
+			probeStoreBlocks(store, dummyValueInsertedList, blockInsertedList, dummyValueActuallyStoredList, blockActuallyStoredList);
+			assertEquals("The number of inserts minus the number of collissions should be the same as the number of keys in the store. Collisions " + collisions, dummyValueInsertedList.size() - collisions, blockActuallyStoredList.size());
+		}
+
+		store = new CHKStore();
+		try (SaltedHashFreenetStore<CHKBlock> saltStore = SaltedHashFreenetStore.construct(f, "teststore", store, weakPRNG,
+				10, false, SemiOrderedShutdownHook.get(), true, true, ticker, null)) {
+			checkStandardTestBlocks(store, dummyValueActuallyStoredList, blockActuallyStoredList, true);
+		}
+	}
+
+	private void checkBlocks(CHKStore store, boolean write, boolean expectFailure)
+			throws CHKEncodeException, IOException, CHKVerifyException, CHKDecodeException {
+
+		for (int i = 0; i < 5; i++) {
+
+			// Encode a block
+			String test = "test" + i;
+			// Use new format for every other block to ensure they are mixed in the same
+			// store.
+			ClientCHKBlock block = encodeBlock(test, (i & 1) == 1);
+			if (write)
+				store.put(block.getBlock(), false);
+
 			ClientCHK key = block.getClientKey();
-			
+
 			CHKBlock verify = store.fetch(key.getNodeCHK(), false, false, null);
-			if(expectFailure)
+			if (expectFailure)
 				assertEquals(null, verify);
 			else {
 				String data = decodeBlock(verify, key);
@@ -179,183 +303,238 @@ public class RAMSaltMigrationTest extends TestCase {
 		}
 	}
 
-	private void innerTestSaltedStoreSlotFilterWithAbort(int persistenceTime, int delay, boolean expectFailure, boolean forceValidEmpty) throws IOException, CHKEncodeException, CHKVerifyException, CHKDecodeException {
+	private void innerTestSaltedStoreSlotFilterWithAbort(int persistenceTime, int delay, boolean expectFailure,
+			boolean forceValidEmpty) throws IOException, CHKEncodeException, CHKVerifyException, CHKDecodeException {
 		ResizablePersistentIntBuffer.setPersistenceTime(persistenceTime);
-		
-		File f = new File(tempDir, "saltstore");
-		FileUtil.removeAll(f);
+
+		File f = getTempStoreFile();
 
 		CHKStore store = new CHKStore();
-		SaltedHashFreenetStore<CHKBlock> saltStore = SaltedHashFreenetStore.construct(f, "teststore", store, weakPRNG, 10, true, SemiOrderedShutdownHook.get(), true, true, ticker, null);
-		saltStore.start(ticker, true);
-		
-		// Make sure it's clear.
-		checkBlocks(store, false, true);
+		try (SaltedHashFreenetStore<CHKBlock> saltStore = SaltedHashFreenetStore.construct(f, "teststore", store, weakPRNG,
+				10, true, SemiOrderedShutdownHook.get(), true, true, ticker, null)) {
+			saltStore.start(ticker, true);
 
-		checkBlocks(store, true, false);
-		
-		if(delay != 0)
-			try {
-				Thread.sleep(delay);
-			} catch (InterruptedException e) {
-				// Ignore
-			}
-		
-		saltStore.close(true);
-		
+			// Make sure it's clear.
+			checkBlocks(store, false, true);
+
+			checkBlocks(store, true, false);
+
+			sleep(delay);
+		}
+
 		store = new CHKStore();
-		saltStore = SaltedHashFreenetStore.construct(f, "teststore", store, weakPRNG, 10, true, SemiOrderedShutdownHook.get(), true, true, ticker, null);
-		saltStore.start(ticker, true);
-		if(forceValidEmpty)
-			saltStore.forceValidEmpty();
-		
-		checkBlocks(store, false, expectFailure);
+		try (SaltedHashFreenetStore<CHKBlock> saltStore = SaltedHashFreenetStore.construct(f, "teststore", store, weakPRNG,
+				10, true, SemiOrderedShutdownHook.get(), true, true, ticker, null)) {
+			saltStore.start(ticker, true);
+			if (forceValidEmpty)
+				saltStore.forceValidEmpty();
 
-		saltStore.close();
+			checkBlocks(store, false, expectFailure);
+		}
 	}
 
-	public void testSaltedStoreWithClose() throws IOException, CHKEncodeException, CHKVerifyException, CHKDecodeException {
+	public void testSaltedStoreWithClose_writeImmediately()
+			throws IOException, CHKEncodeException, CHKVerifyException, CHKDecodeException {
 		// Write straight through should work.
 		innerTestSaltedStoreWithClose(-1, 0);
+	}
+
+	public void testSaltedStoreWithClose_writeOnShotdown()
+			throws IOException, CHKEncodeException, CHKVerifyException, CHKDecodeException {
 		// Write on shutdown should work.
 		innerTestSaltedStoreWithClose(0, 0);
+	}
+
+	public void testSaltedStoreWithClose_waitLongerThanPersistenceTime()
+			throws IOException, CHKEncodeException, CHKVerifyException, CHKDecodeException {
 		// Shorter interval than delay should work.
 		innerTestSaltedStoreWithClose(1000, 2000);
+	}
+
+	public void testSaltedStoreWithClose_noWaitWithPersincenceTime_relayOnClose()
+			throws IOException, CHKEncodeException, CHKVerifyException, CHKDecodeException {
 		// Longer interval than delay should work (write on shutdown).
 		innerTestSaltedStoreWithClose(5000, 0);
+	}
+
+	public void innerTestSaltedStoreSlotFilterWithAbort_writeImmediately()
+			throws IOException, CHKEncodeException, CHKVerifyException, CHKDecodeException {
 		// Write straight through should work even with abort.
 		innerTestSaltedStoreSlotFilterWithAbort(-1, 0, false, false);
-		// Write straight through should work 
+	}
+
+	public void innerTestSaltedStoreSlotFilterWithAbort_waitLongerThanPersistenceTime()
+			throws IOException, CHKEncodeException, CHKVerifyException, CHKDecodeException {
+		// Shorter interval than delay should work.
 		innerTestSaltedStoreSlotFilterWithAbort(1000, 2000, false, false);
+	}
+
+	public void innerTestSaltedStoreSlotFilterWithAbort_noWaitWithPersincenceTime_slotsUnknown()
+			throws IOException, CHKEncodeException, CHKVerifyException, CHKDecodeException {
 		// Even this should work, because the slots still say unknown.
 		innerTestSaltedStoreSlotFilterWithAbort(5000, 0, false, false);
+	}
+
+	public void innerTestSaltedStoreSlotFilterWithAbort_noWaitWithPersincenceTime_forceKownEmpty_fails()
+			throws IOException, CHKEncodeException, CHKVerifyException, CHKDecodeException {
 		// However if we set the unknown slots to known empty, it should fail.
 		innerTestSaltedStoreSlotFilterWithAbort(5000, 0, true, true);
-		// But if we do the same thing while giving it enough time to write, it should work.
-		innerTestSaltedStoreSlotFilterWithAbort(-1, 0, false, true);
-		innerTestSaltedStoreSlotFilterWithAbort(1000, 2000, false, true);
-		
 	}
 
-	public void testSaltedStoreOldBlock() throws CHKEncodeException, CHKVerifyException, CHKDecodeException, IOException {
+	public void innerTestSaltedStoreSlotFilterWithAbort_writeImmediately_forceKownEmptz()
+			throws IOException, CHKEncodeException, CHKVerifyException, CHKDecodeException {
+		// But if we do the same thing while giving it enough time to write, it should
+		// work.
+		innerTestSaltedStoreSlotFilterWithAbort(-1, 0, false, true);
+	}
+
+	public void testSaltedStoreWithClose_withPersincenceTimeAndLongerWait_forceKownEmpty()
+			throws IOException, CHKEncodeException, CHKVerifyException, CHKDecodeException {
+		// But if we do the same thing while giving it enough time to write, it should
+		// work.
+		innerTestSaltedStoreSlotFilterWithAbort(1000, 2000, false, true);
+	}
+
+	public void testSaltedStoreOldBlock_noSlotFilters_bloomZero()
+			throws CHKEncodeException, CHKVerifyException, CHKDecodeException, IOException {
 		checkSaltedStoreOldBlocks(5, 10, 0, false);
+	}
+
+	public void testSaltedStoreOldBlock_noSlotFilters_bloom50()
+			throws CHKEncodeException, CHKVerifyException, CHKDecodeException, IOException {
 		checkSaltedStoreOldBlocks(5, 10, 50, false);
+	}
+
+	public void testSaltedStoreOldBlock_withSlotFilters_bloomZero()
+			throws CHKEncodeException, CHKVerifyException, CHKDecodeException, IOException {
 		checkSaltedStoreOldBlocks(5, 10, 0, true);
 	}
-	
-	public void checkSaltedStoreOldBlocks(int keycount, int size, int bloomSize, boolean useSlotFilter) throws IOException, CHKEncodeException, CHKVerifyException, CHKDecodeException {
-		CHKStore store = new CHKStore();
-		SaltedHashFreenetStore<CHKBlock> saltStore = SaltedHashFreenetStore.construct(new File(tempDir, "saltstore-"+keycount+"-"+size+"-"+bloomSize+"-"+useSlotFilter), "teststore", store, weakPRNG, size, useSlotFilter, SemiOrderedShutdownHook.get(), true, true, ticker, null);
-		saltStore.start(null, true);
-		
-		ClientCHK[] keys = new ClientCHK[keycount];
-		String[] test = new String[keycount];
-		ClientCHKBlock[] block = new ClientCHKBlock[keycount];
 
-		for(int i=0;i<keycount;i++) {
+	public void checkSaltedStoreOldBlocks(int keycount, int size, int bloomSize, boolean useSlotFilter)
+			throws IOException, CHKEncodeException, CHKVerifyException, CHKDecodeException {
+		int delay = 1000;
+		ResizablePersistentIntBuffer.setPersistenceTime(delay);
+
+		CHKStore store = new CHKStore();
+
+		File f = getTempStoreFile();
+		try (SaltedHashFreenetStore<CHKBlock> saltStore = SaltedHashFreenetStore.construct(f, "teststore", store, weakPRNG,
+				size, useSlotFilter, SemiOrderedShutdownHook.get(), true, true, ticker, null)) {
 			
-			// Encode a block
-			test[i] = "test" + i;
-			block[i] = encodeBlock(test[i], true);
-			store.put(block[i].getBlock(), true);
+			saltStore.start(null, true);
+
+			List<String> dummyValueInsertedList = new ArrayList<String>(keycount);
+			List<ClientCHKBlock> blockInsertedList = new ArrayList<ClientCHKBlock>(keycount);
+			int collisions = insertStandardTestBlocksIntoStore(keycount, store, dummyValueInsertedList, blockInsertedList);
+
+			List<String> dummyValueActuallyStoredList = new ArrayList<String>(keycount);
+			List<ClientCHKBlock> blockActuallyStoredList = new ArrayList<ClientCHKBlock>(keycount);
+			probeStoreBlocks(store, dummyValueInsertedList, blockInsertedList, dummyValueActuallyStoredList, blockActuallyStoredList);
+			assertEquals("The number of inserts minus the number of collissions should be the same as the number of keys in the store. Collisions " + collisions, dummyValueInsertedList.size() - collisions, blockActuallyStoredList.size());
 			
-			keys[i] = block[i].getClientKey();
+			for (int i = 0; i < dummyValueActuallyStoredList.size(); i++) {
+
+				String value = dummyValueActuallyStoredList.get(i);
+				ClientCHKBlock block = blockActuallyStoredList.get(i);
+
+				ClientCHK key = block.getClientKey();
+
+				CHKBlock verify = store.fetch(key.getNodeCHK(), false, false, null);
+				String decodedValue = decodeBlock(verify, key);
+				assertEquals(value, decodedValue);
+
+				// ignoreOldBlocks works.
+				assertEquals(null, store.fetch(key.getNodeCHK(), false, true, null));
+
+				// Put it with oldBlock = false should unset the flag.
+				store.put(block.getBlock(), false);
+
+				verify = store.fetch(key.getNodeCHK(), false, true, null);
+				decodedValue = decodeBlock(verify, key);
+				assertEquals(decodedValue, decodedValue);
+			}
 		}
-		
-		for(int i=0;i<keycount;i++) {
-			
-			ClientCHK key = keys[i];
-			
-			CHKBlock verify = store.fetch(key.getNodeCHK(), false, false, null);
-			String data = decodeBlock(verify, key);
-			assertEquals(test[i], data);
-			
-			// ignoreOldBlocks works.
-			assertEquals(null, store.fetch(key.getNodeCHK(), false, true, null));
-			
-			// Put it with oldBlock = false should unset the flag.
-			store.put(block[i].getBlock(), false);
-			
-			verify = store.fetch(key.getNodeCHK(), false, true, null);
-			data = decodeBlock(verify, key);
-			assertEquals(test[i], data);
-		}
-		
-		saltStore.close();
 	}
-	
-	public void testSaltedStoreResize() throws CHKEncodeException, CHKVerifyException, CHKDecodeException, IOException {
+
+	public void testSaltedStoreResize_noUseSlotFilter_writeImmediately_noAbort_openNewSize()
+			throws CHKEncodeException, CHKVerifyException, CHKDecodeException, IOException {
 		checkSaltedStoreResize(5, 10, 20, false, -1, false, true);
-		checkSaltedStoreResize(5, 10, 20, true, -1, false, true);
-		// Will write to disk on shutdown.
-		checkSaltedStoreResize(5, 10, 20, true, 60*60*1000, false, true);
-		// Using the old size causes it to resize on startup back to the old size. This needs testing too, and revealed some odd bugs.
-		checkSaltedStoreResize(5, 10, 20, true, 60*60*1000, false, false);
-		// It will force to disk after resizing, so should still work even with a long write time.
-		checkSaltedStoreResize(5, 10, 20, true, 60*60*1000, true, true);
-		checkSaltedStoreResize(5, 10, 20, true, 60*60*1000, true, false);
 	}
-	
-	public void checkSaltedStoreResize(int keycount, int size, int newSize, boolean useSlotFilter, int persistenceTime, boolean abort, boolean openNewSize) throws IOException, CHKEncodeException, CHKVerifyException, CHKDecodeException {
-		
-		File f = new File(tempDir, "saltstore-"+keycount+"-"+size+"-"+useSlotFilter);
-		FileUtil.removeAll(f);
-		
+
+	public void testSaltedStoreResize_useSlotFilter_writeImmediately_noAbort_openNewSize()
+			throws CHKEncodeException, CHKVerifyException, CHKDecodeException, IOException {
+		checkSaltedStoreResize(5, 10, 20, true, -1, false, true);
+	}
+
+	public void testSaltedStoreResize_useSlotFilter_1h_noAbort_openNewSize()
+			throws CHKEncodeException, CHKVerifyException, CHKDecodeException, IOException {
+		// Will write to disk on shutdown.
+		checkSaltedStoreResize(5, 10, 20, true, 60000, false, true);
+	}
+
+	public void testSaltedStoreResize_useSlotFilter_1h_noAbort_noOpenNewSize()
+			throws CHKEncodeException, CHKVerifyException, CHKDecodeException, IOException {
+		// Using the old size causes it to resize on startup back to the old size. This
+		// needs testing too, and revealed some odd bugs.
+		checkSaltedStoreResize(5, 10, 20, true, 60000, false, false);
+	}
+
+	public void testSaltedStoreResize_useSlotFilter_1h_abort_openNewSize()
+			throws CHKEncodeException, CHKVerifyException, CHKDecodeException, IOException {
+		// It will force to disk after resizing, so should still work even with a long
+		// write time.
+		checkSaltedStoreResize(5, 10, 20, true, 60000, true, true);
+	}
+
+	public void testSaltedStoreResize_useSlotFilter_1h_abort_noOpenNewSize()
+			throws CHKEncodeException, CHKVerifyException, CHKDecodeException, IOException {
+		checkSaltedStoreResize(5, 10, 20, true, 60000, true, false);
+	}
+
+	public void checkSaltedStoreResize(int keycount, int size, int newSize, boolean useSlotFilter, int persistenceTime,
+			boolean abort, boolean openNewSize)
+			throws IOException, CHKEncodeException, CHKVerifyException, CHKDecodeException {
+		File f = getTempStoreFile();
+
 		ResizablePersistentIntBuffer.setPersistenceTime(persistenceTime);
-		
+
 		CHKStore store = new CHKStore();
 		SaltedHashFreenetStore.NO_CLEANER_SLEEP = true;
-		SaltedHashFreenetStore<CHKBlock> saltStore = SaltedHashFreenetStore.construct(f, "teststore", store, weakPRNG, size, useSlotFilter, SemiOrderedShutdownHook.get(), true, true, ticker, null);
-		saltStore.start(ticker, true);
-		
-		ClientCHK[] keys = new ClientCHK[keycount];
-		String[] test = new String[keycount];
-		ClientCHKBlock[] block = new ClientCHKBlock[keycount];
+		List<String> dummyValueActuallyStoredList = new ArrayList<String>(keycount);
+		List<ClientCHKBlock> blockActuallyStoredList = new ArrayList<ClientCHKBlock>(keycount);
+		try (SaltedHashFreenetStore<CHKBlock> saltStore = SaltedHashFreenetStore.construct(f, "teststore", store, weakPRNG,
+				size, useSlotFilter, SemiOrderedShutdownHook.get(), true, true, ticker, null)) {
+			saltStore.start(ticker, true);
 
-		for(int i=0;i<keycount;i++) {
+			List<String> dummyValueInsertedList = new ArrayList<String>(keycount);
+			List<ClientCHKBlock> blockInsertedList = new ArrayList<ClientCHKBlock>(keycount);
+			int collisions = insertStandardTestBlocksIntoStore(keycount, store, dummyValueInsertedList, blockInsertedList);
 			
-			// Encode a block
-			test[i] = "test" + i;
-			block[i] = encodeBlock(test[i], true);
-			store.put(block[i].getBlock(), true);
-			
-			keys[i] = block[i].getClientKey();
+			saltStore.setMaxKeys(newSize, true);
+
+			probeStoreBlocks(store, dummyValueInsertedList, blockInsertedList, dummyValueActuallyStoredList, blockActuallyStoredList);
+			assertEquals("The number of inserts minus the number of collissions should be the same as the number of keys in the store. Collisions " + collisions, dummyValueInsertedList.size() - collisions, blockActuallyStoredList.size());
+
+			saltStore.close(abort);
 		}
-		
-		saltStore.setMaxKeys(newSize, true);
-		
-		for(int i=0;i<keycount;i++) {
-			
-			ClientCHK key = keys[i];
-			
-			CHKBlock verify = store.fetch(key.getNodeCHK(), false, false, null);
-			assert(verify != null);
-			String data = decodeBlock(verify, key);
-			assertEquals(test[i], data);
-		}
-		
-		saltStore.close(abort);
 
 		store = new CHKStore();
-		saltStore = SaltedHashFreenetStore.construct(f, "teststore", store, weakPRNG, openNewSize ? newSize : size, useSlotFilter, SemiOrderedShutdownHook.get(), true, true, ticker, null);
-		saltStore.start(ticker, true);
-		
-		for(int i=0;i<keycount;i++) {
-			
-			ClientCHK key = keys[i];
-			
-			CHKBlock verify = store.fetch(key.getNodeCHK(), false, false, null);
-			assert(verify != null);
-			String data = decodeBlock(verify, key);
-			assertEquals(test[i], data);
+		try (SaltedHashFreenetStore<CHKBlock> saltStore = SaltedHashFreenetStore.construct(f, "teststore", store, weakPRNG,
+				openNewSize ? newSize : size, useSlotFilter, SemiOrderedShutdownHook.get(), true, true, ticker, null)) {
+			saltStore.start(ticker, true);
+
+			// If we did open the new size we expect all previously matched keys to be present.
+			// If we opend the old size, it causes a resize again, which might create new collisions and keys might be lost again.
+			boolean expectAll = openNewSize;
+
+			checkStandardTestBlocks(store, dummyValueActuallyStoredList, blockActuallyStoredList, expectAll);
 		}
-		
-		saltStore.close();
 	}
 
 	public void testMigrate() throws IOException, CHKEncodeException, CHKVerifyException, CHKDecodeException {
 		CHKStore store = new CHKStore();
 		RAMFreenetStore<CHKBlock> ramStore = new RAMFreenetStore<CHKBlock>(store, 10);
+		store.setStore(ramStore);
 
 		// Encode a block
 		String test = "test";
@@ -369,20 +548,23 @@ public class RAMSaltMigrationTest extends TestCase {
 		assertEquals(test, data);
 
 		CHKStore newStore = new CHKStore();
-		SaltedHashFreenetStore<CHKBlock> saltStore = SaltedHashFreenetStore.construct(new File(tempDir, "saltstore"), "teststore", newStore, weakPRNG, 10, false, SemiOrderedShutdownHook.get(), true, true, ticker, null);
-		saltStore.start(null, true);
+		File f = getTempStoreFile();
+		try (SaltedHashFreenetStore<CHKBlock> saltStore = SaltedHashFreenetStore.construct(f, "teststore", newStore,
+				weakPRNG, 10, false, SemiOrderedShutdownHook.get(), true, true, ticker, null)) {
+			saltStore.start(null, true);
 
-		ramStore.migrateTo(newStore, false);
+			ramStore.migrateTo(newStore, false);
 
-		CHKBlock newVerify = store.fetch(key.getNodeCHK(), false, false, null);
-		String newData = decodeBlock(newVerify, key);
-		assertEquals(test, newData);
-		saltStore.close();
+			CHKBlock newVerify = store.fetch(key.getNodeCHK(), false, false, null);
+			String newData = decodeBlock(newVerify, key);
+			assertEquals(test, newData);
+		}
 	}
 
 	public void testMigrateKeyed() throws IOException, CHKEncodeException, CHKVerifyException, CHKDecodeException {
 		CHKStore store = new CHKStore();
 		RAMFreenetStore<CHKBlock> ramStore = new RAMFreenetStore<CHKBlock>(store, 10);
+		store.setStore(ramStore);
 
 		// Encode a block
 		String test = "test";
@@ -399,29 +581,33 @@ public class RAMSaltMigrationTest extends TestCase {
 		strongPRNG.nextBytes(storeKey);
 
 		CHKStore newStore = new CHKStore();
-		SaltedHashFreenetStore<CHKBlock> saltStore = SaltedHashFreenetStore.construct(new File(tempDir, "saltstore"), "teststore", newStore, weakPRNG, 10, false, SemiOrderedShutdownHook.get(), true, true, ticker, storeKey);
-		saltStore.start(null, true);
+		File f = getTempStoreFile();
+		try (SaltedHashFreenetStore<CHKBlock> saltStore = SaltedHashFreenetStore.construct(f, "teststore", newStore,
+				weakPRNG, 10, false, SemiOrderedShutdownHook.get(), true, true, ticker, storeKey)) {
+			saltStore.start(null, true);
 
-		ramStore.migrateTo(newStore, false);
+			ramStore.migrateTo(newStore, false);
 
-		CHKBlock newVerify = store.fetch(key.getNodeCHK(), false, false, null);
-		String newData = decodeBlock(newVerify, key);
-		assertEquals(test, newData);
-		saltStore.close();
+			CHKBlock newVerify = store.fetch(key.getNodeCHK(), false, false, null);
+			String newData = decodeBlock(newVerify, key);
+			assertEquals(test, newData);
+		}
 	}
 
-	private String decodeBlock(CHKBlock verify, ClientCHK key) throws CHKVerifyException, CHKDecodeException, IOException {
+	private String decodeBlock(CHKBlock verify, ClientCHK key)
+			throws CHKVerifyException, CHKDecodeException, IOException {
 		ClientCHKBlock cb = new ClientCHKBlock(verify, key);
 		Bucket output = cb.decode(new ArrayBucketFactory(), 32768, false);
 		byte[] buf = BucketTools.toByteArray(output);
 		return new String(buf, "UTF-8");
 	}
-	
+
 	private ClientCHKBlock encodeBlock(String test, boolean newFormat) throws CHKEncodeException, IOException {
 		byte[] data = test.getBytes("UTF-8");
 		SimpleReadOnlyArrayBucket bucket = new SimpleReadOnlyArrayBucket(data);
-		return ClientCHKBlock.encode(bucket, false, false, (short)-1, bucket.size(), Compressor.DEFAULT_COMPRESSORDESCRIPTOR,
-        null, newFormat ? Key.ALGO_AES_CTR_256_SHA256 : Key.ALGO_AES_PCFB_256_SHA256);
+		return ClientCHKBlock.encode(bucket, false, false, (short) -1, bucket.size(),
+				Compressor.DEFAULT_COMPRESSORDESCRIPTOR, null,
+				newFormat ? Key.ALGO_AES_CTR_256_SHA256 : Key.ALGO_AES_PCFB_256_SHA256);
 	}
 
 }

--- a/test/freenet/store/caching/CachingFreenetStoreTest.java
+++ b/test/freenet/store/caching/CachingFreenetStoreTest.java
@@ -58,28 +58,31 @@ import freenet.support.io.BucketTools;
 import freenet.support.io.FileUtil;
 
 /**
- * CachingFreenetStoreTest
- * Test for CachingFreenetStore
+ * CachingFreenetStoreTest Test for CachingFreenetStore
  *
  * @author Simon Vocella <voxsim@gmail.com>
  *
- * FIXME lots of repeated code, factor out.
+ *         FIXME lots of repeated code, factor out.
  */
 public class CachingFreenetStoreTest extends TestCase {
 
 	private Random weakPRNG = new Random(12340);
 	private PooledExecutor exec = new PooledExecutor();
 	private Ticker ticker = new TrivialTicker(exec);
-	private File tempDir;
+	private File tempDir = new File("tmp-cachingfreenetstoretest");
 	private long cachingFreenetStoreMaxSize = Fields.parseLong("1M");
 	private long cachingFreenetStorePeriod = Fields.parseLong("300k");
 
 	@Override
 	protected void setUp() throws java.lang.Exception {
-		tempDir = new File("tmp-cachingfreenetstoretest");
-		tempDir.mkdir();
-		exec.start();
 		ResizablePersistentIntBuffer.setPersistenceTime(-1);
+		exec.start();
+
+		// Make sure each test has a nice clean working directory to start with
+		if (!FileUtil.removeAll(tempDir)) {
+			throw new RuntimeException("Could not clean temporary directory for running clean tests");
+		}
+		tempDir.mkdir();
 	}
 
 	@Override
@@ -89,151 +92,156 @@ public class CachingFreenetStoreTest extends TestCase {
 
 	/* Simple test with CHK for CachingFreenetStore */
 	public void testSimpleCHK() throws IOException, CHKEncodeException, CHKVerifyException, CHKDecodeException {
-		File f = new File(tempDir, "saltstore");
-		FileUtil.removeAll(f);
-
 		CHKStore store = new CHKStore();
-		SaltedHashFreenetStore<CHKBlock> saltStore = SaltedHashFreenetStore.construct(f, "testCachingFreenetStoreCHK", store, weakPRNG, 10, false, SemiOrderedShutdownHook.get(), true, true, ticker, null);
-		CachingFreenetStoreTracker tracker = new CachingFreenetStoreTracker(cachingFreenetStoreMaxSize, cachingFreenetStorePeriod, ticker);
-		CachingFreenetStore<CHKBlock> cachingStore = new CachingFreenetStore<CHKBlock>(store, saltStore, tracker);
-		cachingStore.start(null, true);
+		File f = new File(tempDir, "saltstore");
+		try (SaltedHashFreenetStore<CHKBlock> saltStore = SaltedHashFreenetStore.construct(f, "testCachingFreenetStoreCHK",
+				store, weakPRNG, 10, false, SemiOrderedShutdownHook.get(), true, true, ticker, null)) {
+			CachingFreenetStoreTracker tracker = new CachingFreenetStoreTracker(cachingFreenetStoreMaxSize,
+					cachingFreenetStorePeriod, ticker);
+			try (CachingFreenetStore<CHKBlock> cachingStore = new CachingFreenetStore<CHKBlock>(store, saltStore, tracker)) {
+				cachingStore.start(null, true);
 
-		for(int i=0;i<5;i++) {
-			String test = "test" + i;
-			ClientCHKBlock block = encodeBlockCHK(test);
-			store.put(block.getBlock(), false);
-			ClientCHK key = block.getClientKey();
-			// Check that it's in the cache, *not* the underlying store.
-			assertEquals(saltStore.fetch(key.getRoutingKey(), key.getNodeCHK().getFullKey(), false, false, false, false, null), null);
-			CHKBlock verify = store.fetch(key.getNodeCHK(), false, false, null);
-			String data = decodeBlockCHK(verify, key);
-			assertEquals(test, data);
+				for (int i = 0; i < 5; i++) {
+					String test = "test" + i;
+					ClientCHKBlock block = encodeBlockCHK(test);
+					store.put(block.getBlock(), false);
+
+					ClientCHK key = block.getClientKey();
+					// Check that it's in the cache, *not* the underlying store.
+					assertEquals(null, saltStore.fetch(key.getRoutingKey(), key.getNodeCHK().getFullKey(), false, false, false, false, null));
+					CHKBlock verify = store.fetch(key.getNodeCHK(), false, false, null);
+					String data = decodeBlockCHK(verify, key);
+					assertEquals(test, data);
+				}
+			}
 		}
-
-		cachingStore.close();
 	}
 
-	/* Check that if the size limit is 0 (and therefore presumably if it is smaller than the key being
-	 * cached), we will pass through immediately. */
+	/*
+	 * Check that if the size limit is 0 (and therefore presumably if it is smaller
+	 * than the key being cached), we will pass through immediately.
+	 */
 	public void testZeroSize() throws IOException, CHKEncodeException, CHKVerifyException, CHKDecodeException {
+
 		File f = new File(tempDir, "saltstore");
-		FileUtil.removeAll(f);
-
 		CHKStore store = new CHKStore();
-		SaltedHashFreenetStore<CHKBlock> saltStore = SaltedHashFreenetStore.construct(f, "testCachingFreenetStoreCHK", store, weakPRNG, 10, false, SemiOrderedShutdownHook.get(), true, true, ticker, null);
-		CachingFreenetStoreTracker tracker = new CachingFreenetStoreTracker(0, cachingFreenetStorePeriod, ticker);
-		CachingFreenetStore<CHKBlock> cachingStore = new CachingFreenetStore<CHKBlock>(store, saltStore, tracker);
-		cachingStore.start(null, true);
+		try (SaltedHashFreenetStore<CHKBlock> saltStore = SaltedHashFreenetStore.construct(f, "testCachingFreenetStoreCHK",
+				store, weakPRNG, 10, false, SemiOrderedShutdownHook.get(), true, true, ticker, null)) {
+			CachingFreenetStoreTracker tracker = new CachingFreenetStoreTracker(0, cachingFreenetStorePeriod, ticker);
+			try (CachingFreenetStore<CHKBlock> cachingStore = new CachingFreenetStore<CHKBlock>(store, saltStore, tracker)) {
+				cachingStore.start(null, true);
 
-		for(int i=0;i<5;i++) {
-			String test = "test" + i;
-			ClientCHKBlock block = encodeBlockCHK(test);
-			store.put(block.getBlock(), false);
-			ClientCHK key = block.getClientKey();
-			// It should pass straight through.
-			assertNotNull(saltStore.fetch(key.getRoutingKey(), key.getNodeCHK().getFullKey(), false, false, false, false, null));
-			CHKBlock verify = store.fetch(key.getNodeCHK(), false, false, null);
-			String data = decodeBlockCHK(verify, key);
-			assertEquals(test, data);
+				for (int i = 0; i < 5; i++) {
+					String test = "test" + i;
+					ClientCHKBlock block = encodeBlockCHK(test);
+					store.put(block.getBlock(), false);
+
+					ClientCHK key = block.getClientKey();
+					// It should pass straight through.
+					assertNotNull( saltStore.fetch(key.getRoutingKey(), key.getNodeCHK().getFullKey(), false, false, false, false, null));
+					CHKBlock verify = store.fetch(key.getNodeCHK(), false, false, null);
+					String data = decodeBlockCHK(verify, key);
+					assertEquals(test, data);
+				}
+			}
 		}
-
-		cachingStore.close();
 	}
 
 	class WaitableCachingFreenetStoreTracker extends CachingFreenetStoreTracker {
-	    /* Don't reuse (this), avoid changing locking behaviour of parent class */
-	    private final Object sync = new Object();
+		/* Don't reuse (this), avoid changing locking behaviour of parent class */
+		private final Object sync = new Object();
 
-	    public WaitableCachingFreenetStoreTracker(long cachingFreenetStoreMaxSize,
-                long cachingFreenetStorePeriod, Ticker ticker) {
-	        super(cachingFreenetStoreMaxSize, cachingFreenetStorePeriod, ticker);
-        }
+		public WaitableCachingFreenetStoreTracker(long cachingFreenetStoreMaxSize, long cachingFreenetStorePeriod,
+				Ticker ticker) {
+			super(cachingFreenetStoreMaxSize, cachingFreenetStorePeriod, ticker);
+		}
 
-        @Override
-	    void pushAllCachingStores() {
-	        super.pushAllCachingStores();
-	        synchronized(sync) {
-	            sync.notifyAll();
-	        }
-	    }
+		@Override
+		void pushAllCachingStores() {
+			super.pushAllCachingStores();
+			synchronized (sync) {
+				sync.notifyAll();
+			}
+		}
 
-        public void waitForZero() throws InterruptedException {
-            synchronized(sync) {
-                while(getSizeOfCache() > 0)
-                    sync.wait();
-            }
-        }
-
+		public void waitForZero() throws InterruptedException {
+			synchronized (sync) {
+				while (getSizeOfCache() > 0)
+					sync.wait();
+			}
+		}
 	}
 
-	/* Check that if we are going over the maximum size, the caching store will call pushAll and all blocks is in the
-	 *  *undelying* store and the size is 0
+	/*
+	 * Check that if we are going over the maximum size, the caching store will call
+	 * pushAll and all blocks is in the *undelying* store and the size is 0
 	 */
-	public void testOverMaximumSize() throws IOException, CHKEncodeException, CHKVerifyException, CHKDecodeException, InterruptedException {
+	public void testOverMaximumSize()
+			throws IOException, CHKEncodeException, CHKVerifyException, CHKDecodeException, InterruptedException {
 		File f = new File(tempDir, "saltstore");
-		FileUtil.removeAll(f);
 
 		String test = "test0";
 		ClientCHKBlock block = encodeBlockCHK(test);
 		byte[] data = block.getBlock().getRawData();
 		byte[] header = block.getBlock().getRawHeaders();
 		byte[] routingKey = block.getBlock().getRoutingKey();
-		long sizeBlock = data.length+header.length+block.getBlock().getFullKey().length+routingKey.length;
-		long sumSizeBlock = sizeBlock;
+		long sizeBlock = data.length + header.length + block.getBlock().getFullKey().length + routingKey.length;
 		int howManyBlocks = ((int) (cachingFreenetStoreMaxSize / sizeBlock)) + 1;
 
 		CHKStore store = new CHKStore();
 
-		// SaltedHashFreenetStore is lossy, since it only has 5 possible places to put each
-		// key. So if you want to be 100% sure it doesn't lose any keys you need to give it
-		// 5x the number of slots as the keys you are putting in. For small stores you can
-		// get away with smaller numbers.
-		SaltedHashFreenetStore<CHKBlock> saltStore = SaltedHashFreenetStore.construct(f, "testCachingFreenetStoreCHK", store, weakPRNG, howManyBlocks*5, false, SemiOrderedShutdownHook.get(), true, true, ticker, null);
-		WaitableCachingFreenetStoreTracker tracker = new WaitableCachingFreenetStoreTracker(cachingFreenetStoreMaxSize, cachingFreenetStorePeriod, ticker);
-		CachingFreenetStore<CHKBlock> cachingStore = new CachingFreenetStore<CHKBlock>(store, saltStore, tracker);
-		cachingStore.start(null, true);
-		List<ClientCHKBlock> chkBlocks = new ArrayList<ClientCHKBlock>();
-		List<String> tests = new ArrayList<String>();
+		try (SaltedHashFreenetStore<CHKBlock> saltStore = SaltedHashFreenetStore.construct(f, "testCachingFreenetStoreCHK",
+				store, weakPRNG, howManyBlocks * 5, false, SemiOrderedShutdownHook.get(), true, true, ticker, null)) {
+			WaitableCachingFreenetStoreTracker tracker = new WaitableCachingFreenetStoreTracker(cachingFreenetStoreMaxSize,
+					cachingFreenetStorePeriod, ticker);
+			try (CachingFreenetStore<CHKBlock> cachingStore = new CachingFreenetStore<CHKBlock>(store, saltStore, tracker)) {
+				cachingStore.start(null, true);
+				List<ClientCHKBlock> chkBlocks = new ArrayList<ClientCHKBlock>();
+				List<String> tests = new ArrayList<String>();
 
-		store.put(block.getBlock(), false);
-		chkBlocks.add(block);
-		tests.add(test);
+				store.put(block.getBlock(), false);
+				chkBlocks.add(block);
+				tests.add(test);
 
-		for(int i=1; i<howManyBlocks; i++) {
-			test = "test" + i;
-			block = encodeBlockCHK(test);
-			data = block.getBlock().getRawData();
-			header = block.getBlock().getRawHeaders();
-			routingKey = block.getBlock().getRoutingKey();
-			sizeBlock = data.length+header.length+block.getBlock().getFullKey().length+routingKey.length;
-			sumSizeBlock += sizeBlock;
-			store.put(block.getBlock(), false);
-			chkBlocks.add(block);
-			tests.add(test);
+				for (int i = 1; i < howManyBlocks; i++) {
+					test = "test" + i;
+					tests.add(test);
+
+					block = encodeBlockCHK(test);
+					store.put(block.getBlock(), false);
+					chkBlocks.add(block);
+				}
+
+				tracker.waitForZero();
+
+				boolean atLeastOneKey = false;
+				for (int i = 0; i < howManyBlocks; i++) {
+					test = tests.get(i);
+					block = chkBlocks.get(i);
+					ClientCHK key = block.getClientKey();
+
+					CHKBlock verifyInStore = saltStore.fetch(key.getRoutingKey(), key.getNodeCHK().getFullKey(), false, false,
+							false, false, null);
+					// Since SaltedHashFreenetStore is loosy, it might have been replaced in a
+					// collision
+					if (verifyInStore == null) {
+						continue;
+					}
+					// If its in the Store, it should be obtainable through the Cache
+					CHKBlock verify = store.fetch(key.getNodeCHK(), false, false, null);
+					String receivedData = decodeBlockCHK(verify, key);
+					assertEquals(test, receivedData);
+
+					atLeastOneKey = true;
+				}
+
+				assertTrue("At least one key should have matched", atLeastOneKey);
+			}
 		}
-
-		assertTrue(sumSizeBlock > cachingFreenetStoreMaxSize);
-
-		tracker.waitForZero();
-
-		for(int i=0; i<howManyBlocks; i++) {
-			test = tests.remove(0); //get the first element
-			block = chkBlocks.remove(0); //get the first element
-			ClientCHK key = block.getClientKey();
-			// It should pass straight through.
-			assertNotNull(saltStore.fetch(key.getRoutingKey(), key.getNodeCHK().getFullKey(), false, false, false, false, null));
-			CHKBlock verify = store.fetch(key.getNodeCHK(), false, false, null);
-			String receivedData = decodeBlockCHK(verify, key);
-			assertEquals(test, receivedData);
-		}
-
-		cachingStore.close();
 	}
 
-	public void testCollisionsOverMaximumSize() throws IOException, SSKEncodeException, InvalidCompressionCodecException, InterruptedException {
-
-		File f = new File(tempDir, "saltstore");
-		FileUtil.removeAll(f);
+	public void testCollisionsOverMaximumSize()
+			throws IOException, SSKEncodeException, InvalidCompressionCodecException, InterruptedException {
 		PubkeyStore pk = new PubkeyStore();
 		new RAMFreenetStore<DSAPublicKey>(pk, 10);
 		GetPubkey pubkeyCache = new SimpleGetPubkey(pk);
@@ -241,347 +249,419 @@ public class CachingFreenetStoreTest extends TestCase {
 		int sskBlockSize = store.getTotalBlockSize();
 
 		// Create a cache with size limit of 1.5 SSK's.
-
-		SaltedHashFreenetStore<SSKBlock> saltStore = SaltedHashFreenetStore.construct(f, "testCachingFreenetStoreSSK", store, weakPRNG, 20, true, SemiOrderedShutdownHook.get(), true, true, ticker, null);
-		WaitableCachingFreenetStoreTracker tracker = new WaitableCachingFreenetStoreTracker((sskBlockSize * 3) / 2, cachingFreenetStorePeriod, ticker);
-		CachingFreenetStore<SSKBlock> cachingStore = new CachingFreenetStore<SSKBlock>(store, saltStore, tracker);
-		cachingStore.start(null, true);
-		RandomSource random = new DummyRandomSource(12345);
-
-		final int CRYPTO_KEY_LENGTH = 32;
-		byte[] ckey = new byte[CRYPTO_KEY_LENGTH];
-		random.nextBytes(ckey);
-		DSAGroup g = Global.DSAgroupBigA;
-		DSAPrivateKey privKey = new DSAPrivateKey(g, random);
-		DSAPublicKey pubKey = new DSAPublicKey(g, privKey);
-		byte[] pkHash = SHA256.digest(pubKey.asBytes());
-		String docName = "myDOC";
-		InsertableClientSSK ik = new InsertableClientSSK(docName, pkHash, pubKey, privKey, ckey, Key.ALGO_AES_PCFB_256_SHA256);
-
-		// Write one key to the store.
-
-		String test = "test";
-		SimpleReadOnlyArrayBucket bucket = new SimpleReadOnlyArrayBucket(test.getBytes("UTF-8"));
-		ClientSSKBlock block = ik.encode(bucket, false, false, (short)-1, bucket.size(), random, Compressor.DEFAULT_COMPRESSORDESCRIPTOR);
-		SSKBlock sskBlock = (SSKBlock) block.getBlock();
-		pubkeyCache.cacheKey(sskBlock.getKey().getPubKeyHash(), sskBlock.getPubKey(), false, false, false, false, false);
-		try {
-			store.put(sskBlock, false, false);
-		} catch (KeyCollisionException e1) {
-			fail();
-		}
-
-		assertTrue(tracker.getSizeOfCache() == sskBlockSize);
-
-		// Write a colliding key.
-		test = "test1";
-		bucket = new SimpleReadOnlyArrayBucket(test.getBytes("UTF-8"));
-		block = ik.encode(bucket, false, false, (short)-1, bucket.size(), random, Compressor.DEFAULT_COMPRESSORDESCRIPTOR);
-		sskBlock = (SSKBlock) block.getBlock();
-		try {
-			store.put(sskBlock, false, false);
-			fail();
-		} catch (KeyCollisionException e) {
-			// Expected.
-		}
-		try {
-			store.put(sskBlock, true, false);
-		} catch (KeyCollisionException e) {
-			fail();
-		}
-
-		// Size is still one key.
-		assertTrue(tracker.getSizeOfCache() == sskBlockSize);
-
-		// Write a second key, should trigger write to disk.
-		DSAPrivateKey privKey2 = new DSAPrivateKey(g, random);
-		DSAPublicKey pubKey2 = new DSAPublicKey(g, privKey2);
-		byte[] pkHash2 = SHA256.digest(pubKey2.asBytes());
-		InsertableClientSSK ik2 = new InsertableClientSSK(docName, pkHash2, pubKey2, privKey2, ckey, Key.ALGO_AES_PCFB_256_SHA256);
-		block = ik2.encode(bucket, false, false, (short)-1, bucket.size(), random, Compressor.DEFAULT_COMPRESSORDESCRIPTOR);
-		SSKBlock sskBlock2 = (SSKBlock) block.getBlock();
-		pubkeyCache.cacheKey(sskBlock2.getKey().getPubKeyHash(), sskBlock2.getPubKey(), false, false, false, false, false);
-
-		try {
-			store.put(sskBlock2, false, false);
-		} catch (KeyCollisionException e) {
-			fail();
-		}
-
-		// Wait for it to write to disk.
-		tracker.waitForZero();
-
-		assertTrue(store.fetch(sskBlock.getKey(), false, false, false, false, null).equals(sskBlock));
-		assertTrue(store.fetch(sskBlock2.getKey(), false, false, false, false, null).equals(sskBlock2));
-	}
-
-	public void testSimpleManualWrite() throws IOException, SSKEncodeException, InvalidCompressionCodecException, InterruptedException {
-
 		File f = new File(tempDir, "saltstore");
-		FileUtil.removeAll(f);
-		PubkeyStore pk = new PubkeyStore();
-		new RAMFreenetStore<DSAPublicKey>(pk, 10);
-		GetPubkey pubkeyCache = new SimpleGetPubkey(pk);
-		SSKStore store = new SSKStore(pubkeyCache);
-		int sskBlockSize = store.getTotalBlockSize();
+		try (SaltedHashFreenetStore<SSKBlock> saltStore = SaltedHashFreenetStore.construct(f, "testCachingFreenetStoreSSK",
+				store, weakPRNG, 20, true, SemiOrderedShutdownHook.get(), true, true, ticker, null)) {
+			WaitableCachingFreenetStoreTracker tracker = new WaitableCachingFreenetStoreTracker((sskBlockSize * 3) / 2,
+					cachingFreenetStorePeriod, ticker);
+			try (CachingFreenetStore<SSKBlock> cachingStore = new CachingFreenetStore<SSKBlock>(store, saltStore, tracker)) {
+				cachingStore.start(null, true);
+				RandomSource random = new DummyRandomSource(12345);
 
-		SaltedHashFreenetStore<SSKBlock> saltStore = SaltedHashFreenetStore.construct(f, "testCachingFreenetStoreSSK", store, weakPRNG, 20, true, SemiOrderedShutdownHook.get(), true, true, ticker, null);
-		CachingFreenetStoreTracker tracker = new CachingFreenetStoreTracker((sskBlockSize * 3), cachingFreenetStorePeriod, ticker);
-		CachingFreenetStore<SSKBlock> cachingStore = new CachingFreenetStore<SSKBlock>(store, saltStore, tracker);
-		cachingStore.start(null, true);
-		RandomSource random = new DummyRandomSource(12345);
+				final int CRYPTO_KEY_LENGTH = 32;
+				byte[] ckey = new byte[CRYPTO_KEY_LENGTH];
+				random.nextBytes(ckey);
+				DSAGroup g = Global.DSAgroupBigA;
+				DSAPrivateKey privKey = new DSAPrivateKey(g, random);
+				DSAPublicKey pubKey = new DSAPublicKey(g, privKey);
+				byte[] pkHash = SHA256.digest(pubKey.asBytes());
+				String docName = "myDOC";
+				InsertableClientSSK ik = new InsertableClientSSK(docName, pkHash, pubKey, privKey, ckey,
+						Key.ALGO_AES_PCFB_256_SHA256);
 
-		final int CRYPTO_KEY_LENGTH = 32;
-		byte[] ckey = new byte[CRYPTO_KEY_LENGTH];
-		random.nextBytes(ckey);
-		DSAGroup g = Global.DSAgroupBigA;
-		DSAPrivateKey privKey = new DSAPrivateKey(g, random);
-		DSAPublicKey pubKey = new DSAPublicKey(g, privKey);
-		byte[] pkHash = SHA256.digest(pubKey.asBytes());
-		String docName = "myDOC";
-		InsertableClientSSK ik = new InsertableClientSSK(docName, pkHash, pubKey, privKey, ckey, Key.ALGO_AES_PCFB_256_SHA256);
+				// Write one key to the store.
 
-		// Nothing to write.
-		assertTrue(tracker.getSizeOfCache() == 0);
-		assert(cachingStore.pushLeastRecentlyBlock() == -1);
+				String test = "test";
+				SimpleReadOnlyArrayBucket bucket = new SimpleReadOnlyArrayBucket(test.getBytes("UTF-8"));
+				ClientSSKBlock block = ik.encode(bucket, false, false, (short) -1, bucket.size(), random,
+						Compressor.DEFAULT_COMPRESSORDESCRIPTOR);
+				SSKBlock sskBlock = (SSKBlock) block.getBlock();
+				pubkeyCache.cacheKey(sskBlock.getKey().getPubKeyHash(), sskBlock.getPubKey(), false, false, false, false,
+						false);
+				try {
+					store.put(sskBlock, false, false);
+				} catch (KeyCollisionException e1) {
+					fail();
+				}
 
-		// Write one key to the store.
+				assertEquals(sskBlockSize, tracker.getSizeOfCache());
 
-		String test = "test";
-		SimpleReadOnlyArrayBucket bucket = new SimpleReadOnlyArrayBucket(test.getBytes("UTF-8"));
-		ClientSSKBlock block = ik.encode(bucket, false, false, (short)-1, bucket.size(), random, Compressor.DEFAULT_COMPRESSORDESCRIPTOR);
-		SSKBlock sskBlock = (SSKBlock) block.getBlock();
-		pubkeyCache.cacheKey(sskBlock.getKey().getPubKeyHash(), sskBlock.getPubKey(), false, false, false, false, false);
-		try {
-			store.put(sskBlock, false, false);
-		} catch (KeyCollisionException e1) {
-			fail();
-		}
+				// Write a colliding key.
+				test = "test1";
+				bucket = new SimpleReadOnlyArrayBucket(test.getBytes("UTF-8"));
+				block = ik.encode(bucket, false, false, (short) -1, bucket.size(), random,
+						Compressor.DEFAULT_COMPRESSORDESCRIPTOR);
+				sskBlock = (SSKBlock) block.getBlock();
+				try {
+					store.put(sskBlock, false, false);
+					fail();
+				} catch (KeyCollisionException e) {
+					// Expected.
+				}
+				try {
+					store.put(sskBlock, true, false);
+				} catch (KeyCollisionException e) {
+					fail();
+				}
 
-		// Write.
-		assertEquals(tracker.getSizeOfCache(), sskBlockSize);
-		assertEquals(cachingStore.pushLeastRecentlyBlock(), sskBlockSize);
+				// Size is still one key.
+				assertEquals(sskBlockSize, tracker.getSizeOfCache());
 
-		// Nothing to write.
-		assertEquals(cachingStore.pushLeastRecentlyBlock(), -1);
-	}
+				// Write a second key, should trigger write to disk.
+				DSAPrivateKey privKey2 = new DSAPrivateKey(g, random);
+				DSAPublicKey pubKey2 = new DSAPublicKey(g, privKey2);
+				byte[] pkHash2 = SHA256.digest(pubKey2.asBytes());
+				InsertableClientSSK ik2 = new InsertableClientSSK(docName, pkHash2, pubKey2, privKey2, ckey,
+						Key.ALGO_AES_PCFB_256_SHA256);
+				block = ik2.encode(bucket, false, false, (short) -1, bucket.size(), random,
+						Compressor.DEFAULT_COMPRESSORDESCRIPTOR);
+				SSKBlock sskBlock2 = (SSKBlock) block.getBlock();
+				pubkeyCache.cacheKey(sskBlock2.getKey().getPubKeyHash(), sskBlock2.getPubKey(), false, false, false, false,
+						false);
 
-	/** pushLeastRecentlyBlock() with collisions:
-	 * Lock { Grab a block for key K. (Do not remove it) }
-	 * Write the block.
-	 * Lock { Detected a different block for key K. Return 0 rather than removing it. }
-	 */
-	public void testManualWriteCollision() throws IOException, SSKEncodeException, InvalidCompressionCodecException, InterruptedException, ExecutionException {
+				try {
+					store.put(sskBlock2, false, false);
+				} catch (KeyCollisionException e) {
+					fail();
+				}
 
-		File f = new File(tempDir, "saltstore");
-		FileUtil.removeAll(f);
-		PubkeyStore pk = new PubkeyStore();
-		new RAMFreenetStore<DSAPublicKey>(pk, 10);
-		GetPubkey pubkeyCache = new SimpleGetPubkey(pk);
-		SSKStore store = new SSKStore(pubkeyCache);
-		int sskBlockSize = store.getTotalBlockSize();
+				// Wait for it to write to disk.
+				tracker.waitForZero();
 
-		SaltedHashFreenetStore<SSKBlock> saltStore = SaltedHashFreenetStore.construct(f, "testCachingFreenetStoreSSK", store, weakPRNG, 20, true, SemiOrderedShutdownHook.get(), true, true, ticker, null);
-		// Don't let the write complete until we say so...
-		WriteBlockableFreenetStore<SSKBlock> delayStore = new WriteBlockableFreenetStore<SSKBlock>(saltStore, true);
-		CachingFreenetStoreTracker tracker = new CachingFreenetStoreTracker((sskBlockSize * 3), cachingFreenetStorePeriod, ticker);
-		final CachingFreenetStore<SSKBlock> cachingStore = new CachingFreenetStore<SSKBlock>(store, delayStore, tracker);
-		cachingStore.start(null, true);
-		RandomSource random = new DummyRandomSource(12345);
-
-		final int CRYPTO_KEY_LENGTH = 32;
-		byte[] ckey = new byte[CRYPTO_KEY_LENGTH];
-		random.nextBytes(ckey);
-		DSAGroup g = Global.DSAgroupBigA;
-		DSAPrivateKey privKey = new DSAPrivateKey(g, random);
-		DSAPublicKey pubKey = new DSAPublicKey(g, privKey);
-		byte[] pkHash = SHA256.digest(pubKey.asBytes());
-		String docName = "myDOC";
-		InsertableClientSSK ik = new InsertableClientSSK(docName, pkHash, pubKey, privKey, ckey, Key.ALGO_AES_PCFB_256_SHA256);
-
-		// Nothing to write.
-		assertTrue(tracker.getSizeOfCache() == 0);
-		assertEquals(cachingStore.pushLeastRecentlyBlock(), -1);
-
-		// Write one key to the cache. It will not be written through to disk.
-		String test = "test";
-		SimpleReadOnlyArrayBucket bucket = new SimpleReadOnlyArrayBucket(test.getBytes("UTF-8"));
-		ClientSSKBlock block = ik.encode(bucket, false, false, (short)-1, bucket.size(), random, Compressor.DEFAULT_COMPRESSORDESCRIPTOR);
-		SSKBlock sskBlock = (SSKBlock) block.getBlock();
-		pubkeyCache.cacheKey(sskBlock.getKey().getPubKeyHash(), sskBlock.getPubKey(), false, false, false, false, false);
-		try {
-			store.put(sskBlock, false, false);
-		} catch (KeyCollisionException e1) {
-			fail();
-		}
-
-		FutureTask<Long> future = new FutureTask<Long>(new Callable<Long>() {
-
-			@Override
-			public Long call() throws Exception {
-				return cachingStore.pushLeastRecentlyBlock();
+				assertTrue(store.fetch(sskBlock.getKey(), false, false, false, false, null).equals(sskBlock));
+				assertTrue(store.fetch(sskBlock2.getKey(), false, false, false, false, null).equals(sskBlock2));
 			}
-
-		});
-		Executors.newCachedThreadPool().execute(future);
-
-		delayStore.waitForSomeBlocked();
-
-		// Write colliding key. Should cause the write above to return 0: After it unlocks, it will see
-		// there is a new, different block for that key, and therefore it cannot remove the block, and
-		// thus must return 0.
-		test = "test1";
-		bucket = new SimpleReadOnlyArrayBucket(test.getBytes("UTF-8"));
-		block = ik.encode(bucket, false, false, (short)-1, bucket.size(), random, Compressor.DEFAULT_COMPRESSORDESCRIPTOR);
-		SSKBlock sskBlock2 = (SSKBlock) block.getBlock();
-		try {
-			store.put(sskBlock2, false, false);
-			fail();
-		} catch (KeyCollisionException e) {
-			// Expected.
 		}
-		try {
-			store.put(sskBlock2, true, false);
-		} catch (KeyCollisionException e) {
-			fail();
+	}
+
+	public void testSimpleManualWrite()
+			throws IOException, SSKEncodeException, InvalidCompressionCodecException, InterruptedException {
+
+		PubkeyStore pk = new PubkeyStore();
+		new RAMFreenetStore<DSAPublicKey>(pk, 10);
+		GetPubkey pubkeyCache = new SimpleGetPubkey(pk);
+		SSKStore store = new SSKStore(pubkeyCache);
+		int sskBlockSize = store.getTotalBlockSize();
+
+		File f = new File(tempDir, "saltstore");
+		try (SaltedHashFreenetStore<SSKBlock> saltStore = SaltedHashFreenetStore.construct(f, "testCachingFreenetStoreSSK",
+				store, weakPRNG, 20, true, SemiOrderedShutdownHook.get(), true, true, ticker, null)) {
+			CachingFreenetStoreTracker tracker = new CachingFreenetStoreTracker((sskBlockSize * 3), cachingFreenetStorePeriod,
+					ticker);
+			try (CachingFreenetStore<SSKBlock> cachingStore = new CachingFreenetStore<SSKBlock>(store, saltStore, tracker)) {
+				cachingStore.start(null, true);
+				RandomSource random = new DummyRandomSource(12345);
+
+				final int CRYPTO_KEY_LENGTH = 32;
+				byte[] ckey = new byte[CRYPTO_KEY_LENGTH];
+				random.nextBytes(ckey);
+				DSAGroup g = Global.DSAgroupBigA;
+				DSAPrivateKey privKey = new DSAPrivateKey(g, random);
+				DSAPublicKey pubKey = new DSAPublicKey(g, privKey);
+				byte[] pkHash = SHA256.digest(pubKey.asBytes());
+				String docName = "myDOC";
+				InsertableClientSSK ik = new InsertableClientSSK(docName, pkHash, pubKey, privKey, ckey,
+						Key.ALGO_AES_PCFB_256_SHA256);
+
+				// Nothing to write.
+				assertTrue(tracker.getSizeOfCache() == 0);
+				assert (cachingStore.pushLeastRecentlyBlock() == -1);
+
+				// Write one key to the store.
+
+				String test = "test";
+				SimpleReadOnlyArrayBucket bucket = new SimpleReadOnlyArrayBucket(test.getBytes("UTF-8"));
+				ClientSSKBlock block = ik.encode(bucket, false, false, (short) -1, bucket.size(), random,
+						Compressor.DEFAULT_COMPRESSORDESCRIPTOR);
+				SSKBlock sskBlock = (SSKBlock) block.getBlock();
+				pubkeyCache.cacheKey(sskBlock.getKey().getPubKeyHash(), sskBlock.getPubKey(), false, false, false, false,
+						false);
+				try {
+					store.put(sskBlock, false, false);
+				} catch (KeyCollisionException e1) {
+					fail();
+				}
+
+				// Write.
+				assertEquals(tracker.getSizeOfCache(), sskBlockSize);
+				assertEquals(cachingStore.pushLeastRecentlyBlock(), sskBlockSize);
+
+				// Nothing to write.
+				assertEquals(cachingStore.pushLeastRecentlyBlock(), -1);
+			}
 		}
+	}
 
-		// Size is still one key.
-		assertTrue(tracker.getSizeOfCache() == sskBlockSize);
+	/**
+	 * pushLeastRecentlyBlock() with collisions: Lock { Grab a block for key K. (Do
+	 * not remove it) } Write the block. Lock { Detected a different block for key
+	 * K. Return 0 rather than removing it. }
+	 */
+	public void testManualWriteCollision() throws IOException, SSKEncodeException, InvalidCompressionCodecException,
+			InterruptedException, ExecutionException {
 
-		// Now let the write through.
-		delayStore.setBlocked(false);
+		PubkeyStore pk = new PubkeyStore();
+		RAMFreenetStore<DSAPublicKey> ramFreenetStore = new RAMFreenetStore<DSAPublicKey>(pk, 10);
+		pk.setStore(ramFreenetStore);
 
-		assertEquals(future.get().longValue(), 0L);
-		NodeSSK key = sskBlock.getKey();
-		assertTrue(saltStore.fetch(key.getRoutingKey(), key.getFullKey(), false, false, false, false, null).equals(sskBlock));
-		assertTrue(store.fetch(key, false, false, false, false, null).equals(sskBlock2));
+		GetPubkey pubkeyCache = new SimpleGetPubkey(pk);
+		SSKStore store = new SSKStore(pubkeyCache);
+		int sskBlockSize = store.getTotalBlockSize();
 
-		// Still needs writing.
-		assertEquals(cachingStore.pushLeastRecentlyBlock(), sskBlockSize);
-		assertTrue(store.fetch(key, false, false, false, false, null).equals(sskBlock2));
+		File f = new File(tempDir, "saltstore");
+		try (SaltedHashFreenetStore<SSKBlock> saltStore = SaltedHashFreenetStore.construct(f, "testCachingFreenetStoreSSK",
+				store, weakPRNG, 20, true, SemiOrderedShutdownHook.get(), true, true, ticker, null)) {
+			// Don't let the write complete until we say so...
+			WriteBlockableFreenetStore<SSKBlock> delayStore = new WriteBlockableFreenetStore<SSKBlock>(saltStore, true);
+			CachingFreenetStoreTracker tracker = new CachingFreenetStoreTracker((sskBlockSize * 3), cachingFreenetStorePeriod,
+					ticker);
+			try (final CachingFreenetStore<SSKBlock> cachingStore = new CachingFreenetStore<SSKBlock>(store, delayStore,
+					tracker)) {
+				cachingStore.start(null, true);
+				RandomSource random = new DummyRandomSource(12345);
+
+				final int CRYPTO_KEY_LENGTH = 32;
+				byte[] ckey = new byte[CRYPTO_KEY_LENGTH];
+				random.nextBytes(ckey);
+				DSAGroup g = Global.DSAgroupBigA;
+				DSAPrivateKey privKey = new DSAPrivateKey(g, random);
+				DSAPublicKey pubKey = new DSAPublicKey(g, privKey);
+				byte[] pkHash = SHA256.digest(pubKey.asBytes());
+				String docName = "myDOC";
+				InsertableClientSSK ik = new InsertableClientSSK(docName, pkHash, pubKey, privKey, ckey,
+						Key.ALGO_AES_PCFB_256_SHA256);
+
+				// Nothing to write.
+				assertTrue(tracker.getSizeOfCache() == 0);
+				assertEquals(cachingStore.pushLeastRecentlyBlock(), -1);
+
+				// Write one key to the cache. It will not be written through to disk.
+				String test = "test";
+				SimpleReadOnlyArrayBucket bucket = new SimpleReadOnlyArrayBucket(test.getBytes("UTF-8"));
+				ClientSSKBlock block = ik.encode(bucket, false, false, (short) -1, bucket.size(), random,
+						Compressor.DEFAULT_COMPRESSORDESCRIPTOR);
+				SSKBlock sskBlock = (SSKBlock) block.getBlock();
+				pubkeyCache.cacheKey(sskBlock.getKey().getPubKeyHash(), sskBlock.getPubKey(), false, false, false, false,
+						false);
+				try {
+					store.put(sskBlock, false, false);
+				} catch (KeyCollisionException e1) {
+					fail();
+				}
+
+				FutureTask<Long> future = new FutureTask<Long>(new Callable<Long>() {
+
+					@Override
+					public Long call() throws Exception {
+						return cachingStore.pushLeastRecentlyBlock();
+					}
+
+				});
+				Executors.newCachedThreadPool().execute(future);
+
+				delayStore.waitForSomeBlocked();
+
+				// Write colliding key. Should cause the write above to return 0: After it
+				// unlocks, it will see
+				// there is a new, different block for that key, and therefore it cannot remove
+				// the block, and
+				// thus must return 0.
+				test = "test1";
+				bucket = new SimpleReadOnlyArrayBucket(test.getBytes("UTF-8"));
+				block = ik.encode(bucket, false, false, (short) -1, bucket.size(), random,
+						Compressor.DEFAULT_COMPRESSORDESCRIPTOR);
+				SSKBlock sskBlock2 = (SSKBlock) block.getBlock();
+				try {
+					store.put(sskBlock2, false, false);
+					fail();
+				} catch (KeyCollisionException e) {
+					// Expected.
+				}
+				try {
+					store.put(sskBlock2, true, false);
+				} catch (KeyCollisionException e) {
+					fail();
+				}
+
+				// Size is still one key.
+				assertTrue(tracker.getSizeOfCache() == sskBlockSize);
+
+				// Now let the write through.
+				delayStore.setBlocked(false);
+
+				assertEquals(future.get().longValue(), 0L);
+				NodeSSK key = sskBlock.getKey();
+				assertTrue(
+						saltStore.fetch(key.getRoutingKey(), key.getFullKey(), false, false, false, false, null).equals(sskBlock));
+				assertTrue(store.fetch(key, false, false, false, false, null).equals(sskBlock2));
+
+				// Still needs writing.
+				assertEquals(cachingStore.pushLeastRecentlyBlock(), sskBlockSize);
+				assertTrue(store.fetch(key, false, false, false, false, null).equals(sskBlock2));
+			}
+		}
 	}
 
 	/* Simple test with SSK for CachingFreenetStore */
-	public void testSimpleSSK() throws IOException, KeyCollisionException, SSKVerifyException, KeyDecodeException, SSKEncodeException, InvalidCompressionCodecException {
-		File f = new File(tempDir, "saltstore");
-		FileUtil.removeAll(f);
+	public void testSimpleSSK() throws IOException, KeyCollisionException, SSKVerifyException, KeyDecodeException,
+			SSKEncodeException, InvalidCompressionCodecException {
 
 		final int keys = 5;
 		PubkeyStore pk = new PubkeyStore();
-		new RAMFreenetStore<DSAPublicKey>(pk, keys);
+		RAMFreenetStore<DSAPublicKey> ramFreenetStore = new RAMFreenetStore<DSAPublicKey>(pk, keys);
+		pk.setStore(ramFreenetStore);
+
 		GetPubkey pubkeyCache = new SimpleGetPubkey(pk);
 		SSKStore store = new SSKStore(pubkeyCache);
-		SaltedHashFreenetStore<SSKBlock> saltStore = SaltedHashFreenetStore.construct(f, "testCachingFreenetStoreSSK", store, weakPRNG, 20, true, SemiOrderedShutdownHook.get(), true, true, ticker, null);
-		CachingFreenetStoreTracker tracker = new CachingFreenetStoreTracker(cachingFreenetStoreMaxSize, cachingFreenetStorePeriod, ticker);
-		CachingFreenetStore<SSKBlock> cachingStore = new CachingFreenetStore<SSKBlock>(store, saltStore, tracker);
-		cachingStore.start(null, true);
-		RandomSource random = new DummyRandomSource(12345);
+		File f = new File(tempDir, "saltstore");
+		try (SaltedHashFreenetStore<SSKBlock> saltStore = SaltedHashFreenetStore.construct(f, "testCachingFreenetStoreSSK",
+				store, weakPRNG, 20, true, SemiOrderedShutdownHook.get(), true, true, ticker, null)) {
+			CachingFreenetStoreTracker tracker = new CachingFreenetStoreTracker(cachingFreenetStoreMaxSize,
+					cachingFreenetStorePeriod, ticker);
+			try (CachingFreenetStore<SSKBlock> cachingStore = new CachingFreenetStore<SSKBlock>(store, saltStore, tracker)) {
+				cachingStore.start(null, true);
+				RandomSource random = new DummyRandomSource(12345);
 
-		for(int i=0;i<5;i++) {
-			String test = "test" + i;
-			ClientSSKBlock block = encodeBlockSSK(test, random);
-			SSKBlock sskBlock = (SSKBlock) block.getBlock();
-			store.put(sskBlock, false, false);
-			ClientSSK key = block.getClientKey();
-			NodeSSK ssk = (NodeSSK) key.getNodeKey();
-			pubkeyCache.cacheKey(ssk.getPubKeyHash(), ssk.getPubKey(), false, false, false, false, false);
-			// Check that it's in the cache, *not* the underlying store.
-			assertEquals(saltStore.fetch(ssk.getRoutingKey(), ssk.getFullKey(), false, false, false, false, null), null);
-			SSKBlock verify = store.fetch(ssk, false, false, false, false, null);
-			String data = decodeBlockSSK(verify, key);
-			assertEquals(test, data);
+				for (int i = 0; i < 5; i++) {
+					String test = "test" + i;
+					ClientSSKBlock block = encodeBlockSSK(test, random);
+					SSKBlock sskBlock = (SSKBlock) block.getBlock();
+					store.put(sskBlock, false, false);
+
+					ClientSSK key = block.getClientKey();
+					NodeSSK ssk = (NodeSSK) key.getNodeKey();
+					pubkeyCache.cacheKey(ssk.getPubKeyHash(), ssk.getPubKey(), false, false, false, false, false);
+					// Check that it's in the cache, *not* the underlying store.
+					assertNull(saltStore.fetch(ssk.getRoutingKey(), ssk.getFullKey(), false, false, false, false, null));
+					SSKBlock verify = store.fetch(ssk, false, false, false, false, null);
+					String data = decodeBlockSSK(verify, key);
+					assertEquals(test, data);
+				}
+			}
 		}
-
-		cachingStore.close();
 	}
 
 	/* Test to re-open after close */
 	public void testOnCloseCHK() throws IOException, CHKEncodeException, CHKVerifyException, CHKDecodeException {
-		File f = new File(tempDir, "saltstore");
-		FileUtil.removeAll(f);
 
 		CHKStore store = new CHKStore();
-		SaltedHashFreenetStore<CHKBlock> saltStore = SaltedHashFreenetStore.construct(f, "testCachingFreenetStoreOnClose", store, weakPRNG, 10, false, SemiOrderedShutdownHook.get(), true, true, ticker, null);
-		CachingFreenetStoreTracker tracker = new CachingFreenetStoreTracker(cachingFreenetStoreMaxSize, cachingFreenetStorePeriod, ticker);
-		CachingFreenetStore<CHKBlock> cachingStore = new CachingFreenetStore<CHKBlock>(store, saltStore, tracker);
-		cachingStore.start(null, true);
-
-		List<ClientCHKBlock> chkBlocks = new ArrayList<ClientCHKBlock>();
+		File f = new File(tempDir, "saltstore");
 		List<String> tests = new ArrayList<String>();
+		List<ClientCHKBlock> chkBlocks = new ArrayList<ClientCHKBlock>();
+		CachingFreenetStoreTracker tracker = new CachingFreenetStoreTracker(cachingFreenetStoreMaxSize,
+				cachingFreenetStorePeriod, ticker);
 
-		for(int i=0;i<5;i++) {
-			String test = "test" + i;
-			ClientCHKBlock block = encodeBlockCHK(test);
-			// Check that it's in the cache, *not* the underlying store.
-			assertEquals(saltStore.fetch(block.getKey().getRoutingKey(), block.getKey().getFullKey(), false, false, false, false, null), null);
-			store.put(block.getBlock(), false);
-			tests.add(test);
-			chkBlocks.add(block);
+		try (SaltedHashFreenetStore<CHKBlock> saltStore = SaltedHashFreenetStore.construct(f,
+				"testCachingFreenetStoreOnClose", store, weakPRNG, 10, false, SemiOrderedShutdownHook.get(), true, true, ticker,
+				null)) {
+			try (CachingFreenetStore<CHKBlock> cachingStore = new CachingFreenetStore<CHKBlock>(store, saltStore, tracker)) {
+				cachingStore.start(null, true);
+
+				// Insert Keys
+				for (int i = 0; i < 5; i++) {
+					String test = "test" + i;
+					ClientCHKBlock block = encodeBlockCHK(test);
+					store.put(block.getBlock(), false);
+					tests.add(test);
+					chkBlocks.add(block);
+
+					// Check that it's in the cache, *not* the underlying store.
+					assertNull(saltStore.fetch(block.getKey().getRoutingKey(), block.getKey().getFullKey(), false, false, false,
+							false, null));
+				}
+			}
 		}
 
-		cachingStore.close();
+		store = new CHKStore();
+		try (SaltedHashFreenetStore<CHKBlock> saltStore2 = SaltedHashFreenetStore.construct(f,
+				"testCachingFreenetStoreOnClose", store, weakPRNG, 10, false, SemiOrderedShutdownHook.get(), true, true, ticker,
+				null)) {
+			try (CachingFreenetStore<CHKBlock> cachingStore = new CachingFreenetStore<CHKBlock>(store, saltStore2, tracker)) {
+				cachingStore.start(null, true);
 
-		SaltedHashFreenetStore<CHKBlock> saltStore2 = SaltedHashFreenetStore.construct(f, "testCachingFreenetStoreOnClose", store, weakPRNG, 10, false, SemiOrderedShutdownHook.get(), true, true, ticker, null);
-		cachingStore = new CachingFreenetStore<CHKBlock>(store, saltStore2, tracker);
-		cachingStore.start(null, true);
+				boolean atLeastOneKey = false;
+				for (int i = 0; i < 5; i++) {
+					ClientCHKBlock block = chkBlocks.get(i);
+					ClientCHK key = block.getClientKey();
+					CHKBlock verify = store.fetch(key.getNodeCHK(), false, false, null);
+					// Key might not be present because of collisions in store
+					if (verify == null) {
+						continue;
+					}
+					String data = decodeBlockCHK(verify, key);
+					String test = tests.get(i);
+					assertEquals(test, data);
 
-		for(int i=0;i<5;i++) {
-			String test = tests.remove(0); //get the first element
-			ClientCHKBlock block = chkBlocks.remove(0); //get the first element
-			ClientCHK key = block.getClientKey();
-			CHKBlock verify = store.fetch(key.getNodeCHK(), false, false, null);
-			String data = decodeBlockCHK(verify, key);
-			assertEquals(test, data);
+					// Check its really in the underlying store
+					assertNotNull(saltStore2.fetch(block.getKey().getRoutingKey(), block.getKey().getFullKey(), false, false,
+							false, false, null));
+
+					atLeastOneKey = true;
+				}
+				assertTrue("Atl least one Key should have been present in the store", atLeastOneKey);
+			}
 		}
-
-		cachingStore.close();
 	}
 
 	/* Test whether stuff gets written to disk after the caching period expires */
-	public void testTimeExpireCHK() throws IOException, CHKEncodeException, CHKVerifyException, CHKDecodeException, InterruptedException {
+	public void testTimeExpireCHK()
+			throws IOException, CHKEncodeException, CHKVerifyException, CHKDecodeException, InterruptedException {
 		File f = new File(tempDir, "saltstore");
-		FileUtil.removeAll(f);
 		long delay = 100;
 
 		CHKStore store = new CHKStore();
-		SaltedHashFreenetStore<CHKBlock> saltStore = SaltedHashFreenetStore.construct(f, "testCachingFreenetStoreTimeExpire", store, weakPRNG, 10, false, SemiOrderedShutdownHook.get(), true, true, ticker, null);
-		WaitableCachingFreenetStoreTracker tracker = new WaitableCachingFreenetStoreTracker(cachingFreenetStoreMaxSize, delay, ticker);
-		CachingFreenetStore<CHKBlock> cachingStore = new CachingFreenetStore<CHKBlock>(store, saltStore, tracker);
-		cachingStore.start(null, true);
+		try (SaltedHashFreenetStore<CHKBlock> saltStore = SaltedHashFreenetStore.construct(f,
+				"testCachingFreenetStoreTimeExpire", store, weakPRNG, 10, false, SemiOrderedShutdownHook.get(), true, true,
+				ticker, null)) {
+			WaitableCachingFreenetStoreTracker tracker = new WaitableCachingFreenetStoreTracker(cachingFreenetStoreMaxSize,
+					delay, ticker);
+			try (CachingFreenetStore<CHKBlock> cachingStore = new CachingFreenetStore<CHKBlock>(store, saltStore, tracker)) {
+				cachingStore.start(null, true);
 
-		List<ClientCHKBlock> chkBlocks = new ArrayList<ClientCHKBlock>();
-		List<String> tests = new ArrayList<String>();
+				List<ClientCHKBlock> chkBlocks = new ArrayList<ClientCHKBlock>();
+				List<String> tests = new ArrayList<String>();
 
-		// Put five chk blocks
-		for(int i=0;i<5;i++) {
-			String test = "test" + i;
-			ClientCHKBlock block = encodeBlockCHK(test);
-			store.put(block.getBlock(), false);
-			// Check that it's in the cache, *not* the underlying store.
-			assertEquals(saltStore.fetch(block.getKey().getRoutingKey(), block.getKey().getFullKey(), false, false, false, false, null), null);
-			tests.add(test);
-			chkBlocks.add(block);
+				// Put five chk blocks
+				for (int i = 0; i < 5; i++) {
+					String test = "test" + i;
+					tests.add(test);
+
+					ClientCHKBlock block = encodeBlockCHK(test);
+					chkBlocks.add(block);
+
+					store.put(block.getBlock(), false);
+					// Check that it's in the cache, *not* the underlying store.
+					assertEquals(saltStore.fetch(block.getKey().getRoutingKey(), block.getKey().getFullKey(), false, false, false,
+							false, null), null);
+				}
+
+				tracker.waitForZero();
+
+				boolean atLeastOneKey = false;
+				for (int i = 0; i < 5; i++) {
+					String test = tests.get(i);
+					ClientCHKBlock block = chkBlocks.get(i);
+					ClientCHK key = block.getClientKey();
+					CHKBlock verify = store.fetch(key.getNodeCHK(), false, false, null);
+					// Key might not be present because of collisions in store
+					if (verify == null) {
+						continue;
+					}
+					String data = decodeBlockCHK(verify, key);
+					assertEquals(test, data);
+					// Check that it's in the underlying store now.
+					assertNotNull(saltStore.fetch(block.getKey().getRoutingKey(), block.getKey().getFullKey(), false, false,
+							false, false, null));
+
+					atLeastOneKey = true;
+				}
+				assertTrue("Atl least one Key should have been present in the store", atLeastOneKey);
+			}
 		}
-
-		tracker.waitForZero();
-
-		//Fetch five chk blocks
-		for(int i=0; i<5; i++){
-			String test = tests.remove(0); //get the first element
-			ClientCHKBlock block = chkBlocks.remove(0); //get the first element
-			ClientCHK key = block.getClientKey();
-			CHKBlock verify = store.fetch(key.getNodeCHK(), false, false, null);
-			String data = decodeBlockCHK(verify, key);
-			assertEquals(test, data);
-			// Check that it's in the underlying store now.
-			assertNotNull(saltStore.fetch(block.getKey().getRoutingKey(), block.getKey().getFullKey(), false, false, false, false, null));
-		}
-
-		cachingStore.close();
 	}
 
-	private String decodeBlockCHK(CHKBlock verify, ClientCHK key) throws CHKVerifyException, CHKDecodeException, IOException {
+	private String decodeBlockCHK(CHKBlock verify, ClientCHK key)
+			throws CHKVerifyException, CHKDecodeException, IOException {
 		ClientCHKBlock cb = new ClientCHKBlock(verify, key);
 		Bucket output = cb.decode(new ArrayBucketFactory(), 32768, false);
 		byte[] buf = BucketTools.toByteArray(output);
@@ -591,204 +671,256 @@ public class CachingFreenetStoreTest extends TestCase {
 	private ClientCHKBlock encodeBlockCHK(String test) throws CHKEncodeException, IOException {
 		byte[] data = test.getBytes("UTF-8");
 		SimpleReadOnlyArrayBucket bucket = new SimpleReadOnlyArrayBucket(data);
-		return ClientCHKBlock.encode(bucket, false, false, (short)-1, bucket.size(), Compressor.DEFAULT_COMPRESSORDESCRIPTOR,
-        null, (byte)0);
+		return ClientCHKBlock.encode(bucket, false, false, (short) -1, bucket.size(),
+				Compressor.DEFAULT_COMPRESSORDESCRIPTOR, null, (byte) 0);
 	}
 
 	/* Test with SSK to re-open after close */
-	public void testOnCloseSSK() throws IOException, SSKEncodeException, InvalidCompressionCodecException, KeyCollisionException, SSKVerifyException, KeyDecodeException {
+	public void testOnCloseSSK() throws IOException, SSKEncodeException, InvalidCompressionCodecException,
+			KeyCollisionException, SSKVerifyException, KeyDecodeException {
 		File f = new File(tempDir, "saltstore");
-		FileUtil.removeAll(f);
 
 		final int keys = 5;
 		PubkeyStore pk = new PubkeyStore();
-		new RAMFreenetStore<DSAPublicKey>(pk, keys);
+		RAMFreenetStore<DSAPublicKey> ramFreenetStore = new RAMFreenetStore<DSAPublicKey>(pk, keys);
+		pk.setStore(ramFreenetStore);
 		GetPubkey pubkeyCache = new SimpleGetPubkey(pk);
 		SSKStore store = new SSKStore(pubkeyCache);
-		SaltedHashFreenetStore<SSKBlock> saltStore = SaltedHashFreenetStore.construct(f, "testCachingFreenetStoreOnCloseSSK", store, weakPRNG, 10, false, SemiOrderedShutdownHook.get(), true, true, ticker, null);
-		CachingFreenetStoreTracker tracker = new CachingFreenetStoreTracker(cachingFreenetStoreMaxSize, cachingFreenetStorePeriod, ticker);
-		CachingFreenetStore<SSKBlock> cachingStore = new CachingFreenetStore<SSKBlock>(store, saltStore, tracker);
-		cachingStore.start(null, true);
-		RandomSource random = new DummyRandomSource(12345);
 
 		List<ClientSSKBlock> sskBlocks = new ArrayList<ClientSSKBlock>();
 		List<String> tests = new ArrayList<String>();
+		CachingFreenetStoreTracker tracker = new CachingFreenetStoreTracker(cachingFreenetStoreMaxSize,
+				cachingFreenetStorePeriod, ticker);
 
-		for(int i=0;i<5;i++) {
-			String test = "test" + i;
-			ClientSSKBlock block = encodeBlockSSK(test, random);
-			SSKBlock sskBlock = (SSKBlock) block.getBlock();
-			store.put(sskBlock, false, false);
-			pubkeyCache.cacheKey(sskBlock.getKey().getPubKeyHash(), sskBlock.getKey().getPubKey(), false, false, false, false, false);
-			tests.add(test);
-			sskBlocks.add(block);
+		try (SaltedHashFreenetStore<SSKBlock> saltStore = SaltedHashFreenetStore.construct(f,
+				"testCachingFreenetStoreOnCloseSSK", store, weakPRNG, 10, false, SemiOrderedShutdownHook.get(), true, true,
+				ticker, null)) {
+			try (CachingFreenetStore<SSKBlock> cachingStore = new CachingFreenetStore<SSKBlock>(store, saltStore, tracker)) {
+				cachingStore.start(null, true);
+				RandomSource random = new DummyRandomSource(12345);
+
+				for (int i = 0; i < 5; i++) {
+					String test = "test" + i;
+					ClientSSKBlock block = encodeBlockSSK(test, random);
+					SSKBlock sskBlock = (SSKBlock) block.getBlock();
+					store.put(sskBlock, false, false);
+					pubkeyCache.cacheKey(sskBlock.getKey().getPubKeyHash(), sskBlock.getKey().getPubKey(), false, false, false,
+							false, false);
+					tests.add(test);
+					sskBlocks.add(block);
+				}
+			}
 		}
 
-		cachingStore.close();
+		try (SaltedHashFreenetStore<SSKBlock> saltStore2 = SaltedHashFreenetStore.construct(f,
+				"testCachingFreenetStoreOnCloseSSK", store, weakPRNG, 10, false, SemiOrderedShutdownHook.get(), true, true,
+				ticker, null)) {
+			try (CachingFreenetStore<SSKBlock> cachingStore = new CachingFreenetStore<SSKBlock>(store, saltStore2, tracker)) {
+				cachingStore.start(null, true);
 
-		SaltedHashFreenetStore<SSKBlock> saltStore2 = SaltedHashFreenetStore.construct(f, "testCachingFreenetStoreOnCloseSSK", store, weakPRNG, 10, false, SemiOrderedShutdownHook.get(), true, true, ticker, null);
-		cachingStore = new CachingFreenetStore<SSKBlock>(store, saltStore2, tracker);
-		cachingStore.start(null, true);
+				boolean atLeastOneKey = false;
+				for (int i = 0; i < 5; i++) {
+					String test = tests.remove(0); // get the first element
+					ClientSSKBlock block = sskBlocks.remove(0); // get the first element
+					ClientSSK key = block.getClientKey();
+					NodeSSK ssk = (NodeSSK) key.getNodeKey();
+					SSKBlock verify = store.fetch(ssk, false, false, false, false, null);
+					// Key might not be present, because of collisions in the store
+					if (verify == null) {
+						continue;
+					}
+					String data = decodeBlockSSK(verify, key);
+					assertEquals(test, data);
+					// Check that it's in the underlying store now.
+					assertNotNull(saltStore2.fetch(block.getKey().getRoutingKey(), block.getKey().getFullKey(), false, false,
+							false, false, null));
 
-
-		for(int i=0;i<5;i++) {
-			String test = tests.remove(0); //get the first element
-			ClientSSKBlock block = sskBlocks.remove(0); //get the first element
-			ClientSSK key = block.getClientKey();
-			NodeSSK ssk = (NodeSSK) key.getNodeKey();
-			SSKBlock verify = store.fetch(ssk, false, false, false, false, null);
-			String data = decodeBlockSSK(verify, key);
-			assertEquals(test, data);
-			// Check that it's in the underlying store now.
-			assertNotNull(saltStore2.fetch(block.getKey().getRoutingKey(), block.getKey().getFullKey(), false, false, false, false, null));
+					atLeastOneKey = true;
+				}
+				assertTrue("At least on key should have been present", atLeastOneKey);
+			}
 		}
-
-		cachingStore.close();
 	}
 
-	/* Test with SSK whether stuff gets written to disk after the caching period expires */
-	public void testTimeExpireSSK() throws IOException, SSKEncodeException, InvalidCompressionCodecException, KeyCollisionException, SSKVerifyException, KeyDecodeException, InterruptedException {
+	/*
+	 * Test with SSK whether stuff gets written to disk after the caching period
+	 * expires
+	 */
+	public void testTimeExpireSSK() throws IOException, SSKEncodeException, InvalidCompressionCodecException,
+			KeyCollisionException, SSKVerifyException, KeyDecodeException, InterruptedException {
 		File f = new File(tempDir, "saltstore");
-		FileUtil.removeAll(f);
 
 		final int keys = 5;
 		PubkeyStore pk = new PubkeyStore();
-		new RAMFreenetStore<DSAPublicKey>(pk, keys);
+		RAMFreenetStore<DSAPublicKey> ramFreenetStore = new RAMFreenetStore<DSAPublicKey>(pk, keys);
+		pk.setStore(ramFreenetStore);
 		GetPubkey pubkeyCache = new SimpleGetPubkey(pk);
 		SSKStore store = new SSKStore(pubkeyCache);
-		SaltedHashFreenetStore<SSKBlock> saltStore = SaltedHashFreenetStore.construct(f, "testCachingFreenetStoreOnCloseSSK", store, weakPRNG, 10, true, SemiOrderedShutdownHook.get(), true, true, ticker, null);
-		WaitableCachingFreenetStoreTracker tracker = new WaitableCachingFreenetStoreTracker(cachingFreenetStoreMaxSize, 100, ticker);
-		CachingFreenetStore<SSKBlock> cachingStore = new CachingFreenetStore<SSKBlock>(store, saltStore, tracker);
-		cachingStore.start(null, true);
-		RandomSource random = new DummyRandomSource(12345);
 
-		List<ClientSSKBlock> sskBlocks = new ArrayList<ClientSSKBlock>();
-		List<String> tests = new ArrayList<String>();
+		try (SaltedHashFreenetStore<SSKBlock> saltStore = SaltedHashFreenetStore.construct(f,
+				"testCachingFreenetStoreOnCloseSSK", store, weakPRNG, 10, true, SemiOrderedShutdownHook.get(), true, true,
+				ticker, null)) {
+			WaitableCachingFreenetStoreTracker tracker = new WaitableCachingFreenetStoreTracker(cachingFreenetStoreMaxSize,
+					100, ticker);
+			try (CachingFreenetStore<SSKBlock> cachingStore = new CachingFreenetStore<SSKBlock>(store, saltStore, tracker)) {
+				cachingStore.start(null, true);
+				RandomSource random = new DummyRandomSource(12345);
 
-		for(int i=0;i<5;i++) {
-			String test = "test" + i;
-			ClientSSKBlock block = encodeBlockSSK(test, random);
-			SSKBlock sskBlock = (SSKBlock) block.getBlock();
-			store.put(sskBlock, false, false);
-			pubkeyCache.cacheKey(sskBlock.getKey().getPubKeyHash(), sskBlock.getKey().getPubKey(), false, false, false, false, false);
-			tests.add(test);
-			sskBlocks.add(block);
+				List<ClientSSKBlock> sskBlocks = new ArrayList<ClientSSKBlock>();
+				List<String> tests = new ArrayList<String>();
+
+				for (int i = 0; i < 5; i++) {
+					String test = "test" + i;
+					ClientSSKBlock block = encodeBlockSSK(test, random);
+					SSKBlock sskBlock = (SSKBlock) block.getBlock();
+					store.put(sskBlock, false, false);
+					pubkeyCache.cacheKey(sskBlock.getKey().getPubKeyHash(), sskBlock.getKey().getPubKey(), false, false, false,
+							false, false);
+					tests.add(test);
+					sskBlocks.add(block);
+				}
+
+				tracker.waitForZero();
+
+				boolean atLeastOneKey = false;
+				for (int i = 0; i < 5; i++) {
+					String test = tests.get(i);
+					ClientSSKBlock block = sskBlocks.get(i);
+					ClientSSK key = block.getClientKey();
+					NodeSSK ssk = (NodeSSK) key.getNodeKey();
+					SSKBlock verify = store.fetch(ssk, false, false, false, false, null);
+					if (verify == null) {
+						continue;
+					}
+					String data = decodeBlockSSK(verify, key);
+					assertEquals(test, data);
+					// Check that it's in the underlying store now.
+					assertNotNull(saltStore.fetch(block.getKey().getRoutingKey(), block.getKey().getFullKey(), false, false,
+							false, false, null));
+
+					atLeastOneKey = true;
+				}
+				assertTrue("At least one key should have been present", atLeastOneKey);
+			}
 		}
-
-		tracker.waitForZero();
-
-		for(int i=0;i<5;i++) {
-			String test = tests.remove(0); //get the first element
-			ClientSSKBlock block = sskBlocks.remove(0); //get the first element
-			ClientSSK key = block.getClientKey();
-			NodeSSK ssk = (NodeSSK) key.getNodeKey();
-			SSKBlock verify = store.fetch(ssk, false, false, false, false, null);
-			String data = decodeBlockSSK(verify, key);
-			assertEquals(test, data);
-			// Check that it's in the underlying store now.
-			assertNotNull(saltStore.fetch(block.getKey().getRoutingKey(), block.getKey().getFullKey(), false, false, false, false, null));
-		}
-
-		cachingStore.close();
 	}
 
-	public void testOnCollisionsSSK() throws IOException, SSKEncodeException, InvalidCompressionCodecException, SSKVerifyException, KeyDecodeException, KeyCollisionException {
-		// With slot filters turned off, it goes straight to disk, because probablyInStore() always returns true.
+	public void testOnCollisionsSSK() throws IOException, SSKEncodeException, InvalidCompressionCodecException,
+			SSKVerifyException, KeyDecodeException, KeyCollisionException {
+		// With slot filters turned off, it goes straight to disk, because
+		// probablyInStore() always returns true.
 		checkOnCollisionsSSK(false);
-		// With slot filters turned on, it should be cached, it should compare it, and still not throw if it's the same block.
+		// With slot filters turned on, it should be cached, it should compare it, and
+		// still not throw if it's the same block.
 		checkOnCollisionsSSK(true);
 	}
 
 	/* Test collisions on SSK */
-	private void checkOnCollisionsSSK(boolean useSlotFilter) throws IOException, SSKEncodeException, InvalidCompressionCodecException, SSKVerifyException, KeyDecodeException, KeyCollisionException {
-		File f = new File(tempDir, "saltstore");
-		FileUtil.removeAll(f);
+	private void checkOnCollisionsSSK(boolean useSlotFilter) throws IOException, SSKEncodeException,
+			InvalidCompressionCodecException, SSKVerifyException, KeyDecodeException, KeyCollisionException {
+
+		FileUtil.removeAll(tempDir);
 
 		final int keys = 5;
 		PubkeyStore pk = new PubkeyStore();
-		new RAMFreenetStore<DSAPublicKey>(pk, keys);
+		RAMFreenetStore<DSAPublicKey> ramFreenetStore = new RAMFreenetStore<DSAPublicKey>(pk, keys);
+		pk.setStore(ramFreenetStore);
 		GetPubkey pubkeyCache = new SimpleGetPubkey(pk);
 		SSKStore store = new SSKStore(pubkeyCache);
-		SaltedHashFreenetStore<SSKBlock> saltStore = SaltedHashFreenetStore.construct(f, "testCachingFreenetStoreOnCloseSSK", store, weakPRNG, 10, useSlotFilter, SemiOrderedShutdownHook.get(), true, true, ticker, null);
-		CachingFreenetStoreTracker tracker = new CachingFreenetStoreTracker(cachingFreenetStoreMaxSize, cachingFreenetStorePeriod, ticker);
-		CachingFreenetStore<SSKBlock> cachingStore = new CachingFreenetStore<SSKBlock>(store, saltStore, tracker);
-		cachingStore.start(null, true);
-		RandomSource random = new DummyRandomSource(12345);
+		File f = new File(tempDir, "saltstore");
 
-		final int CRYPTO_KEY_LENGTH = 32;
-		byte[] ckey = new byte[CRYPTO_KEY_LENGTH];
-		random.nextBytes(ckey);
-		DSAGroup g = Global.DSAgroupBigA;
-		DSAPrivateKey privKey = new DSAPrivateKey(g, random);
-		DSAPublicKey pubKey = new DSAPublicKey(g, privKey);
-		byte[] pkHash = SHA256.digest(pubKey.asBytes());
-		String docName = "myDOC";
-		InsertableClientSSK ik = new InsertableClientSSK(docName, pkHash, pubKey, privKey, ckey, Key.ALGO_AES_PCFB_256_SHA256);
+		try (SaltedHashFreenetStore<SSKBlock> saltStore = SaltedHashFreenetStore.construct(f,
+				"testCachingFreenetStoreOnCloseSSK", store, weakPRNG, 10, useSlotFilter, SemiOrderedShutdownHook.get(), true,
+				true, ticker, null)) {
+			CachingFreenetStoreTracker tracker = new CachingFreenetStoreTracker(cachingFreenetStoreMaxSize,
+					cachingFreenetStorePeriod, ticker);
+			try (CachingFreenetStore<SSKBlock> cachingStore = new CachingFreenetStore<SSKBlock>(store, saltStore, tracker)) {
+				cachingStore.start(null, true);
+				RandomSource random = new DummyRandomSource(12345);
 
-		String test = "test";
-		SimpleReadOnlyArrayBucket bucket = new SimpleReadOnlyArrayBucket(test.getBytes("UTF-8"));
-		ClientSSKBlock block = ik.encode(bucket, false, false, (short)-1, bucket.size(), random, Compressor.DEFAULT_COMPRESSORDESCRIPTOR);
-		SSKBlock sskBlock = (SSKBlock) block.getBlock();
-		store.put(sskBlock, false, false);
+				final int CRYPTO_KEY_LENGTH = 32;
+				byte[] ckey = new byte[CRYPTO_KEY_LENGTH];
+				random.nextBytes(ckey);
+				DSAGroup g = Global.DSAgroupBigA;
+				DSAPrivateKey privKey = new DSAPrivateKey(g, random);
+				DSAPublicKey pubKey = new DSAPublicKey(g, privKey);
+				byte[] pkHash = SHA256.digest(pubKey.asBytes());
+				String docName = "myDOC";
+				InsertableClientSSK ik = new InsertableClientSSK(docName, pkHash, pubKey, privKey, ckey,
+						Key.ALGO_AES_PCFB_256_SHA256);
 
-		//If the block is the same then there should not be a collision
-		try {
-			store.put(sskBlock, false, false);
-			assertTrue(true);
-		} catch (KeyCollisionException e) {
-			fail();
+				String test = "test";
+				SimpleReadOnlyArrayBucket bucket = new SimpleReadOnlyArrayBucket(test.getBytes("UTF-8"));
+				ClientSSKBlock block = ik.encode(bucket, false, false, (short) -1, bucket.size(), random,
+						Compressor.DEFAULT_COMPRESSORDESCRIPTOR);
+				SSKBlock sskBlock = (SSKBlock) block.getBlock();
+				store.put(sskBlock, false, false);
+
+				// If the block is the same then there should not be a collision
+				try {
+					store.put(sskBlock, false, false);
+					assertTrue(true);
+				} catch (KeyCollisionException e) {
+					fail();
+				}
+
+				String test1 = "test1";
+				SimpleReadOnlyArrayBucket bucket1 = new SimpleReadOnlyArrayBucket(test1.getBytes("UTF-8"));
+				ClientSSKBlock block1 = ik.encode(bucket1, false, false, (short) -1, bucket1.size(), random,
+						Compressor.DEFAULT_COMPRESSORDESCRIPTOR);
+				SSKBlock sskBlock1 = (SSKBlock) block1.getBlock();
+
+				// if it's different (e.g. different content, same key), there should be a KCE
+				// thrown
+				try {
+					store.put(sskBlock1, false, false);
+					fail();
+				} catch (KeyCollisionException e) {
+					assertTrue(true);
+				}
+
+				// if overwrite is set, then no collision should be thrown
+				try {
+					store.put(sskBlock1, true, false);
+					assertTrue(true);
+				} catch (KeyCollisionException e) {
+					fail();
+				}
+
+				ClientSSK key = block1.getClientKey();
+				pubkeyCache.cacheKey(sskBlock.getKey().getPubKeyHash(), sskBlock.getKey().getPubKey(), false, false, false,
+						false, false);
+				NodeSSK ssk = (NodeSSK) key.getNodeKey();
+				SSKBlock verify = store.fetch(ssk, false, false, false, false, null);
+				String data = decodeBlockSSK(verify, key);
+				assertEquals(test1, data);
+
+				if (useSlotFilter) {
+					// Check that it's in the cache
+					assertNull(saltStore.fetch(block.getKey().getRoutingKey(), block.getKey().getFullKey(), false, false, false,
+							false, null));
+				} else {
+					// Check that it's in the underlying store now.
+					assertNotNull(saltStore.fetch(block.getKey().getRoutingKey(), block.getKey().getFullKey(), false, false,
+							false, false, null));
+				}
+			}
 		}
-
-		String test1 = "test1";
-		SimpleReadOnlyArrayBucket bucket1 = new SimpleReadOnlyArrayBucket(test1.getBytes("UTF-8"));
-		ClientSSKBlock block1 = ik.encode(bucket1, false, false, (short)-1, bucket1.size(), random, Compressor.DEFAULT_COMPRESSORDESCRIPTOR);
-		SSKBlock sskBlock1 = (SSKBlock) block1.getBlock();
-
-		//if it's different (e.g. different content, same key), there should be a KCE thrown
-		try {
-			store.put(sskBlock1, false, false);
-			fail();
-		} catch (KeyCollisionException e) {
-			assertTrue(true);
-		}
-
-		// if overwrite is set, then no collision should be thrown
-		try {
-			store.put(sskBlock1, true, false);
-			assertTrue(true);
-		} catch (KeyCollisionException e) {
-			fail();
-		}
-
-		ClientSSK key = block1.getClientKey();
-		pubkeyCache.cacheKey(sskBlock.getKey().getPubKeyHash(), sskBlock.getKey().getPubKey(), false, false, false, false, false);
-		NodeSSK ssk = (NodeSSK) key.getNodeKey();
-		SSKBlock verify = store.fetch(ssk, false, false, false, false, null);
-		String data = decodeBlockSSK(verify, key);
-		assertEquals(test1, data);
-
-		if(useSlotFilter) {
-			// Check that it's in the cache
-			assertNull(saltStore.fetch(block.getKey().getRoutingKey(), block.getKey().getFullKey(), false, false, false, false, null));
-		} else {
-			// Check that it's in the underlying store now.
-			assertNotNull(saltStore.fetch(block.getKey().getRoutingKey(), block.getKey().getFullKey(), false, false, false, false, null));
-		}
-
-		cachingStore.close();
 	}
 
-	private String decodeBlockSSK(SSKBlock verify, ClientSSK key) throws SSKVerifyException, KeyDecodeException, IOException {
+	private String decodeBlockSSK(SSKBlock verify, ClientSSK key)
+			throws SSKVerifyException, KeyDecodeException, IOException {
 		ClientSSKBlock cb = ClientSSKBlock.construct(verify, key);
 		Bucket output = cb.decode(new ArrayBucketFactory(), 32768, false);
 		byte[] buf = BucketTools.toByteArray(output);
 		return new String(buf, "UTF-8");
 	}
 
-	private ClientSSKBlock encodeBlockSSK(String test, RandomSource random) throws IOException, SSKEncodeException, InvalidCompressionCodecException {
+	private ClientSSKBlock encodeBlockSSK(String test, RandomSource random)
+			throws IOException, SSKEncodeException, InvalidCompressionCodecException {
 		byte[] data = test.getBytes("UTF-8");
 		SimpleReadOnlyArrayBucket bucket = new SimpleReadOnlyArrayBucket(data);
 		InsertableClientSSK ik = InsertableClientSSK.createRandom(random, test);
-		return ik.encode(bucket, false, false, (short)-1, bucket.size(), random, Compressor.DEFAULT_COMPRESSORDESCRIPTOR);
+		return ik.encode(bucket, false, false, (short) -1, bucket.size(), random, Compressor.DEFAULT_COMPRESSORDESCRIPTOR);
 	}
 }

--- a/test/freenet/store/caching/CachingFreenetStoreTest.java
+++ b/test/freenet/store/caching/CachingFreenetStoreTest.java
@@ -805,14 +805,18 @@ public class CachingFreenetStoreTest extends TestCase {
 		}
 	}
 
-	public void testOnCollisionsSSK() throws IOException, SSKEncodeException, InvalidCompressionCodecException,
+	public void testOnCollisionsSSK_useSlotFilter() throws IOException, SSKEncodeException, InvalidCompressionCodecException,
+			SSKVerifyException, KeyDecodeException, KeyCollisionException {
+		// With slot filters turned on, it should be cached, it should compare it, and
+		// still not throw if it's the same block.
+		checkOnCollisionsSSK(true);
+	}
+
+	public void testOnCollisionsSSK_dontUseSlotFilter() throws IOException, SSKEncodeException, InvalidCompressionCodecException,
 			SSKVerifyException, KeyDecodeException, KeyCollisionException {
 		// With slot filters turned off, it goes straight to disk, because
 		// probablyInStore() always returns true.
 		checkOnCollisionsSSK(false);
-		// With slot filters turned on, it should be cached, it should compare it, and
-		// still not throw if it's the same block.
-		checkOnCollisionsSSK(true);
 	}
 
 	/* Test collisions on SSK */

--- a/test/freenet/store/saltedhash/SaltedHashSlotFilterTest.java
+++ b/test/freenet/store/saltedhash/SaltedHashSlotFilterTest.java
@@ -26,282 +26,233 @@ import freenet.support.io.FileUtil;
 
 /** Test the slot filter mechanism */
 public class SaltedHashSlotFilterTest extends TestCase {
-	
+
 	private Random weakPRNG = new Random(12340);
 	private PooledExecutor exec = new PooledExecutor();
 	private Ticker ticker = new TrivialTicker(exec);
-	private File tempDir;
+	private File tempDir = new File("tmp-cachingfreenetstoretest");;
 	private static final int TEST_COUNT = TestProperty.EXTENSIVE ? 100 : 20;
 	private static final int ACCEPTABLE_FALSE_POSITIVES = TestProperty.EXTENSIVE ? 5 : 2;
-	private static final int STORE_SIZE = TestProperty.EXTENSIVE ? 500 : 100;
+	private static final int STORE_SIZE = TEST_COUNT * 5;
 
 	@Override
 	protected void setUp() throws java.lang.Exception {
-		tempDir = new File("tmp-cachingfreenetstoretest");
-		tempDir.mkdir();
 		exec.start();
 		SaltedHashFreenetStore.NO_CLEANER_SLEEP = false;
+
+		// Make sure each test case starts with a nice empty temporary directory
+		if( ! FileUtil.removeAll(tempDir) ) {
+			throw new RuntimeException("Could not clean temporary directory for running clean tests");
+		}
+		tempDir.mkdir();
 	}
 
 	@Override
 	protected void tearDown() {
 		FileUtil.removeAll(tempDir);
 	}
-	
-	public void testCHKPresent() throws IOException, CHKEncodeException, CHKVerifyException, CHKDecodeException {
+
+	private int populateStore(CHKStore store, SaltedHashFreenetStore<CHKBlock> saltStore, int numKeys)
+			throws CHKEncodeException, IOException, CHKVerifyException, CHKDecodeException {
+		int falsePositives = 0;
+		for (int i = 0; i < numKeys; i++) {
+			String testValue = "test" + i;
+			ClientCHKBlock block = encodeBlockCHK(testValue);
+			ClientCHK key = block.getClientKey();
+			byte[] routingKey = key.getRoutingKey();
+			if (saltStore.probablyInStore(routingKey)) {
+				falsePositives++;
+			}
+			store.put(block.getBlock(), false);
+			assertTrue(saltStore.probablyInStore(routingKey));
+			CHKBlock verifyBlock = store.fetch(key.getNodeCHK(), false, false, null);
+			String verifyValue = decodeBlockCHK(verifyBlock, key);
+			assertEquals(testValue, verifyValue);
+		}
+		return falsePositives;
+	}
+
+	private void checkStore(CHKStore store, SaltedHashFreenetStore<CHKBlock> saltStore, int numKeys)
+			throws CHKEncodeException, CHKVerifyException, CHKDecodeException, IOException {
+		checkStore(store, saltStore, numKeys, false);
+	}
+
+	private void checkStore(CHKStore store, SaltedHashFreenetStore<CHKBlock> saltStore, int numKeys, boolean requireAll)
+			throws CHKEncodeException, IOException, CHKVerifyException, CHKDecodeException {
+		boolean atLeastOneKey = false;
+		for (int i = 0; i < numKeys; i++) {
+			String value = "test" + i;
+			ClientCHKBlock block = encodeBlockCHK(value);
+			ClientCHK key = block.getClientKey();
+			byte[] routingKey = key.getRoutingKey();
+			CHKBlock verifyBlock = store.fetch(key.getNodeCHK(), false, false, null);
+			if (!requireAll && verifyBlock == null) {
+				continue;
+			}
+
+			assertTrue(saltStore.probablyInStore(routingKey));
+			String verifyValue = decodeBlockCHK(verifyBlock, key);
+			assertEquals(value, verifyValue);
+
+			atLeastOneKey = true;
+		}
+		assertTrue("At least one key should have been present", atLeastOneKey);
+	}
+
+	public void testCHKPresent_writeImmediately()
+			throws IOException, CHKEncodeException, CHKVerifyException, CHKDecodeException {
 		checkCHKPresent(-1, TEST_COUNT, ACCEPTABLE_FALSE_POSITIVES, STORE_SIZE);
-		FileUtil.removeAll(tempDir);
-		checkCHKPresent(600*1000, TEST_COUNT, ACCEPTABLE_FALSE_POSITIVES, STORE_SIZE); // Much longer than the test will take.
-		checkCHKPresent(-1, SaltedHashFreenetStore.OPTION_MAX_PROBE, 1, SaltedHashFreenetStore.OPTION_MAX_PROBE); // Check that it doesn't reuse slots if it can avoid it.
+	}
+
+	// Much longer than the test will take.
+	public void testCHKPresent_veryLongPersistanceTime()
+			throws IOException, CHKEncodeException, CHKVerifyException, CHKDecodeException {
+		checkCHKPresent(600 * 1000, TEST_COUNT, ACCEPTABLE_FALSE_POSITIVES, STORE_SIZE);
+	}
+
+	// Check that it doesn't reuse slots if it can avoid it.
+	public void testCHKPresent_noReuseSlots()
+			throws IOException, CHKEncodeException, CHKVerifyException, CHKDecodeException {
+		checkCHKPresent(-1, SaltedHashFreenetStore.OPTION_MAX_PROBE, 1, SaltedHashFreenetStore.OPTION_MAX_PROBE);
+	}
+
+	public void testCHKPresent_smallStoreSpace()
+			throws IOException, CHKEncodeException, CHKVerifyException, CHKDecodeException {
 		checkCHKPresent(-1, 10, 1, 20);
 	}
 
-	private void checkCHKPresent(int persistenceTime, int testCount, int acceptableFalsePositives, int storeSize) throws IOException, CHKEncodeException, CHKVerifyException, CHKDecodeException {
+	private void checkCHKPresent(int persistenceTime, int testCount, int acceptableFalsePositives, int storeSize)
+			throws IOException, CHKEncodeException, CHKVerifyException, CHKDecodeException {
 		ResizablePersistentIntBuffer.setPersistenceTime(persistenceTime);
 		File f = new File(tempDir, "saltstore");
 		FileUtil.removeAll(f);
 
 		CHKStore store = new CHKStore();
-		SaltedHashFreenetStore<CHKBlock> saltStore = SaltedHashFreenetStore.construct(f, "testCachingFreenetStoreCHK", store, weakPRNG, storeSize, true, SemiOrderedShutdownHook.get(), true, true, ticker, null);
-		saltStore.start(null, true);
-		
-		int falsePositives = 0;
+		try (SaltedHashFreenetStore<CHKBlock> saltStore = SaltedHashFreenetStore.construct(f, "testCachingFreenetStoreCHK",
+				store, weakPRNG, storeSize, true, SemiOrderedShutdownHook.get(), true, true, ticker, null)) {
+			saltStore.start(null, true);
 
-		for(int i=0;i<testCount;i++) {
-			String test = "test" + i;
-			ClientCHKBlock block = encodeBlockCHK(test);
-			ClientCHK key = block.getClientKey();
-			byte[] routingKey = key.getRoutingKey();
-			if(saltStore.probablyInStore(routingKey))
-				falsePositives++;
-			store.put(block.getBlock(), false);
-			assertTrue(saltStore.probablyInStore(routingKey));
-			CHKBlock verify = store.fetch(key.getNodeCHK(), false, false, null);
-			String data = decodeBlockCHK(verify, key);
-			assertEquals(test, data);
+			int falsePositives = populateStore(store, saltStore, testCount);
+
+			assertTrue(falsePositives <= acceptableFalsePositives);
+
+			checkStore(store, saltStore, testCount, true);
 		}
-		
-		assertTrue(falsePositives <= acceptableFalsePositives);
-		
-		for(int i=0;i<testCount;i++) {
-			String test = "test" + i;
-			ClientCHKBlock block = encodeBlockCHK(test);
-			ClientCHK key = block.getClientKey();
-			byte[] routingKey = key.getRoutingKey();
-			assertTrue(saltStore.probablyInStore(routingKey));
-			CHKBlock verify = store.fetch(key.getNodeCHK(), false, false, null);
-			String data = decodeBlockCHK(verify, key);
-			assertEquals(test, data);
-		}
-		
-		saltStore.close();
 	}
-	
-	public void testCHKPresentWithClose() throws IOException, CHKEncodeException, CHKVerifyException, CHKDecodeException {
+
+	public void testCHKPresentWithClose_writeImmediately()
+			throws IOException, CHKEncodeException, CHKVerifyException, CHKDecodeException {
 		checkCHKPresentWithClose(-1);
-		FileUtil.removeAll(tempDir);
-		checkCHKPresentWithClose(600*1000); // Much longer than the test will take.
 	}
 
-	public void checkCHKPresentWithClose(int persistenceTime) throws IOException, CHKEncodeException, CHKVerifyException, CHKDecodeException {
+	public void testCHKPresentWithClose_veryLongPersistanceTime()
+			throws IOException, CHKEncodeException, CHKVerifyException, CHKDecodeException {
+		checkCHKPresentWithClose(600 * 1000); // Much longer than the test will take.
+	}
+
+	public void checkCHKPresentWithClose(int persistenceTime)
+			throws IOException, CHKEncodeException, CHKVerifyException, CHKDecodeException {
 		ResizablePersistentIntBuffer.setPersistenceTime(persistenceTime);
 		File f = new File(tempDir, "saltstore");
-		FileUtil.removeAll(f);
 
 		CHKStore store = new CHKStore();
-		SaltedHashFreenetStore<CHKBlock> saltStore = SaltedHashFreenetStore.construct(f, "testCachingFreenetStoreCHK", store, weakPRNG, STORE_SIZE, true, SemiOrderedShutdownHook.get(), true, true, ticker, null);
-		saltStore.start(null, true);
-		
-		int falsePositives = 0;
+		try (SaltedHashFreenetStore<CHKBlock> saltStore = SaltedHashFreenetStore.construct(f, "testCachingFreenetStoreCHK",
+				store, weakPRNG, STORE_SIZE, true, SemiOrderedShutdownHook.get(), true, true, ticker, null)) {
+			saltStore.start(null, true);
 
-		for(int i=0;i<TEST_COUNT;i++) {
-			String test = "test" + i;
-			ClientCHKBlock block = encodeBlockCHK(test);
-			ClientCHK key = block.getClientKey();
-			byte[] routingKey = key.getRoutingKey();
-			if(saltStore.probablyInStore(routingKey))
-				falsePositives++;
-			store.put(block.getBlock(), false);
-			assertTrue(saltStore.probablyInStore(routingKey));
-			CHKBlock verify = store.fetch(key.getNodeCHK(), false, false, null);
-			String data = decodeBlockCHK(verify, key);
-			assertEquals(test, data);
+			int falsePositives = populateStore(store, saltStore, TEST_COUNT);
+
+			assertTrue(falsePositives <= ACCEPTABLE_FALSE_POSITIVES);
 		}
-		
-		assertTrue(falsePositives <= ACCEPTABLE_FALSE_POSITIVES);
-		
-		saltStore.close();
+
 		store = new CHKStore();
-		saltStore = SaltedHashFreenetStore.construct(f, "testCachingFreenetStoreCHK", store, weakPRNG, STORE_SIZE, true, SemiOrderedShutdownHook.get(), true, true, ticker, null);
-		saltStore.start(null, true);
-		
-		for(int i=0;i<TEST_COUNT;i++) {
-			String test = "test" + i;
-			ClientCHKBlock block = encodeBlockCHK(test);
-			ClientCHK key = block.getClientKey();
-			byte[] routingKey = key.getRoutingKey();
-			assertTrue(saltStore.probablyInStore(routingKey));
-			CHKBlock verify = store.fetch(key.getNodeCHK(), false, false, null);
-			String data = decodeBlockCHK(verify, key);
-			assertEquals(test, data);
+		try (SaltedHashFreenetStore<CHKBlock> saltStore = SaltedHashFreenetStore.construct(f, "testCachingFreenetStoreCHK",
+				store, weakPRNG, STORE_SIZE, true, SemiOrderedShutdownHook.get(), true, true, ticker, null)) {
+			saltStore.start(null, true);
+
+			checkStore(store, saltStore, TEST_COUNT);
 		}
-		
-		saltStore.close();
 	}
-	
+
 	public void testCHKPresentWithAbort() throws IOException, CHKEncodeException, CHKVerifyException, CHKDecodeException {
-		int delay = 1000;
-		ResizablePersistentIntBuffer.setPersistenceTime(delay);
+		ResizablePersistentIntBuffer.setPersistenceTime(1000);
 		File f = new File(tempDir, "saltstore");
-		FileUtil.removeAll(f);
 
 		CHKStore store = new CHKStore();
-		SaltedHashFreenetStore<CHKBlock> saltStore = SaltedHashFreenetStore.construct(f, "testCachingFreenetStoreCHK", store, weakPRNG, STORE_SIZE, true, SemiOrderedShutdownHook.get(), true, true, ticker, null);
-		saltStore.start(null, true);
-		
-		int falsePositives = 0;
+		try (SaltedHashFreenetStore<CHKBlock> saltStore = SaltedHashFreenetStore.construct(f, "testCachingFreenetStoreCHK",
+				store, weakPRNG, STORE_SIZE, true, SemiOrderedShutdownHook.get(), true, true, ticker, null)) {
+			saltStore.start(null, true);
 
-		for(int i=0;i<TEST_COUNT;i++) {
-			String test = "test" + i;
-			ClientCHKBlock block = encodeBlockCHK(test);
-			ClientCHK key = block.getClientKey();
-			byte[] routingKey = key.getRoutingKey();
-			if(saltStore.probablyInStore(routingKey))
-				falsePositives++;
-			store.put(block.getBlock(), false);
-			assertTrue(saltStore.probablyInStore(routingKey));
-			CHKBlock verify = store.fetch(key.getNodeCHK(), false, false, null);
-			String data = decodeBlockCHK(verify, key);
-			assertEquals(test, data);
-		}
-		
-		assertTrue(falsePositives <= ACCEPTABLE_FALSE_POSITIVES);
-		
-		try {
-			Thread.sleep(2*delay);
-		} catch (InterruptedException e) {
-			// Ignore
+			int falsePositives = populateStore(store, saltStore, TEST_COUNT);
+
+			assertTrue(falsePositives <= ACCEPTABLE_FALSE_POSITIVES);
+
+			saltStore.close(true);
 		}
 
-		// Abrupt abort. The slots should have been written by now.
-		saltStore.close(true);
 		store = new CHKStore();
-		saltStore = SaltedHashFreenetStore.construct(f, "testCachingFreenetStoreCHK", store, weakPRNG, STORE_SIZE, true, SemiOrderedShutdownHook.get(), true, true, ticker, null);
-		saltStore.start(null, true);
-		
-		for(int i=0;i<TEST_COUNT;i++) {
-			String test = "test" + i;
-			ClientCHKBlock block = encodeBlockCHK(test);
-			ClientCHK key = block.getClientKey();
-			byte[] routingKey = key.getRoutingKey();
-			assertTrue(saltStore.probablyInStore(routingKey));
-			CHKBlock verify = store.fetch(key.getNodeCHK(), false, false, null);
-			String data = decodeBlockCHK(verify, key);
-			assertEquals(test, data);
+		try (SaltedHashFreenetStore<CHKBlock> saltStore = SaltedHashFreenetStore.construct(f, "testCachingFreenetStoreCHK",
+				store, weakPRNG, STORE_SIZE, true, SemiOrderedShutdownHook.get(), true, true, ticker, null)) {
+			saltStore.start(null, true);
+
+			checkStore(store, saltStore, TEST_COUNT);
 		}
-		
-		saltStore.close();
 	}
-	
-	public void testCHKDelayedTurnOnSlotFilters() throws IOException, CHKEncodeException, CHKVerifyException, CHKDecodeException {
-		int delay = 1000;
-		ResizablePersistentIntBuffer.setPersistenceTime(delay);
+
+	public void testCHKDelayedTurnOnSlotFilters()
+			throws IOException, CHKEncodeException, CHKVerifyException, CHKDecodeException {
+		ResizablePersistentIntBuffer.setPersistenceTime(1000);
 		File f = new File(tempDir, "saltstore");
-		FileUtil.removeAll(f);
 
 		CHKStore store = new CHKStore();
-		SaltedHashFreenetStore<CHKBlock> saltStore = SaltedHashFreenetStore.construct(f, "testCachingFreenetStoreCHK", store, weakPRNG, STORE_SIZE, false, SemiOrderedShutdownHook.get(), true, true, ticker, null);
-		saltStore.start(null, true);
-		
-		int falsePositives = 0;
+		try (SaltedHashFreenetStore<CHKBlock> saltStore = SaltedHashFreenetStore.construct(f, "testCachingFreenetStoreCHK",
+				store, weakPRNG, STORE_SIZE, false, SemiOrderedShutdownHook.get(), true, true, ticker, null)) {
+			saltStore.start(null, true);
 
-		for(int i=0;i<TEST_COUNT;i++) {
-			String test = "test" + i;
-			ClientCHKBlock block = encodeBlockCHK(test);
-			ClientCHK key = block.getClientKey();
-			byte[] routingKey = key.getRoutingKey();
-			if(saltStore.probablyInStore(routingKey))
-				falsePositives++;
-			store.put(block.getBlock(), false);
-			assertTrue(saltStore.probablyInStore(routingKey));
-			CHKBlock verify = store.fetch(key.getNodeCHK(), false, false, null);
-			String data = decodeBlockCHK(verify, key);
-			assertEquals(test, data);
+			int falsePositives = populateStore(store, saltStore, TEST_COUNT);
+
+			assertTrue(falsePositives == TEST_COUNT);
 		}
-		
-		assertTrue(falsePositives == TEST_COUNT);
-		
-		saltStore.close();
+
 		store = new CHKStore();
 		// Now turn on slot filters. Does it still work?
-		saltStore = SaltedHashFreenetStore.construct(f, "testCachingFreenetStoreCHK", store, weakPRNG, STORE_SIZE, true, SemiOrderedShutdownHook.get(), true, true, ticker, null);
-		saltStore.start(null, true);
-		
-		for(int i=0;i<TEST_COUNT;i++) {
-			String test = "test" + i;
-			ClientCHKBlock block = encodeBlockCHK(test);
-			ClientCHK key = block.getClientKey();
-			byte[] routingKey = key.getRoutingKey();
-			assertTrue(saltStore.probablyInStore(routingKey));
-			CHKBlock verify = store.fetch(key.getNodeCHK(), false, false, null);
-			String data = decodeBlockCHK(verify, key);
-			assertEquals(test, data);
+		try (SaltedHashFreenetStore<CHKBlock> saltStore = SaltedHashFreenetStore.construct(f, "testCachingFreenetStoreCHK",
+				store, weakPRNG, STORE_SIZE, true, SemiOrderedShutdownHook.get(), true, true, ticker, null)) {
+			saltStore.start(null, true);
+
+			checkStore(store, saltStore, TEST_COUNT);
 		}
-		
-		saltStore.close();
 	}
-	
-	public void testCHKDelayedTurnOnSlotFiltersWithCleaner() throws IOException, CHKEncodeException, CHKVerifyException, CHKDecodeException, InterruptedException {
-		int delay = 1000;
-		ResizablePersistentIntBuffer.setPersistenceTime(delay);
+
+	public void testCHKDelayedTurnOnSlotFiltersWithCleaner()
+			throws IOException, CHKEncodeException, CHKVerifyException, CHKDecodeException, InterruptedException {
+		ResizablePersistentIntBuffer.setPersistenceTime(1000);
 		File f = new File(tempDir, "saltstore");
-		FileUtil.removeAll(f);
 
 		CHKStore store = new CHKStore();
-		SaltedHashFreenetStore<CHKBlock> saltStore = SaltedHashFreenetStore.construct(f, "testCachingFreenetStoreCHK", store, weakPRNG, STORE_SIZE, false, SemiOrderedShutdownHook.get(), true, true, ticker, null);
-		saltStore.start(null, true);
-		
-		int falsePositives = 0;
+		try (SaltedHashFreenetStore<CHKBlock> saltStore = SaltedHashFreenetStore.construct(f, "testCachingFreenetStoreCHK",
+				store, weakPRNG, STORE_SIZE, false, SemiOrderedShutdownHook.get(), true, true, ticker, null)) {
+			saltStore.start(null, true);
 
-		for(int i=0;i<TEST_COUNT;i++) {
-			String test = "test" + i;
-			ClientCHKBlock block = encodeBlockCHK(test);
-			ClientCHK key = block.getClientKey();
-			byte[] routingKey = key.getRoutingKey();
-			if(saltStore.probablyInStore(routingKey))
-				falsePositives++;
-			store.put(block.getBlock(), false);
-			assertTrue(saltStore.probablyInStore(routingKey));
-			CHKBlock verify = store.fetch(key.getNodeCHK(), false, false, null);
-			String data = decodeBlockCHK(verify, key);
-			assertEquals(test, data);
+			int falsePositives = populateStore(store, saltStore, TEST_COUNT);
+
+			assertTrue(falsePositives == TEST_COUNT);
 		}
-		
-		assertTrue(falsePositives == TEST_COUNT);
-		
-		saltStore.close();
+
 		store = new CHKStore();
 		// Now turn on slot filters. Does it still work?
 		SaltedHashFreenetStore.NO_CLEANER_SLEEP = true;
-		saltStore = SaltedHashFreenetStore.construct(f, "testCachingFreenetStoreCHK", store, weakPRNG, STORE_SIZE, true, SemiOrderedShutdownHook.get(), true, true, ticker, null);
-		saltStore.start(null, true);
-		saltStore.testingWaitForCleanerDone(50, 100);
-		
-		for(int i=0;i<TEST_COUNT;i++) {
-			String test = "test" + i;
-			ClientCHKBlock block = encodeBlockCHK(test);
-			ClientCHK key = block.getClientKey();
-			byte[] routingKey = key.getRoutingKey();
-			assertTrue(saltStore.probablyInStore(routingKey));
-			CHKBlock verify = store.fetch(key.getNodeCHK(), false, false, null);
-			String data = decodeBlockCHK(verify, key);
-			assertEquals(test, data);
+		try (SaltedHashFreenetStore<CHKBlock> saltStore = SaltedHashFreenetStore.construct(f, "testCachingFreenetStoreCHK",
+				store, weakPRNG, STORE_SIZE, true, SemiOrderedShutdownHook.get(), true, true, ticker, null)) {
+			saltStore.start(null, true);
+			saltStore.testingWaitForCleanerDone(50, 100);
+
+			checkStore(store, saltStore, TEST_COUNT);
 		}
-		
-		saltStore.close();
 	}
-	
-	private String decodeBlockCHK(CHKBlock verify, ClientCHK key) throws CHKVerifyException, CHKDecodeException, IOException {
+
+	private String decodeBlockCHK(CHKBlock verify, ClientCHK key)
+			throws CHKVerifyException, CHKDecodeException, IOException {
 		ClientCHKBlock cb = new ClientCHKBlock(verify, key);
 		Bucket output = cb.decode(new ArrayBucketFactory(), 32768, false);
 		byte[] buf = BucketTools.toByteArray(output);
@@ -311,10 +262,8 @@ public class SaltedHashSlotFilterTest extends TestCase {
 	private ClientCHKBlock encodeBlockCHK(String test) throws CHKEncodeException, IOException {
 		byte[] data = test.getBytes("UTF-8");
 		SimpleReadOnlyArrayBucket bucket = new SimpleReadOnlyArrayBucket(data);
-		return ClientCHKBlock.encode(bucket, false, false, (short)-1, bucket.size(), Compressor.DEFAULT_COMPRESSORDESCRIPTOR,
-        null, (byte)0);
+		return ClientCHKBlock.encode(bucket, false, false, (short) -1, bucket.size(),
+				Compressor.DEFAULT_COMPRESSORDESCRIPTOR, null, (byte) 0);
 	}
-	
-
 
 }


### PR DESCRIPTION
Several store tests fail when run (on windows system).

**Update:**
Now each test is executed in its own directory, so tests should be able to be executed in parallel without conflicting.

There were several problems.
**Stores are not closed properly in tests** 
One problem was that in many places the stores were not closed correctly at the end of each test case, which kept their file handlers open.
On windows machines you cannot move or delete a file which has an open file handle pointing to it.

The file pointers in the stores were often only closed after they were garbage collected. Since the garbage collection run is unpredictable, the success of the test was unpredictable.

You could see this in the messages that the system complained that it could not move or delete certain files (because they were still open by stores of previous tests)

**SaltedHashFreenetStore can lose entries through collisions**
Another problem was that inserting keys into a SaltedHashFreenetStore can create a collision, so it might replace an existing key,
but the test cases relied on the fact that all keys are present. (Maybe an artifact from the old LRU Store?)

**Changes:**
* Changed FreenetStore to implement closable, which allows to use try-with-resources syntax, to make sure all stores are closed probably at the end of a block.
* SaltedHashFreenetStore and CachingFreenetStore also double check in their close() method, that they do nothing if called twice, to prevent it from writing their data again on a consecutive call. (I used atomic boolean to make the check thread save, don't know if it is required)
* Tests now use try-with-recource syntax to create stores, to make sure that the store is closed at the end of the test. Independent of, if the test was successful or not.
* Also added a check to SaltedHashFreenetStore.java.openStoreFiles() , to check if a lock could be acquired and generate a exception with a helpful message if not.
* The test cases have been refactored heavily, to take into account that a key can be lost. 
