### PR TITLE
Fix prefix detection to support https, web+freenet: and ext+freenet:

### DIFF
--- a/src/freenet/keys/FreenetURI.java
+++ b/src/freenet/keys/FreenetURI.java
@@ -325,8 +325,8 @@ public class FreenetURI implements Cloneable, Comparable<FreenetURI>, Serializab
 		if (logDEBUG) Logger.minor(this, "Created from components (B): "+toString(), new Exception("debug"));
 	}
 
-	// Strip http:// and freenet: prefix
-	protected final static Pattern URI_PREFIX = Pattern.compile("^(http://[^/]+/+)?(freenet:)?");
+	// Strip http(s):// and (web+|ext+)freenet: prefix
+	protected final static Pattern URI_PREFIX = Pattern.compile("^(https?://[^/]+/+)?(((ext|web)\+)?freenet:)?");
 
 	public FreenetURI(String URI) throws MalformedURLException {
 		this(URI, false);


### PR DESCRIPTION
Support web+freenet: and ext+freenet: as protocol handlers since it doesn't look like freenet: is getting whitelisted any time soon.

https seems to work without the change, perhaps the host part is currently always being stripped before calling the function?  Added the check to allow it in case that ever changes.