### PR TITLE
fix: first time wizard caused a startup loop with JS enabled

### DIFF
--- a/src/freenet/clients/http/FirstTimeWizardNewToadlet.java
+++ b/src/freenet/clients/http/FirstTimeWizardNewToadlet.java
@@ -334,6 +334,11 @@ public class FirstTimeWizardNewToadlet extends WebTemplateToadlet {
                 }
             }
 
+            try {
+                config.get("fproxy").set("hasCompletedWizard", true);
+            } catch (ConfigException e) {
+                Logger.error(this, "Should not happen, please report! " + e, e);
+            }
             core.storeConfig();
         }
     }

--- a/src/freenet/clients/http/SimpleToadletServer.java
+++ b/src/freenet/clients/http/SimpleToadletServer.java
@@ -985,9 +985,10 @@ public final class SimpleToadletServer implements ToadletContainer, Runnable, Li
 			//If the user has not completed the wizard, only allow access to the wizard and static
 			//resources. Anything else redirects to the first page of the wizard.
 			if (!(path.startsWith(FirstTimeWizardToadlet.TOADLET_URL) ||
-				path.startsWith(StaticToadlet.ROOT_URL) ||
-				path.startsWith(ExternalLinkToadlet.PATH) ||
-				path.equals("/favicon.ico"))) {
+			      path.startsWith(FirstTimeWizardNewToadlet.TOADLET_URL) ||
+			      path.startsWith(StaticToadlet.ROOT_URL) ||
+			      path.startsWith(ExternalLinkToadlet.PATH) ||
+			      path.equals("/favicon.ico"))) {
 				try {
 					throw new PermanentRedirectException(new URI(null, null, null, -1, FirstTimeWizardToadlet.TOADLET_URL, uri.getQuery(), null));
 				} catch(URISyntaxException e) { throw new Error(e); }


### PR DESCRIPTION
with JS enabled, a new install redirected from /wizard to /wiz with Javascript and then redirected back to /wizard due to the check for the first time wizard.

And filling out the first time wizard did not set the wizard filled out flag, so new users with Javascript enabled wouldn’t be able to get out of the wizard whatever they did.