### PR TITLE
try replacing spaces by newlines in noderefs when parsing fails.

### DIFF
--- a/src/freenet/clients/http/ConnectionsToadlet.java
+++ b/src/freenet/clients/http/ConnectionsToadlet.java
@@ -768,8 +768,7 @@ public abstract class ConnectionsToadlet extends Toadlet {
 		SimpleFieldSet fs;
 		
 		try {
-			nodeReference = Fields.trimLines(nodeReference);
-			fs = new SimpleFieldSet(nodeReference, false, true, true);
+			fs = parseNoderefLiberally(nodeReference);
 			if(!fs.getEndMarker().endsWith("End")) {
 				Logger.error(this, "Trying to add noderef with end marker \""+fs.getEndMarker()+"\"");
 				return PeerAdditionReturnCodes.WRONG_ENCODING;
@@ -807,6 +806,16 @@ public abstract class ConnectionsToadlet extends Toadlet {
 			return PeerAdditionReturnCodes.ALREADY_IN_REFERENCE;
 		}
 		return PeerAdditionReturnCodes.OK;
+	}
+
+	private static SimpleFieldSet parseNoderefLiberally(String nodeReference) throws IOException {
+		nodeReference = Fields.trimLines(nodeReference);
+		try {
+			return new SimpleFieldSet(nodeReference, false, true, true);
+		} catch (IOException e) {
+				Logger.warning(null, "Cannot parse noderef, trying to replace all spaces with newlines and parsing again.");
+			return new SimpleFieldSet(nodeReference.split("\n"), false, true, true);
+		}
 	}
 
 	/** Adding a darknet node or an opennet node? */

--- a/src/freenet/clients/http/ConnectionsToadlet.java
+++ b/src/freenet/clients/http/ConnectionsToadlet.java
@@ -810,10 +810,11 @@ public abstract class ConnectionsToadlet extends Toadlet {
 
 	private static SimpleFieldSet parseNoderefLiberally(String nodeReference) throws IOException {
 		nodeReference = Fields.trimLines(nodeReference);
-		try {
-			return new SimpleFieldSet(nodeReference, false, true, true);
-		} catch (IOException e) {
-				Logger.warning(null, "Cannot parse noderef, trying to replace all spaces with newlines and parsing again.");
+		SimpleFieldSet fs = new SimpleFieldSet(nodeReference, false, true, true);
+		if (fs.directKeys().contains("lastGoodVersion")) {
+			return fs;
+		} else {
+			Logger.warning(null, "Cannot parse noderef: does not contain lastGoodVersion, trying to replace all spaces with newlines and parsing again.");
 			return new SimpleFieldSet(nodeReference.replace(" ", "\n"), false, true, true);
 		}
 	}

--- a/src/freenet/clients/http/ConnectionsToadlet.java
+++ b/src/freenet/clients/http/ConnectionsToadlet.java
@@ -814,7 +814,7 @@ public abstract class ConnectionsToadlet extends Toadlet {
 			return new SimpleFieldSet(nodeReference, false, true, true);
 		} catch (IOException e) {
 				Logger.warning(null, "Cannot parse noderef, trying to replace all spaces with newlines and parsing again.");
-			return new SimpleFieldSet(nodeReference.split("\n"), false, true, true);
+			return new SimpleFieldSet(nodeReference.replace(" ", "\n"), false, true, true);
 		}
 	}
 


### PR DESCRIPTION
This is now possible (since 2013 where encoding by key==<base64> was added)