### PR TITLE
fix: this threw an exception if the checksum was exactly [0,0,0,0].

### DIFF
--- a/src/freenet/client/async/SplitFileInserterSegmentStorage.java
+++ b/src/freenet/client/async/SplitFileInserterSegmentStorage.java
@@ -569,8 +569,6 @@ public class SplitFileInserterSegmentStorage {
         int checksumLength = parent.checker.checksumLength();
         System.arraycopy(buf, 0, checkBuf, prefix.length, buf.length - checksumLength);
         byte[] checksum = Arrays.copyOfRange(buf, buf.length - checksumLength, buf.length);
-        if(parent.checker.checkChecksum(checkBuf, 0, checkBuf.length, checksum))
-            throw new MissingKeyException();
         DataInputStream dis = new DataInputStream(new ByteArrayInputStream(buf));
         byte b = dis.readByte();
         if(b != 1) throw new MissingKeyException();


### PR DESCRIPTION
CRC32 can legally be 0000, so this had the chance to fail falsely.

It was implemented 2014 in one go for storage for splitfile inserts,
so I expect this to have been just a bug.