### PR TITLE
Bugfix: skip in support.io.SkipShieldingInputStream must return non-negative

### DIFF
--- a/src/freenet/support/io/SkipShieldingInputStream.java
+++ b/src/freenet/support/io/SkipShieldingInputStream.java
@@ -46,6 +46,14 @@ public class SkipShieldingInputStream extends FilterInputStream {
 
     @Override
     public long skip(long n) throws IOException {
-        return n < 0 ? 0 : read(SKIP_BUFFER, 0, (int) Math.min(n, SKIP_BUFFER_SIZE));
+        int retval;
+        if (n < 0)
+            retval = 0;
+        else {
+            retval = read(SKIP_BUFFER, 0, (int) Math.min(n, SKIP_BUFFER_SIZE));
+            if (retval < 0)
+                retval = 0;
+        }
+        return retval;
     }
 }


### PR DESCRIPTION
read() in skip(n) sometimes returns -1, but skip cannot return a negative number. This caused an infinite loop in recent versions of commons-compress (IOUtils.java) which introduced another while loop in it's skip function that assumed the overrided skip() function returned a non-negative value.