### PR TITLE
m3u-player: prevent flickering on track-transitions

### DIFF
--- a/src/freenet/clients/http/ToadletContextImpl.java
+++ b/src/freenet/clients/http/ToadletContextImpl.java
@@ -465,7 +465,7 @@ public class ToadletContextImpl implements ToadletContext {
 	private static String generateRestrictedScriptSrc() {
 		// TODO: auto-generate these hashes from the path to the source file
 		String[] allowedScriptHashes = new String[] {
-				"sha256-uBohlLWVKw+CT6aoh/dTlBfKXU7QWzLXnomOhe7JxdQ=" // freenet/clients/http/staticfiles/js/m3u-player.js
+				"sha256-Q62svpg2DVmqkdDQuG/nKUpYqz8FRjSWYbenaFrxXoQ=" // freenet/clients/http/staticfiles/js/m3u-player.js
 		};
 		if (allowedScriptHashes.length == 0) {
 			return "'none'";


### PR DESCRIPTION
prevent flickering on track-transitions by keeping the size fixed and overlaying an image of the video