### PR TITLE
only include the inline m3u player if the page contains media-tags

### DIFF
--- a/src/freenet/client/filter/HTMLFilter.java
+++ b/src/freenet/client/filter/HTMLFilter.java
@@ -643,7 +643,7 @@ public class HTMLFilter implements ContentDataFilter, CharsetExtractor {
 						if(pc.onlyDetectingCharset) pc.failedDetectCharset = true;
 					}
 				// if the body is ended and we found a media tag (<video> or <audio>) we include the m3u-player just before the end of the body. 
-				}else if(t.element.compareTo("body")==0 && t.startSlash && pc.wasMediaElementFound == true) {
+				}else if(t.element.compareTo("body")==0 && t.startSlash && pc.wasMediaElementFound) {
 					if (embedM3uPlayer) {
 						w.write(m3uPlayerScriptTagContent);
 					}


### PR DESCRIPTION
This avoids injecting javascript (though secured with a strict CSP header) where it is not needed. The csp-header still ensures that no malicious javascript can leak from previous content of the page.

this was quite long in the making, but I hope that it finally makes the m3u support as clean as it should be. It is a bit less robust than before — if you omit the closing </body> tag, the m3u-player won’t be injected, but then: If you omit the </body>, you should get errors … — and the player is now at the end of the body, not in the head.

Moving to the end of the body may actually be a good thing; with the inline script, it should be ensured that it still registers the on DOM content loaded event before parsing is done.