### PR TITLE
m3u-player: skip tracks that fail.

### DIFF
--- a/src/freenet/clients/http/ToadletContextImpl.java
+++ b/src/freenet/clients/http/ToadletContextImpl.java
@@ -465,7 +465,7 @@ public class ToadletContextImpl implements ToadletContext {
 	private static String generateRestrictedScriptSrc() {
 		// TODO: auto-generate these hashes from the path to the source file
 		String[] allowedScriptHashes = new String[] {
-				"sha256-KY83PQJfSazuB58nUE619z075YyMtVHGQOWeyALG0kU=" // freenet/clients/http/staticfiles/js/m3u-player.js
+				"sha256-daSSQeS23MkRvxlybdcSz2dCNbK/T+BTZz+fhG2cZwI=" // freenet/clients/http/staticfiles/js/m3u-player.js
 		};
 		if (allowedScriptHashes.length == 0) {
 			return "'none'";

--- a/src/freenet/clients/http/ToadletContextImpl.java
+++ b/src/freenet/clients/http/ToadletContextImpl.java
@@ -465,7 +465,7 @@ public class ToadletContextImpl implements ToadletContext {
 	private static String generateRestrictedScriptSrc() {
 		// TODO: auto-generate these hashes from the path to the source file
 		String[] allowedScriptHashes = new String[] {
-				"sha256-daSSQeS23MkRvxlybdcSz2dCNbK/T+BTZz+fhG2cZwI=" // freenet/clients/http/staticfiles/js/m3u-player.js
+				"sha256-RY9OjosvFxocXEmcUqBJ2v1KByDRdUgnGHYSL3Qx/t8=" // freenet/clients/http/staticfiles/js/m3u-player.js
 		};
 		if (allowedScriptHashes.length == 0) {
 			return "'none'";

--- a/src/freenet/clients/http/ToadletContextImpl.java
+++ b/src/freenet/clients/http/ToadletContextImpl.java
@@ -465,7 +465,7 @@ public class ToadletContextImpl implements ToadletContext {
 	private static String generateRestrictedScriptSrc() {
 		// TODO: auto-generate these hashes from the path to the source file
 		String[] allowedScriptHashes = new String[] {
-				"sha256-65KUrjDrXy9qaXvBwlb07WWlUykh3VGs+JkSgxAPqlc=" // freenet/clients/http/staticfiles/js/m3u-player.js
+				"sha256-KY83PQJfSazuB58nUE619z075YyMtVHGQOWeyALG0kU=" // freenet/clients/http/staticfiles/js/m3u-player.js
 		};
 		if (allowedScriptHashes.length == 0) {
 			return "'none'";

--- a/src/freenet/clients/http/staticfiles/js/m3u-player.js
+++ b/src/freenet/clients/http/staticfiles/js/m3u-player.js
@@ -290,6 +290,8 @@ function initPlayer(mediaTag) {
   left.onclick = () => changeTrack(mediaTag, -1);
   right.innerHTML = "&gt;";
   right.onclick = () => changeTrack(mediaTag, +1);
+  // if loading fails, skip to the next track. Be resilient against error for listening in the background
+  mediaTag.addEventListener("error", () => changeTrack(mediaTag, +1));
   fetchPlaylist(
     url,
     () => {


### PR DESCRIPTION
This increases the resilience against failing fragments (which do happen in Freenet, especially in live-streaming where the problem might actually be a failed upload).

The goal of this change is to enable listening in the background without having to interact with the freenet player after the initial start of playback.