### PR TITLE
Continue deleting other files when some fail to delete in FileUtils

### DIFF
--- a/src/freenet/clients/http/StaticToadlet.java
+++ b/src/freenet/clients/http/StaticToadlet.java
@@ -140,7 +140,7 @@ public class StaticToadlet extends Toadlet {
 
 	/** Do we have a specific static file? Note that override files are not 
 	 * supported here as it is a static method.
-	 * @param The path to the file, relative to the staticfiles directory.
+	 * @param path The path to the file, relative to the staticfiles directory.
 	 */
 	public static boolean haveFile(String path) {
 		URL url = StaticToadlet.class.getResource(ROOT_PATH+path);

--- a/src/freenet/clients/http/Toadlet.java
+++ b/src/freenet/clients/http/Toadlet.java
@@ -218,7 +218,7 @@ public abstract class Toadlet {
 	/**
 	 * Write an HTTP response, e.g. a page, an image, an error message, possibly with custom
 	 * headers, for example, we may want to send a redirect, or a file with a specified filename.
-	 * @param ctx The specific request to reply to.
+	 * @param context The specific request to reply to.
 	 * @param code The HTTP reply code to use.
 	 * @param mimeType The MIME type of the data we are returning.
 	 * @param desc The HTTP response description for the code.
@@ -327,8 +327,8 @@ public abstract class Toadlet {
 	 * @param mimeType The MIME type of the data we are returning.
 	 * @param desc The HTTP response description for the code.
 	 * @param headers The additional HTTP headers to send.
-	 * @param data The data to write as the response body.
-	 * @param offset The offset within data of the first byte to send.
+	 * @param buffer The data to write as the response body.
+	 * @param startIndex The offset within data of the first byte to send.
 	 * @param length The number of bytes of data to send as the response body.
 	 */
 	private void writeReply(ToadletContext context, int code, String mimeType, String desc, MultiValueTable<String, String> headers, byte[] buffer, int startIndex, int length, boolean forceDisableJavascript) throws ToadletContextClosedException, IOException {

--- a/src/freenet/clients/http/ToadletContext.java
+++ b/src/freenet/clients/http/ToadletContext.java
@@ -27,8 +27,6 @@ public interface ToadletContext {
      * @param mvt Any extra headers. Can be null.
      * @param mimeType The MIME type of the reply.
      * @param length The length of the reply.
-     * @param forceDisableJavascript Disable javascript even if it is enabled for the web interface
-     * as a whole.
      */
     void sendReplyHeaders(int code, String desc, MultiValueTable<String,String> mvt, String mimeType, long length) throws ToadletContextClosedException, IOException;
     

--- a/src/freenet/support/io/FileUtil.java
+++ b/src/freenet/support/io/FileUtil.java
@@ -592,12 +592,16 @@ final public class FileUtil {
 				return false;
 			}
 		} else {
+			boolean success = true;
 			for(File subfile: wd.listFiles()) {
-				if(!removeAll(subfile)) return false;
+				if(!secureDeleteAll(subfile)){
+					success = false;
+				}
 			}
 			if(!wd.delete()) {
 				Logger.error(FileUtil.class, "Could not delete directory: "+wd);
 			}
+			return success;
 		}
 		return true;
 	}
@@ -613,12 +617,16 @@ final public class FileUtil {
 				return false;
 			}
 		} else {
+			boolean success = true;
 			for(File subfile: wd.listFiles()) {
-				if(!removeAll(subfile)) return false;
+				if(!removeAll(subfile)){
+					success = false;
+				}
 			}
 			if(!wd.delete()) {
 				Logger.error(FileUtil.class, "Could not delete directory: "+wd);
 			}
+			return success;
 		}
 		return true;
 	}

--- a/src/freenet/support/io/FileUtil.java
+++ b/src/freenet/support/io/FileUtil.java
@@ -594,9 +594,7 @@ final public class FileUtil {
 		} else {
 			boolean success = true;
 			for(File subfile: wd.listFiles()) {
-				if(!secureDeleteAll(subfile)){
-					success = false;
-				}
+				success &= secureDeleteAll(subfile);
 			}
 			if(!wd.delete()) {
 				Logger.error(FileUtil.class, "Could not delete directory: "+wd);
@@ -619,9 +617,7 @@ final public class FileUtil {
 		} else {
 			boolean success = true;
 			for(File subfile: wd.listFiles()) {
-				if(!removeAll(subfile)){
-					success = false;
-				}
+				success &= removeAll(subfile);
 			}
 			if(!wd.delete()) {
 				Logger.error(FileUtil.class, "Could not delete directory: "+wd);
@@ -630,24 +626,24 @@ final public class FileUtil {
 		}
 		return true;
 	}
-	
+
+	/**
+	 * Secure deleting this file or everything in this directory.
+	 * @param file the file or directory to delete
+	 * @throws IOException deletion failed
+	 */
 	public static void secureDelete(File file) throws IOException {
 		// FIXME somebody who understands these things should have a look at this...
 		if(!file.exists()) return;
 		long size = file.length();
 		if(size > 0) {
-			RandomAccessFile raf = null;
-			try {
-				System.out.println("Securely deleting "+file+" which is of length "+size+" bytes...");
-				raf = new RandomAccessFile(file, "rw");
+			System.out.println("Securely deleting "+file+" which is of length "+size+" bytes...");
+			try (RandomAccessFile raf = new RandomAccessFile(file, "rw")) {
 				// Random data first.
 				raf.seek(0);
 				fill(new RandomAccessFileOutputStream(raf), size);
 				raf.getFD().sync();
 				raf.close();
-				raf = null;
-			} finally {
-				Closer.close(raf);
 			}
 		}
 		if((!file.delete()) && file.exists())

--- a/src/freenet/support/io/TempBucketFactory.java
+++ b/src/freenet/support/io/TempBucketFactory.java
@@ -719,7 +719,7 @@ public class TempBucketFactory implements BucketFactory, LockableRandomAccessBuf
 	 * just to free up space. Otherwise we will migrate all long-lived buckets but
 	 * not any others. 
 	 * @return True if we migrated any buckets.
-	 * @throws InsufficientSpaceException If there is not enough space to migrate buckets to disk.
+	 * @throws InsufficientDiskSpaceException If there is not enough space to migrate buckets to disk.
 	 */
 	private boolean cleanBucketQueue(long now, boolean force) throws InsufficientDiskSpaceException {
 		boolean shouldContinue = true;

--- a/test/freenet/client/async/ClientRequestSelectorTest.java
+++ b/test/freenet/client/async/ClientRequestSelectorTest.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Random;
 
+import org.junit.After;
 import org.junit.Test;
 
 import freenet.client.ClientMetadata;
@@ -84,6 +85,11 @@ public class ClientRequestSelectorTest {
         checker = new CRCChecksumChecker();
         memoryLimitedJobRunner = new MemoryLimitedJobRunner(9 * 1024 * 1024L, 20, executor, NativeThread.JAVA_PRIORITY_RANGE);
         jobRunner = new DummyJobRunner(executor, null);
+    }
+
+    @After
+    public void tearDown() {
+        FileUtil.removeAll(dir);
     }
 
     private static class MyCallback implements SplitFileInserterStorageCallback {

--- a/test/freenet/client/async/ClientRequestSelectorTest.java
+++ b/test/freenet/client/async/ClientRequestSelectorTest.java
@@ -69,7 +69,7 @@ public class ClientRequestSelectorTest {
     final PersistentJobRunner jobRunner;
 
     public ClientRequestSelectorTest() throws IOException {
-        dir = new File("split-file-inserter-storage-test");
+        dir = new File("client-request-selector-test");
         dir.mkdir();
         executor = new WaitableExecutor(new PooledExecutor());
         ticker = new CheatingTicker(executor);

--- a/test/freenet/client/async/SplitFileInserterStorageTest.java
+++ b/test/freenet/client/async/SplitFileInserterStorageTest.java
@@ -13,9 +13,10 @@ import java.util.HashSet;
 import java.util.Random;
 
 import freenet.support.io.*;
-import org.junit.After;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import freenet.client.ClientMetadata;
 import freenet.client.FetchContext;
@@ -66,6 +67,8 @@ public class SplitFileInserterStorageTest {
     final LockableRandomAccessBufferFactory bigRAFFactory;
     final BucketFactory smallBucketFactory;
     final BucketFactory bigBucketFactory;
+    @Rule
+    public final TemporaryFolder tempFolder;
     final File dir;
     final InsertContext baseContext;
     final WaitableExecutor executor;
@@ -86,8 +89,9 @@ public class SplitFileInserterStorageTest {
     private InsertContext context;
 
     public SplitFileInserterStorageTest() throws IOException {
-        dir = new File("split-file-inserter-storage-test");
-        dir.mkdir();
+        tempFolder = new TemporaryFolder();
+        tempFolder.create();
+        dir = tempFolder.newFolder("split-file-inserter-storage-test");
         executor = new WaitableExecutor(new PooledExecutor());
         ticker = new CheatingTicker(executor);
         RandomSource r = new DummyRandomSource(12345);
@@ -110,11 +114,6 @@ public class SplitFileInserterStorageTest {
         hashes = getHashes(data);
         keys = new MyKeysFetchingLocally();
         context = baseContext.clone();
-    }
-
-    @After
-    public void tearDown() {
-        FileUtil.removeAll(dir);
     }
 
     private static class MyCallback implements SplitFileInserterStorageCallback {

--- a/test/freenet/client/async/SplitFileInserterStorageTest.java
+++ b/test/freenet/client/async/SplitFileInserterStorageTest.java
@@ -13,6 +13,7 @@ import java.util.HashSet;
 import java.util.Random;
 
 import freenet.support.io.*;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -109,6 +110,11 @@ public class SplitFileInserterStorageTest {
         hashes = getHashes(data);
         keys = new MyKeysFetchingLocally();
         context = baseContext.clone();
+    }
+
+    @After
+    public void tearDown() {
+        FileUtil.removeAll(dir);
     }
 
     private static class MyCallback implements SplitFileInserterStorageCallback {

--- a/test/freenet/client/filter/ContentFilterTest.java
+++ b/test/freenet/client/filter/ContentFilterTest.java
@@ -10,10 +10,8 @@ import static org.junit.Assert.*;
 
 import freenet.l10n.BaseL10n;
 import freenet.l10n.BaseL10nTest;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
+
+import java.io.*;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -357,6 +355,7 @@ public class ContentFilterTest {
         try (
             FileOutputStream fos = new FileOutputStream("output.utf16")
         ){
+            new File("output.utf16").deleteOnExit();
             ArrayBucket out = new ArrayBucket();
             filter.readFilter(new ArrayBucket(total).getInputStream(), out.getOutputStream(), "UTF-16", null, null, null);
             fos.write(out.toByteArray());
@@ -373,6 +372,7 @@ public class ContentFilterTest {
         try (
             FileOutputStream fos = new FileOutputStream("output.filtered")
         ){
+            new File("output.filtered").deleteOnExit();
             ArrayBucket out = new ArrayBucket();
             FilterStatus fo = ContentFilter.filter(new ArrayBucket(total).getInputStream(), out.getOutputStream(), "text/html", null, null, null);
             fos.write(out.toByteArray());
@@ -390,6 +390,7 @@ public class ContentFilterTest {
         if (failed) {
             try (FileOutputStream fos = new FileOutputStream("unfiltered")) {
                 fos.write(total);
+                new File("unfiltered").deleteOnExit();
             }
             throw failures.get(0);
         }

--- a/test/freenet/client/filter/ContentFilterTest.java
+++ b/test/freenet/client/filter/ContentFilterTest.java
@@ -8,10 +8,13 @@ import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.*;
 
-import freenet.l10n.BaseL10n;
 import freenet.l10n.BaseL10nTest;
 
-import java.io.*;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -352,10 +355,10 @@ public class ContentFilterTest {
         HTMLFilter filter = new HTMLFilter();
         boolean failed = false;
         List<RuntimeException> failures = new ArrayList<>();
+        File file = new File("output.utf16");
         try (
-            FileOutputStream fos = new FileOutputStream("output.utf16")
+            FileOutputStream fos = new FileOutputStream(file)
         ){
-            new File("output.utf16").deleteOnExit();
             ArrayBucket out = new ArrayBucket();
             filter.readFilter(new ArrayBucket(total).getInputStream(), out.getOutputStream(), "UTF-16", null, null, null);
             fos.write(out.toByteArray());
@@ -368,11 +371,13 @@ public class ContentFilterTest {
                 e.getCause().printStackTrace();
             }
             // Ok.
+        } finally {
+            file.delete();
         }
+        file = new File("output.filtered");
         try (
-            FileOutputStream fos = new FileOutputStream("output.filtered")
+            FileOutputStream fos = new FileOutputStream(file)
         ){
-            new File("output.filtered").deleteOnExit();
             ArrayBucket out = new ArrayBucket();
             FilterStatus fo = ContentFilter.filter(new ArrayBucket(total).getInputStream(), out.getOutputStream(), "text/html", null, null, null);
             fos.write(out.toByteArray());
@@ -385,12 +390,14 @@ public class ContentFilterTest {
                 e.getCause().printStackTrace();
             }
             // Ok.
+        } finally {
+            file.delete();
         }
 
         if (failed) {
+            // Write debug data. Should never be here.
             try (FileOutputStream fos = new FileOutputStream("unfiltered")) {
                 fos.write(total);
-                new File("unfiltered").deleteOnExit();
             }
             throw failures.get(0);
         }

--- a/test/freenet/crypt/EncryptedRandomAccessBucketTest.java
+++ b/test/freenet/crypt/EncryptedRandomAccessBucketTest.java
@@ -145,11 +145,10 @@ public class EncryptedRandomAccessBucketTest extends BucketTestBase {
         }
     }
     
-    private File base;
+    private final File base = new File("tmp.encrypted-random-access-bucket-test");
     
     @Before
     public void setUp() {
-        base = new File("tmp.encrypted-random-access-thing-test");
         base.mkdir();
     }
     

--- a/test/freenet/crypt/EncryptedRandomAccessBucketTest.java
+++ b/test/freenet/crypt/EncryptedRandomAccessBucketTest.java
@@ -145,10 +145,11 @@ public class EncryptedRandomAccessBucketTest extends BucketTestBase {
         }
     }
     
-    private File base = new File("tmp.encrypted-random-access-thing-test");
+    private File base;
     
     @Before
     public void setUp() {
+        base = new File("tmp.encrypted-random-access-thing-test");
         base.mkdir();
     }
     

--- a/test/freenet/crypt/EncryptedRandomAccessBucketTest.java
+++ b/test/freenet/crypt/EncryptedRandomAccessBucketTest.java
@@ -18,9 +18,9 @@ import java.util.Arrays;
 import java.util.Random;
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import freenet.client.async.ClientContext;
 import freenet.support.api.Bucket;
@@ -30,7 +30,6 @@ import freenet.support.io.ArrayBucket;
 import freenet.support.io.BucketTestBase;
 import freenet.support.io.BucketTools;
 import freenet.support.io.FileBucket;
-import freenet.support.io.FileUtil;
 import freenet.support.io.RAFBucket;
 import freenet.support.io.RandomAccessBufferTestBase;
 import freenet.support.io.ResumeFailedException;
@@ -45,8 +44,11 @@ public class EncryptedRandomAccessBucketTest extends BucketTestBase {
     static{
         Security.addProvider(new BouncyCastleProvider());
     }
-    
-    @Override
+
+    @Rule
+    public final TemporaryFolder tempFolder = new TemporaryFolder();
+
+	@Override
     protected Bucket makeBucket(long size) throws IOException {
         ArrayBucket underlying = new ArrayBucket();
         return new EncryptedRandomAccessBucket(types[0], underlying, secret);
@@ -77,7 +79,7 @@ public class EncryptedRandomAccessBucketTest extends BucketTestBase {
             byte[] buf = new byte[readBytes];
             readBytes = is.read(buf);
             assertTrue(readBytes > 0);
-            assertTrue(Arrays.equals(Arrays.copyOfRange(buf, 0, readBytes), Arrays.copyOfRange(data, moved, moved+readBytes)));
+            assertArrayEquals(Arrays.copyOfRange(buf, 0, readBytes), Arrays.copyOfRange(data, moved, moved + readBytes));
             moved += readBytes;
         }
         is.close();
@@ -104,7 +106,7 @@ public class EncryptedRandomAccessBucketTest extends BucketTestBase {
             byte[] buf = new byte[readBytes];
             readBytes = is.read(buf);
             assertTrue(readBytes > 0);
-            assertTrue(Arrays.equals(Arrays.copyOfRange(buf, 0, readBytes), Arrays.copyOfRange(data, moved, moved+readBytes)));
+            assertArrayEquals(Arrays.copyOfRange(buf, 0, readBytes), Arrays.copyOfRange(data, moved, moved + readBytes));
             moved += readBytes;
         }
         is.close();
@@ -131,7 +133,7 @@ public class EncryptedRandomAccessBucketTest extends BucketTestBase {
             byte[] buf = new byte[readBytes];
             readBytes = is.read(buf);
             assertTrue(readBytes > 0);
-            assertTrue(Arrays.equals(Arrays.copyOfRange(buf, 0, readBytes), Arrays.copyOfRange(data, moved, moved+readBytes)));
+            assertArrayEquals(Arrays.copyOfRange(buf, 0, readBytes), Arrays.copyOfRange(data, moved, moved + readBytes));
             moved += readBytes;
         }
         LockableRandomAccessBuffer raf = bucket.toRandomAccessBuffer();
@@ -144,22 +146,10 @@ public class EncryptedRandomAccessBucketTest extends BucketTestBase {
             RandomAccessBufferTestBase.checkArraySectionEqualsReadData(data, raf, start, end, true);
         }
     }
-    
-    private final File base = new File("tmp.encrypted-random-access-bucket-test");
-    
-    @Before
-    public void setUp() {
-        base.mkdir();
-    }
-    
-    @After
-    public void tearDown() {
-        FileUtil.removeAll(base);
-    }
 
     @Test
     public void testStoreTo() throws IOException, StorageFormatException, ResumeFailedException, GeneralSecurityException {
-        File tempFile = File.createTempFile("test-storeto", ".tmp", base);
+        File tempFile = tempFolder.newFile();
         byte[] buf = new byte[4096];
         Random r = new Random(1267612);
         r.nextBytes(buf);
@@ -195,7 +185,7 @@ public class EncryptedRandomAccessBucketTest extends BucketTestBase {
     
     @Test
     public void testSerialize() throws IOException, StorageFormatException, ResumeFailedException, GeneralSecurityException, ClassNotFoundException {
-        File tempFile = File.createTempFile("test-storeto", ".tmp", base);
+        File tempFile = tempFolder.newFile();
         byte[] buf = new byte[4096];
         Random r = new Random(1267612);
         r.nextBytes(buf);

--- a/test/freenet/crypt/EncryptedRandomAccessBufferTest.java
+++ b/test/freenet/crypt/EncryptedRandomAccessBufferTest.java
@@ -20,8 +20,6 @@ import java.security.Security;
 import java.util.Random;
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -29,10 +27,10 @@ import org.junit.rules.ExpectedException;
 import freenet.client.async.ClientContext;
 import freenet.support.io.BucketTools;
 import freenet.support.io.ByteArrayRandomAccessBuffer;
-import freenet.support.io.FileUtil;
 import freenet.support.io.FileRandomAccessBuffer;
 import freenet.support.io.ResumeFailedException;
 import freenet.support.io.StorageFormatException;
+import org.junit.rules.TemporaryFolder;
 
 public class EncryptedRandomAccessBufferTest {
     private final static EncryptedRandomAccessBufferType[] types = 
@@ -44,7 +42,10 @@ public class EncryptedRandomAccessBufferTest {
     static{
         Security.addProvider(new BouncyCastleProvider());
     }
-    
+
+    @Rule
+    public final TemporaryFolder tempFolder = new TemporaryFolder();
+
     @Rule public ExpectedException thrown= ExpectedException.none();
     
     @Test
@@ -251,22 +252,10 @@ public class EncryptedRandomAccessBufferTest {
                     + " be written to.");
         erat.pwrite(0, result, 0, 20);
     }
-    
-    private final File base = new File("tmp.encrypted-random-access-buffer-test");
-    
-    @Before
-    public void setUp() {
-        base.mkdir();
-    }
-    
-    @After
-    public void tearDown() {
-        FileUtil.removeAll(base);
-    }
 
     @Test
     public void testStoreTo() throws IOException, StorageFormatException, ResumeFailedException, GeneralSecurityException {
-        File tempFile = File.createTempFile("test-storeto", ".tmp", base);
+        File tempFile = tempFolder.newFile();
         byte[] buf = new byte[4096];
         Random r = new Random(1267612);
         r.nextBytes(buf);
@@ -298,7 +287,7 @@ public class EncryptedRandomAccessBufferTest {
     
     @Test
     public void testSerialize() throws IOException, StorageFormatException, ResumeFailedException, GeneralSecurityException, ClassNotFoundException {
-        File tempFile = File.createTempFile("test-storeto", ".tmp", base);
+        File tempFile = tempFolder.newFile();
         byte[] buf = new byte[4096];
         Random r = new Random(1267612);
         r.nextBytes(buf);

--- a/test/freenet/crypt/EncryptedRandomAccessBufferTest.java
+++ b/test/freenet/crypt/EncryptedRandomAccessBufferTest.java
@@ -252,7 +252,7 @@ public class EncryptedRandomAccessBufferTest {
         erat.pwrite(0, result, 0, 20);
     }
     
-    private File base = new File("tmp.encrypted-random-access-thing-test");
+    private final File base = new File("tmp.encrypted-random-access-buffer-test");
     
     @Before
     public void setUp() {

--- a/test/freenet/support/SerializerTest.java
+++ b/test/freenet/support/SerializerTest.java
@@ -82,9 +82,9 @@ public class SerializerTest {
 				Object read = Serializer.readFromDataInputStream(datum.getClass(), dis);
 				//Might be an array.
 				if (read instanceof double[]) {
-					assertTrue(Arrays.equals((double[])datum, (double[])read));
+					assertArrayEquals((double[]) datum, (double[]) read, 0.0);
 				} else if (read instanceof float[]) {
-					assertTrue(Arrays.equals((float[])datum, (float[])read));
+					assertArrayEquals((float[]) datum, (float[]) read, 0.0F);
 				} else {
 					assertEquals(datum, read);
 				}

--- a/test/freenet/support/ShortBufferTest.java
+++ b/test/freenet/support/ShortBufferTest.java
@@ -60,8 +60,8 @@ public class ShortBufferTest {
 		System.arraycopy(data, 4, dataSub, 0, 5);
 
 		ShortBuffer buffer = new ShortBuffer(data, 4, 5);
-		
-		assertFalse(dataSub.equals(buffer.getData()));
+
+		assertNotEquals(dataSub, buffer.getData());
 
 		doTestShortBuffer(dataSub, buffer);
 	}
@@ -153,13 +153,13 @@ public class ShortBufferTest {
 		ShortBuffer b1 = new ShortBuffer("ShortBuffer1".getBytes());
 		ShortBuffer b2 = new ShortBuffer("ShortBuffer2".getBytes());
 		ShortBuffer b3 = new ShortBuffer("ShortBuffer1".getBytes());
-		
-		assertFalse(b1.equals(b2));
-		assertTrue(b1.equals(b3));
-		assertFalse(b2.equals(b3));
-		assertTrue(b1.equals(b1));
-		assertTrue(b2.equals(b2));
-		assertTrue(b3.equals(b1));				
+
+		assertNotEquals(b1, b2);
+		assertEquals(b1, b3);
+		assertNotEquals(b2, b3);
+		assertEquals(b1, b1);
+		assertEquals(b2, b2);
+		assertEquals(b3, b1);
 	}
 	
 	@Test
@@ -177,13 +177,13 @@ public class ShortBufferTest {
 
 		// see if b3 survived
 		Object o = hashMap.get(b3);
-		assertFalse(o == b1);
-		assertTrue(o == b3);
+		assertNotSame(o, b1);
+		assertSame(o, b3);
 		
 		// see if b1 survived
 		o = hashMap.get(b1);
-		assertFalse(o == b1);		
-		assertTrue(o == b3);
+		assertNotSame(o, b1);
+		assertSame(o, b3);
 	}
 	
 	@Test

--- a/test/freenet/support/SparseBitmapTest.java
+++ b/test/freenet/support/SparseBitmapTest.java
@@ -30,10 +30,7 @@ public class SparseBitmapTest {
 		assertTrue(s.contains(0, 5));
 		assertTrue(s.contains(10, 15));
 
-		try {
-			s.add(5, 0);
-			fail("Didn't throw when adding range 5->0");
-		} catch (IllegalArgumentException e) {}
+		assertThrows(IllegalArgumentException.class, () -> s.add(5, 0));
 
 		assertTrue(s.contains(0, 5));
 		assertTrue(s.contains(10, 15));
@@ -99,7 +96,7 @@ public class SparseBitmapTest {
 				final int notOverlapping = s.notOverlapping(a, b);
 				final int width = b - a + 1;
 				final int overlapping = width - notOverlapping;
-				assertTrue((notOverlapping == 0) == s.contains(a, b));
+				assertEquals((notOverlapping == 0), s.contains(a, b));
 				s.remove(a, b);
 				assertFalse(s.contains(a, b));
 				assertEquals(width, s.notOverlapping(a, b));


### PR DESCRIPTION
* `secureDeleteAll` should delete all files in a directory using `secureDeleteAll`.
* Continue deleting other files when some of the files fail to delete in `FileUtils`.
* Use distinct temp file names in tests.
* tests should delete temp directories on exit.