### PR TITLE
Add css transition and word-breaking support by naejadu

### DIFF
--- a/src/freenet/client/filter/CSSTokenizerFilter.java
+++ b/src/freenet/client/filter/CSSTokenizerFilter.java
@@ -180,18 +180,18 @@ class CSSTokenizerFilter {
 		allelementVerifiers.add("caret-color");
 		allelementVerifiers.add("clear");
 		allelementVerifiers.add("clip");
-                allelementVerifiers.add("break-before");
-                allelementVerifiers.add("break-after");
-                allelementVerifiers.add("break-inside");
-                allelementVerifiers.add("column-count");
-                allelementVerifiers.add("column-fill");
-                allelementVerifiers.add("column-gap");
-                allelementVerifiers.add("column-rule-color");
-                allelementVerifiers.add("column-rule-style");
-                allelementVerifiers.add("column-rule-width");
-                allelementVerifiers.add("column-span");
+		allelementVerifiers.add("break-before");
+		allelementVerifiers.add("break-after");
+		allelementVerifiers.add("break-inside");
+		allelementVerifiers.add("column-count");
+		allelementVerifiers.add("column-fill");
+		allelementVerifiers.add("column-gap");
+		allelementVerifiers.add("column-rule-color");
+		allelementVerifiers.add("column-rule-style");
+		allelementVerifiers.add("column-rule-width");
+		allelementVerifiers.add("column-span");
 		allelementVerifiers.add("column-rule");
-                allelementVerifiers.add("column-width");
+		allelementVerifiers.add("column-width");
 		allelementVerifiers.add("columns");
 		allelementVerifiers.add("color");
 		allelementVerifiers.add("color-interpolation");
@@ -306,6 +306,10 @@ class CSSTokenizerFilter {
 		allelementVerifiers.add("top");
 		allelementVerifiers.add("transform");
 		allelementVerifiers.add("transform-origin");
+		allelementVerifiers.add("transition-delay");
+		allelementVerifiers.add("transition-duration");
+		allelementVerifiers.add("transition-property");
+		allelementVerifiers.add("transition-timing-function");
 		allelementVerifiers.add("unicode-bidi");
 		allelementVerifiers.add("vertical-align");
 		allelementVerifiers.add("visibility");
@@ -317,7 +321,7 @@ class CSSTokenizerFilter {
 		allelementVerifiers.add("width");
 		allelementVerifiers.add("word-break");
 		allelementVerifiers.add("word-spacing");
-                allelementVerifiers.add("word-wrap");
+		allelementVerifiers.add("word-wrap");
 		allelementVerifiers.add("z-index");
 
 
@@ -327,7 +331,7 @@ class CSSTokenizerFilter {
 	 * Array for storing additional Verifier objects for validating Regular expressions in CSS Property value
 	 * e.g. [ <color> | transparent]{1,4}. It is explained in detail in CSSPropertyVerifier class
 	 */
-	private final static CSSPropertyVerifier[] auxilaryVerifiers=new CSSPropertyVerifier[145];
+	private final static CSSPropertyVerifier[] auxilaryVerifiers=new CSSPropertyVerifier[148];
 	static
 	{
 		/*CSSPropertyVerifier(String[] allowedValues,String[] possibleValues,String expression,boolean onlyValueVerifier)*/
@@ -416,6 +420,14 @@ class CSSTokenizerFilter {
 		// used in nav-down, nav-left, nav-right and nav-up
 		auxilaryVerifiers[143] = new CSSPropertyVerifier(null, Arrays.asList("se"), null, null, true);
 		auxilaryVerifiers[144] = new CSSPropertyVerifier(Arrays.asList("current", "root"), Arrays.asList("st"), null, null, true);
+		
+		// <transition-delay> & <transition-duration>
+		auxilaryVerifiers[145]=new CSSPropertyVerifier(null, Arrays.asList("ti"), null, null, true);
+		// <transition-property>
+		auxilaryVerifiers[146]=new CSSPropertyVerifier(null, Arrays.asList("id"), null, null, true);
+		// <transition-timing-function>
+		// TODO: Add function values: steps(...) & cubic-bezier(...) similar to freenet.client.filter.FilterUtils.isCSSTransform(String)
+		auxilaryVerifiers[147]=new CSSPropertyVerifier(Arrays.asList("ease","ease-in","ease-out","ease-in-out","linear","step-start","step-end"), null, null, null, true);
 	}
 	/* This function loads a verifier object in elementVerifiers.
 	 * After the object has been loaded, property name is removed from allelementVerifier.
@@ -1611,6 +1623,46 @@ class CSSTokenizerFilter {
 		else if("z-index".equalsIgnoreCase(element))
 		{
 			elementVerifiers.put(element,new CSSPropertyVerifier(Arrays.asList("auto"),ElementInfo.VISUALMEDIA,Arrays.asList("in")));
+			allelementVerifiers.remove(element);
+		}
+		else if("transition-delay".equalsIgnoreCase(element))
+		{
+			elementVerifiers.put(element,new CSSPropertyVerifier(null,ElementInfo.VISUALMEDIA,null,Arrays.asList("145<1,65535>"),false,true));
+			allelementVerifiers.remove(element);
+		}
+		else if("transition-duration".equalsIgnoreCase(element))
+		{
+			elementVerifiers.put(element,new CSSPropertyVerifier(null,ElementInfo.VISUALMEDIA,null,Arrays.asList("145<1,65535>"),false,true));
+			allelementVerifiers.remove(element);
+		}
+		else if("transition-property".equalsIgnoreCase(element))
+		{
+			elementVerifiers.put(element,new CSSPropertyVerifier(null,ElementInfo.VISUALMEDIA,null,Arrays.asList("146<1,65535>"),false,true));
+			allelementVerifiers.remove(element);
+		}
+		else if("transition-timing-function".equalsIgnoreCase(element))
+		{
+			elementVerifiers.put(element,new CSSPropertyVerifier(null,ElementInfo.VISUALMEDIA,null,Arrays.asList("147<1,65535>"),false,true));
+			allelementVerifiers.remove(element);
+		}
+		else if("transition-delay".equalsIgnoreCase(element))
+		{
+			elementVerifiers.put(element,new CSSPropertyVerifier(null,ElementInfo.VISUALMEDIA,null,Arrays.asList("145<1,65535>"),false,true));
+			allelementVerifiers.remove(element);
+		}
+		else if("transition-duration".equalsIgnoreCase(element))
+		{
+			elementVerifiers.put(element,new CSSPropertyVerifier(null,ElementInfo.VISUALMEDIA,null,Arrays.asList("145<1,65535>"),false,true));
+			allelementVerifiers.remove(element);
+		}
+		else if("transition-property".equalsIgnoreCase(element))
+		{
+			elementVerifiers.put(element,new CSSPropertyVerifier(null,ElementInfo.VISUALMEDIA,null,Arrays.asList("146<1,65535>"),false,true));
+			allelementVerifiers.remove(element);
+		}
+		else if("transition-timing-function".equalsIgnoreCase(element))
+		{
+			elementVerifiers.put(element,new CSSPropertyVerifier(null,ElementInfo.VISUALMEDIA,null,Arrays.asList("147<1,65535>"),false,true));
 			allelementVerifiers.remove(element);
 		}
 	}

--- a/src/freenet/client/filter/HTMLFilter.java
+++ b/src/freenet/client/filter/HTMLFilter.java
@@ -992,7 +992,8 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
 				"footer",
 				"article",
 				"section",
-				"hgroup"};
+				"hgroup",
+				"wbr"};
 		for (String x: group2)
 			allowedTagsVerifiers.put(
 				x,

--- a/test/freenet/client/filter/CSSParserTest.java
+++ b/test/freenet/client/filter/CSSParserTest.java
@@ -876,6 +876,28 @@ public class CSSParserTest extends TestCase {
 		propertyTests.put("body { nav-left: div.bold '<target-name>'; }",  "body { }");
 		propertyTests.put("button#foo { nav-left: #bar \"sidebar\"; }", "button#foo { nav-left: #bar \"sidebar\"; }");
 		propertyTests.put("button#foo { nav-left: invalidSelector \"sidebar\"; }", "button#foo { }");
+		
+		// transition-* 
+		// valid, 1 value
+		propertyTests.put("div { transition-duration: 5s; }", "div { transition-duration: 5s; }");
+		propertyTests.put("div { transition-delay: 1s; }", "div { transition-delay: 1s; }");
+		propertyTests.put("div { transition-property: width; }", "div { transition-property: width; }");
+		propertyTests.put("div { transition-timing-function: ease; }", "div { transition-timing-function: ease; }");
+		// valid, 2 values
+		propertyTests.put("div { transition-duration: 5s, 1s; }", "div { transition-duration: 5s, 1s; }");
+		propertyTests.put("div { transition-delay: 1s, 3s; }", "div { transition-delay: 1s, 3s; }");
+		propertyTests.put("div { transition-property: width, transform; }", "div { transition-property: width, transform; }");
+		propertyTests.put("div { transition-timing-function: ease, ease-out; }", "div { transition-timing-function: ease, ease-out; }");
+		// invalid, no values
+		propertyTests.put("div { transition-duration: ; }", "div { }");
+		propertyTests.put("div { transition-delay: ; }", "div { }");
+		propertyTests.put("div { transition-property: ; }", "div { }");
+		propertyTests.put("div { transition-timing-function: ; }", "div { }");
+		// invalid, wrong values
+		propertyTests.put("div { transition-duration: \"test\"; }", "div { }");
+		propertyTests.put("div { transition-delay: \"test\"; }", "div { }");
+		propertyTests.put("div { transition-property: \"test\"; }", "div { }");
+		propertyTests.put("div { transition-timing-function: \"test\"; }", "div { }");
 	}
 
 	FilterMIMEType cssMIMEType;


### PR DESCRIPTION
FMS-message:

Word breaking is not fully supported right now.

What I'd need for Freenet-Quickstart is <wbr> as a html tag and "transition-duration" & "transition-delay" as css tags.

<wbr> indicates possible places for the browser to do a word break, which is very much needed for long USK that usually break the page layout because the browser does not break them at all.

This is a very easy fix, you can just add it to freenet.client.filter.HTMLFilter.getAllowedTagVerifiers().group2

----------
I need the css to show a popup with a help tooltip when hovering over a link. The popup should be visible for a second after the cursor leaves the link, so you can actually move your mouse to the popup and copy text from there. Right now the popup vanishes instantly - see the purple links I have on Freenet-Quickstart.

Adding css is more complicated, but I took the time to figure it out and wrote a patch.

Please copy the explanation below to the issue tracker along with the patch.

----------
This patch adds the html <wbr> tag as well as the transition-* css tags to the FRED filter.

Transition tags support multiple entries as a comma separated list:

transition-duration: 5s, 1s;
transition-delay: 1s, 3s;
transition-property: width, transform;
transition-timing-function: ease, ease-out;
Currently not supported: transition-timing-function with the function values: steps(...) & cubic-bezier(...).

Further information: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Transitions/Using_CSS_transitions

What this patch does:
1) Fix some tab/space issues.
2) Increase array size of "auxilaryVerifiers" because we add new ones.

3) Add three new auxilaryVerifiers (145, 146 & 147) for the transition effects. 3.1) 145: "ti" allows for time values (1s, ...) to be present. 3.2) 146: "id" allows for identifier values (width, height, transform, ...) to be present. Both 145 & 146 are the same as the existing "auxilaryVerifiers[143]", except for ti/id instead of se). 3.3) 147: Allows for a fixed set of keywords (ease, ease-in, ...) to be present. This is the same as the existing "auxilaryVerifiers[70]", except with other keywords.

4) Add each auxilaryVerifier to the corresponding css tag. 4.0) The last 'true' means we can have comma separated values, because transition tags support multiple values. 4.1) "Arrays.asList("145<1,65535>")" means we allow from 1 to 65535 values in the list and apply auxilaryVerifier 145 to each element, so we test that each element is a time value. Same for the other tags. This is similar to the existing "background-origin" tag. 65535 is the value used by existing verifiers.

5) Add <wbr> to HTMLFilter.java.

I tested the new tags with "Filesharing" -> "Filter a file" and they seem to work.