### PR TITLE
Shallow cloning on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,3 +56,6 @@ deploy:
     on:
       tags: true
       jdk: openjdk8
+
+git:
+  depth: 1


### PR DESCRIPTION
Travis CI provide a way to shallow clone a repository. This has the obvious benefit of speed, since you only need to download a small number of commits.