### PR TITLE
Fix KeepAlive error on new keys

### DIFF
--- a/src/freenet/client/HighLevelSimpleClientImpl.java
+++ b/src/freenet/client/HighLevelSimpleClientImpl.java
@@ -198,7 +198,11 @@ public class HighLevelSimpleClientImpl implements HighLevelSimpleClient, Request
 
 	@Override
 	public ClientGetter fetch(FreenetURI uri, long maxSize, ClientGetCallback callback, FetchContext fctx, short prio) throws FetchException {
-		fctx.maxOutputLength = maxSize;
+		if (maxSize > 0) {
+			fctx.maxOutputLength = maxSize;
+			fctx.maxTempLength = maxSize;
+		}
+		
 		return fetch(uri, callback, fctx, prio);
 	}
 

--- a/src/freenet/client/async/SingleKeyListener.java
+++ b/src/freenet/client/async/SingleKeyListener.java
@@ -57,7 +57,7 @@ public class SingleKeyListener implements KeyListener {
 			fetcher.onGotKey(key, found, context);
 		} catch (Throwable t) {
 			Logger.error(this, "Failed: "+t, t);
-			fetcher.onFailure(new LowLevelGetException(LowLevelGetException.INTERNAL_ERROR), null, context);
+			fetcher.onFailure(new LowLevelGetException(LowLevelGetException.INTERNAL_ERROR, t), null, context);
 		}
 		synchronized(this) {
 			done = true;

--- a/src/freenet/node/LowLevelGetException.java
+++ b/src/freenet/node/LowLevelGetException.java
@@ -92,6 +92,11 @@ public class LowLevelGetException extends LightweightException {
 		super(getMessage(reason));
 		this.code = reason;
 	}
+
+	public LowLevelGetException(int reason, Throwable t) {
+		super(getMessage(reason), t);
+		this.code = reason;
+	}
 	
 	@Override
 	public String toString() {


### PR DESCRIPTION
- fix negative maxsize per new fetch override
- also override maxTempLength
- LowLevelGetException also return the throwable because the error doesnt help, the real gets hidden

see: https://github.com/freenet/plugin-KeepAlive/pull/2