### PR TITLE
Stop storing blocks twice

### DIFF
--- a/src/freenet/node/Node.java
+++ b/src/freenet/node/Node.java
@@ -3734,7 +3734,7 @@ public class Node implements TimeSkewDetectorCallback {
 	 * Store a datum.
 	 * @param block
 	 *      a KeyBlock
-	 * @param deep If true, insert to the store as well as the cache. Do not set
+	 * @param deep If true, insert to the store rather than the cache. Do not set
 	 * this to true unless the store results from an insert, and this node is the
 	 * closest node to the target; see the description of chkDatastore.
 	 */
@@ -3764,9 +3764,10 @@ public class Node implements TimeSkewDetectorCallback {
 					chkDatastore.put(block, !canWriteDatastore);
 					nodeStats.avgStoreCHKLocation.report(loc);
 
+				} else {
+					chkDatacache.put(block, !canWriteDatastore);
+					nodeStats.avgCacheCHKLocation.report(loc);
 				}
-				chkDatacache.put(block, !canWriteDatastore);
-				nodeStats.avgCacheCHKLocation.report(loc);
 			}
 			if (canWriteDatastore || forULPR || useSlashdotCache)
 				failureTable.onFound(block);
@@ -3812,9 +3813,10 @@ public class Node implements TimeSkewDetectorCallback {
 				if(deep) {
 					sskDatastore.put(block, overwrite, !canWriteDatastore);
 					nodeStats.avgStoreSSKLocation.report(loc);
+				} else {
+					sskDatacache.put(block, overwrite, !canWriteDatastore);
+					nodeStats.avgCacheSSKLocation.report(loc);
 				}
-				sskDatacache.put(block, overwrite, !canWriteDatastore);
-				nodeStats.avgCacheSSKLocation.report(loc);
 			}
 			if(canWriteDatastore || forULPR || useSlashdotCache)
 				failureTable.onFound(block);


### PR DESCRIPTION
*code sent on FMS, not written by me, reviewed by me*

The logic was wrong, causing all blocks written to the store to also
be written to the cache. The store is written to in about half the
speed of the cache. This means effective cache storage capacity is
only 50% of what it should be, the other 50% hold copies of the store.

Whenever we get an incoming request, we already check both the cache
and store to see if we can fulfill the request. We also already make
sure the block never gets promoted from store to cache later on.

This fix may improve total network capacity significantly.