### PR TITLE
OpenJDK 16+ compat: add wrapper.conf argument to allow access to internal openjdk modules

### DIFF
--- a/src/freenet/node/updater/UpdateDeployContext.java
+++ b/src/freenet/node/updater/UpdateDeployContext.java
@@ -146,7 +146,9 @@ public class UpdateDeployContext {
 		boolean writtenAnchorInterval = false;
 		/** Add the relative JNA tempdir if it does not exist already */
 		boolean writtenJnaTmpDir = false;
-		
+		/** Allow accessing internal modules in Java 16+ */
+		boolean writtenIllegalAccessPermit = false;
+
 		String newMain = mainJarAbsolute ? newMainJar.getAbsolutePath() : newMainJar.getPath();
 		
 		String mainRHS = null;
@@ -177,7 +179,7 @@ public class UpdateDeployContext {
 					// Ignore the numbers.
 					String rhs = line.substring(idx+1);
 					dontWrite = true;
-					if(rhs.equals("freenet.jar") || rhs.equals("freenet.jar.new") || 
+					if(rhs.equals("freenet.jar") || rhs.equals("freenet.jar.new") ||
 							rhs.equals("freenet-stable-latest.jar") || rhs.equals("freenet-stable-latest.jar.new") ||
 							rhs.equals("freenet-testing-latest.jar") || rhs.equals("freenet-testing-latest.jar.new")) {
 						if(writtenNewJar)
@@ -210,6 +212,9 @@ public class UpdateDeployContext {
 				 additionalJavaArguments.add(rhs);
 				 if (rhs.startsWith("-Djava.io.tmpdir=")) {
 				       writtenJnaTmpDir = true;
+				 }
+				 if (rhs.startsWith("--illegal-access=permit")) {
+				       writtenIllegalAccessPermit = true;
 				 }
 			    }
 			} else if(lowcaseLine.equals("wrapper.restart.reload_configuration=true")) {
@@ -258,7 +263,12 @@ public class UpdateDeployContext {
 		if (!writtenJnaTmpDir) {
 			bw.write("wrapper.java.additional."+count+"=-Djava.io.tmpdir=./tmp/"+'\n');
 		}
-		
+
+		// allow accessing internal modules (required for Java 16+)
+		if (!writtenIllegalAccessPermit) {
+			bw.write("wrapper.java.additional."+count+"=--illegal-access=permit"+'\n');
+		}
+
 		for(String s : otherLines)
 			bw.write(s+'\n');
 


### PR DESCRIPTION
Needs very careful review because a broken wrapper.conf breaks installs.