### PR TITLE
Limit travis checks to Java in debian stable, Java LTS and the most recent GA

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,11 +26,8 @@ install: "./gradlew jar"
 
 jdk:
   - openjdk8
-  - openjdk9
-  - openjdk10
   - openjdk11
-  - openjdk12
-  - openjdk13
+  - openjdk15
 
 before_deploy:
   - "./gradlew javadoc ; true"


### PR DESCRIPTION
This should reduce the spurious errors in travis builds and mitigate the effects of the new usage policies of travis.