### PR TITLE
Correct "current size" option in Wizard => datastore size

### DIFF
--- a/src/freenet/clients/http/wizardsteps/DATASTORE_SIZE.java
+++ b/src/freenet/clients/http/wizardsteps/DATASTORE_SIZE.java
@@ -44,11 +44,19 @@ public class DATASTORE_SIZE implements Step {
 
 		@SuppressWarnings("unchecked")
 		Option<Long> sizeOption = (Option<Long>) config.get("node").getOption("storeSize");
+		@SuppressWarnings("unchecked")
+		Option<Long> clientCacheSizeOption = (Option<Long>) config.get("node").getOption("clientCacheSize");
+		@SuppressWarnings("unchecked")
+		Option<Long> slashdotCacheSizeOption = (Option<Long>) config.get("node").getOption("slashdotCacheSize");
 		if(!sizeOption.isDefault()) {
 			long current = sizeOption.getValue();
+			long currentTotal = current;
+			if (!clientCacheSizeOption.isDefault() && !slashdotCacheSizeOption.isDefault()) {
+				currentTotal += clientCacheSizeOption.getValue() + slashdotCacheSizeOption.getValue();
+			}
 			result.addChild("option",
 			        new String[] { "value", "selected" },
-			        new String[] { SizeUtil.formatSize(current), "on" }, WizardL10n.l10n("currentPrefix")+" "+SizeUtil.formatSize(current));
+			        new String[] { SizeUtil.formatSize(currentTotal), "on" }, WizardL10n.l10n("currentPrefix")+" "+SizeUtil.formatSize(currentTotal));
 		} else if(autodetectedSize != -1) {
 			result.addChild("option",
 			        new String[] { "value", "selected" },


### PR DESCRIPTION
If you happen to run the installation wizard after you've already configured your node, when reaching the "Datastore size" step, the wizard will load your current datastore size parameter.

However, when you choose a value as datastore size, the wizard will then apply the following operations:
- compute a `clientCacheSize`, of 10% or 200 MiB (whichever is smaller)
- compute a `slashdotCacheSize` of up to 10%
- compute `storeSize` = `[your chosen size] - clientCacheSize - slashdotCacheSize`, and use this as the datastore size.

So, the actual value for datastore size will be different from the chosen value. In particular, if you choose "current size", in the end the datastore will get reduced, leading to a datastore resize (which may take a long time and will lead to its partial purge).

## Example

For instance, if I choose 10 GiB, then in the logs I'll see:

> Setting datastore size to 9016MiB
> Setting client cache size to 200MiB
> Setting slashdot/ULPR/recent requests cache size to 1024MiB

And if I go back to the datastore size wizard step, "current size" will then show 8.8 GiB (the equivalent of 9016 MiB), instead of 10 GiB (what I chose).

## Proposed fix

In this PR, I compute `storeSize + clientCacheSize + slashdotCacheSize`, and I the use this to fill in the "current size" option, instead of just `storeSize`.

Although this is a bit inaccurate as far as what the current size of the datastore really is, it seems to me that it leads to a more coherent behavior.
