### PR TITLE
Fix translations and UpdatedVersionAvailableUserAlert.updateNowButton

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,8 @@
 next:
 
 - Show a user alert (once every Freenet update) if the datastore is
-  below 10% of available space   thanks to Trivuele
+  below 10% of available space with a link to the store size wizard page
+  to make it easy to increase the store ― thanks to Trivuele
 - Do not store blocks in the cache, if they are eligible for the store
   (should increase usable cache size)   thanks to Trivuele
 - m3u-player: more robust sizes, do not use overlay for audio. This

--- a/src/freenet/l10n/BaseL10n.java
+++ b/src/freenet/l10n/BaseL10n.java
@@ -581,16 +581,16 @@ public class BaseL10n {
 	/**
 	 * Get the default value for a key.
 	 * @param key Key to search for.
-	 * @return String
+	 * @return the matching string in the fallback language (English); the raw key if there is no entry for it in the fallback language.
 	 */
 	public String getDefaultString(String key) {
-        return getStrings(key, FallbackState.CURRENT_LANG).iterator().next();
+        return getStrings(key, FallbackState.FALLBACK_LANG).iterator().next();
 	}
 
 	/**
 	 * Get the default value for a key.
 	 * @param key Key to search for.
-	 * @return String
+	 * @return the matching string in the fallback language (English); the raw key if there is no entry for it in the fallback language. Patterns are replaced by the matching values.
 	 */
 	public String getDefaultString(String key, String[] patterns, String[] values) {
 		assert (patterns.length == values.length);

--- a/src/freenet/l10n/BaseL10n.java
+++ b/src/freenet/l10n/BaseL10n.java
@@ -584,7 +584,7 @@ public class BaseL10n {
 	 * @return String
 	 */
 	public String getDefaultString(String key) {
-        return getStrings(key, FallbackState.FALLBACK_LANG).iterator().next();
+        return getStrings(key, FallbackState.CURRENT_LANG).iterator().next();
 	}
 
 	/**

--- a/src/freenet/node/updater/MainJarUpdater.java
+++ b/src/freenet/node/updater/MainJarUpdater.java
@@ -410,7 +410,7 @@ public class MainJarUpdater extends NodeUpdater implements Deployer {
 
                 @Override
                 public String dismissButtonText() {
-                    return NodeL10n.getBase().getDefaultString("UpdatedVersionAvailableUserAlert.updateNowButton");
+                    return NodeL10n.getBase().getString("UpdatedVersionAvailableUserAlert.updateNowButton");
                 }
 
                 @Override


### PR DESCRIPTION
It used the FALLBACK_LANG to get the fallback lang, but
iterator().next() skipped to the next value, which is the raw key.

This had also broken our whole translation system.