### PR TITLE
CONTRIBUTING.md: remove duplicate "the" in plugin-repo sentence

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ we may have missed it.
 
 All commits with functional changes must be reviewed, including those from
 maintainers. An exception are plugins: updates to official plugins
-must include the commit id from the the plugin-repo in the commit
+must include the commit id from the plugin-repo in the commit
 description; the review in the plugin repository then serves as review in fred.
 
 Code review helps improve code quality, ensures that multiple people know the


### PR DESCRIPTION
Typo fix in CONTRIBUTING.md. No functional change.

- Before: "from the the plugin-repo"
- After:  "from the plugin-repo"