### PR TITLE
fix peer scaling for very fast peers:

### DIFF
--- a/src/freenet/node/OpennetManager.java
+++ b/src/freenet/node/OpennetManager.java
@@ -977,10 +977,12 @@ public class OpennetManager {
 		int max = node.getMaxOpennetPeers();
 		if(ENABLE_PEERS_PER_KB_OUTPUT) {
 			int obwLimit = node.getOutputBandwidthLimit();
-			int targetPeers = (int)Math.round(Math.min(MAX_PEERS_FOR_SCALING, Math.sqrt(obwLimit * SCALING_CONSTANT / 1000.0)));
+			int targetPeers = (int)Math.round(Math.sqrt(obwLimit * SCALING_CONSTANT / 1000.0));
 			if(targetPeers < MIN_PEERS_FOR_SCALING)
 				targetPeers = MIN_PEERS_FOR_SCALING;
 			targetPeers = addMorePeersIfSlowPeersCannotSupplyEnoughBandwidthPerConnection(targetPeers);
+			// limit to max peers
+			targetPeers = Math.min(MAX_PEERS_FOR_SCALING, targetPeers);
 			if(max > targetPeers) {
 				max = targetPeers; // Allow user to reduce it.
 			}

--- a/src/freenet/node/OpennetManager.java
+++ b/src/freenet/node/OpennetManager.java
@@ -191,11 +191,11 @@ public class OpennetManager {
 	public static final boolean ENABLE_PEERS_PER_KB_OUTPUT = true;
 	/** Constant for scaling peers: we multiply bandwidth in kB/sec by this
 	 * and then take the square root. Minimum is MIN_PEERs_FOR_SCALING.
-     * 
-     * (define (peers kbps) (sqrt (* kbps scaling)))
-     * 
+     *
+     * (define (peers kBps) (sqrt (* kBps scaling)))
+     *
      * Scaling at 3 gives 4 peers at 5K (min peers),
-	 * 5 at 7K, 5 at 10K, 8 at 20K, 9 at 30K, 13 at 60K, 
+	 * 5 at 7K, 5 at 10K, 8 at 20K, 9 at 30K, 13 at 60K,
      * 17 at 100K, 20 at 140K, 87 at 2500K.
 	 * 106 at 30mbit/s (the mean upload in Japan in 2014) and
 	 * 180 at 88mbit/s (the mean upload in Hong Kong in 2014).*/

--- a/src/freenet/node/OpennetManager.java
+++ b/src/freenet/node/OpennetManager.java
@@ -155,7 +155,9 @@ public class OpennetManager {
 	public static final long DONT_READD_TIME = MINUTES.toMillis(1);
 	/** Don't drop a node until it's at least this old, if it's connected. */
 	public static final long DROP_MIN_AGE = MINUTES.toMillis(5);
-	/** Don't drop a node until it's at least this old, if it's not connected (if it has connected once then DROP_DISCONNECT_DELAY applies, but only once an hour as below). Must be less than DROP_MIN_AGE.
+	/** Don't drop a node until it's at least this old, if it's not connected
+	 * (if it has connected once then DROP_DISCONNECT_DELAY applies,
+	 * but only once an hour as below). Must be less than DROP_MIN_AGE.
 	 * Relatively generous because noderef transfers e.g. for announcement can be slow (Note
 	 * that announcements actually wait for previous transfers!). */
 	public static final long DROP_MIN_AGE_DISCONNECTED = MINUTES.toMillis(5);

--- a/src/freenet/node/OpennetManager.java
+++ b/src/freenet/node/OpennetManager.java
@@ -98,6 +98,9 @@ public class OpennetManager {
 	static final double LONG_PROPORTION = 0.3;
 	/** The proportion of the routing table which consists of "short links". */
 	public static final double SHORT_PROPORTION = 1.0 - LONG_PROPORTION;
+	/** Assumed proportion of slow peers for scaling up the peer count
+	 * to take limited capacity of slow peers into account. */
+	public static final double ASSUMPTION_50_PERCENT_SLOW_PEERS = 0.5;
 	
     enum LinkLengthClass {
         /** Shorter than LONG_DISTANCE */
@@ -1018,8 +1021,8 @@ public class OpennetManager {
 			return targetPeers;
 		}
 		double missingPacketsPerSlowPeer = targetPeers - packetsFromSlowPeer;
-		double missingPackets = 0.5 * targetPeers * missingPacketsPerSlowPeer;
-		double additionalPacketsPerAddedPeer = 0.5 * targetPeers + packetsFromSlowPeer;
+		double missingPackets = ASSUMPTION_50_PERCENT_SLOW_PEERS * targetPeers * missingPacketsPerSlowPeer;
+		double additionalPacketsPerAddedPeer = ASSUMPTION_50_PERCENT_SLOW_PEERS * targetPeers + packetsFromSlowPeer;
 		// always compensate for the missing packets. The worst nodes to be underused are the fast ones.
 		return targetPeers + 1 + (int) (missingPackets / additionalPacketsPerAddedPeer);
 	}


### PR DESCRIPTION
slow peers have insufficient total bandwidth to support the inbound
bandwidth expectation of a fast peer due to square-root peer count
scaling.