### PR TITLE
Pitch black defense only if swapping enabled

### DIFF
--- a/src/freenet/node/LocationManager.java
+++ b/src/freenet/node/LocationManager.java
@@ -190,6 +190,9 @@ public class LocationManager implements ByteCounter {
             @Override
             public void run() {
                 node.ticker.queueTimedJob(this, DAYS.toMillis(1));
+                if (swappingDisabled()) {
+                    return;
+                }
                 LocalDateTime now = LocalDateTime.now();
                 String isoDateStringToday = DateTimeFormatter.ISO_DATE
                     .format(now);


### PR DESCRIPTION
Missing this might be causing stray defensive location changes right now.