### PR TITLE
Replace Pointer.SIZE with Native.POINTER_SIZE for JNA 5.x

### DIFF
--- a/src/freenet/io/comm/UdpSocketHandler.java
+++ b/src/freenet/io/comm/UdpSocketHandler.java
@@ -120,7 +120,7 @@ public class UdpSocketHandler implements PrioRunnable, PacketSocketHandler, Port
 			    return false;
 			int ret = -1;
 			try {
-			    ret = socketOptionsHolder.setsockopt(fd, SOCKET_level.IPPROTO_IPV6.linux, p.option_name.linux, new IntByReference(p.linux).getPointer(), Pointer.SIZE);
+			    ret = socketOptionsHolder.setsockopt(fd, SOCKET_level.IPPROTO_IPV6.linux, p.option_name.linux, new IntByReference(p.linux).getPointer(), Native.POINTER_SIZE);
 			} catch(Exception e) { Logger.normal(UdpSocketHandler.class, e.getMessage(),e); } //if it fails that's fine
 			return (ret == 0 ? true : false);
 		}


### PR DESCRIPTION
This commit will make this program more "future-proof" by preparing it for the latest major release of JNA, which is a dependency of this program.  There are some minor API-incompatible changes between JNA 4.5.2 (which this program uses as of now) and 5.x, and removal of `Pointer.SIZE` is one of them.  The replacement API is `Native.POINTER_SIZE`; see the first bug linked in the commit message for details.

This commit does not break compatibility with JNA 4.5.2 because `Native.POINTER_SIZE` is available in both 4.5.2 and 5.x, so you guys are still free to either stick with JNA 4.5.2 or update.  On some GNU/Linux distributions, like Gentoo, we might build this program against a newer JNA version (5.10.0), and we currently rely on a patch containing this commit to fix the incompatibility issue (see the second bug linked in the commit message).  If this pull request could get merged, it would benefit both parties as you would have one less source of hassle when you decide to update to JNA 5.x in the future, and we could drop the out-of-tree patch, which we would try to avoid adding unless deemed necessary.