### PR TITLE
Fix FreenetURI intern() to not forget edition of USK

### DIFF
--- a/src/freenet/keys/FreenetURI.java
+++ b/src/freenet/keys/FreenetURI.java
@@ -249,7 +249,7 @@ public class FreenetURI implements Cloneable, Comparable<FreenetURI>, Serializab
 			noCacheURI = true;
 			return this;
 		}
-		FreenetURI u = new FreenetURI(keyType, dn, newMetaStr, routingKey, cryptoKey, extra);
+		FreenetURI u = new FreenetURI(keyType, dn, newMetaStr, routingKey, cryptoKey, extra, suggestedEdition);
 		u.noCacheURI = true;
 		return u;
 	}

--- a/test/freenet/keys/FreenetURITest.java
+++ b/test/freenet/keys/FreenetURITest.java
@@ -131,4 +131,9 @@ public class FreenetURITest {
 		new FreenetURI("SSK@");
 	}
 
+	@Test
+	public void internedUskIsPreserved() throws MalformedURLException {
+		FreenetURI uri1 = new FreenetURI(WANNA_USK_1);
+		assertEquals(uri1.toString(), uri1.intern().toString());
+	}
 }


### PR DESCRIPTION
I noticed that the suggested edition was not preserved when calling intern() in FreenetURI. Here is a unit test to prove this. This test currently fails.

I assume a fix would be simple enough, I haven't provided any. The consequences of a fix in fred and in the modules, I guess could be confusing so maybe fixing this method is not the best option.