### PR TITLE
fix DNS checks: fast during startup, throttle after first connection

### DIFF
--- a/src/freenet/node/DNSRequester.java
+++ b/src/freenet/node/DNSRequester.java
@@ -101,11 +101,14 @@ public class DNSRequester implements Runnable {
             // Try new DNS lookup
             pn.maybeUpdateHandshakeIPs(false);
         }
-
-        int nextMaxWaitTime = 1000 + node.getFastWeakRandom().nextInt(60000);
+        // fast checks during startup (for seednodes), throttled after first connection
+        boolean noConnectedPeers = node.noConnectedPeers();
+        int nextMaxWaitTime = noConnectedPeers
+            ? 100 + node.getFastWeakRandom().nextInt(400)
+            : 1000 + node.getFastWeakRandom().nextInt(60000);
         try {
             synchronized(this) {
-                wait(nextMaxWaitTime);  // sleep 1-61s ...
+                wait(nextMaxWaitTime);  // sleep 1-61s if connected, else 0.1-0.5s (3s for 10 seeds)
             }
         } catch (InterruptedException e) {
             // Ignore, just wake up. Just sleeping to not busy wait anyway

--- a/src/freenet/node/DNSRequester.java
+++ b/src/freenet/node/DNSRequester.java
@@ -109,10 +109,10 @@ public class DNSRequester implements Runnable {
             // Try new DNS lookup
             pn.maybeUpdateHandshakeIPs(false);
         }
-        int textWaitTime = getNextWaitTime(peerHasHostname, node.noConnectedPeers());
+        int nextWaitTime = getNextWaitTime(peerHasHostname, node.noConnectedPeers());
         try {
             synchronized(this) {
-                wait(textWaitTime);  // sleep 1-61s if connected, else 0.1-0.5s (3s for 10 seeds)
+                wait(nextWaitTime);  // sleep 1-61s if connected, else 0.1-0.5s (3s for 10 seeds)
             }
         } catch (InterruptedException e) {
             // Ignore, just wake up. Just sleeping to not busy wait anyway

--- a/src/freenet/node/DNSRequester.java
+++ b/src/freenet/node/DNSRequester.java
@@ -54,7 +54,7 @@ public class DNSRequester implements Runnable {
 
     @Override
     public void run() {
-        while(true) {
+        while (shouldContinue()) {
             try {
                 realRun();
             } catch (Throwable t) {
@@ -66,7 +66,7 @@ public class DNSRequester implements Runnable {
     private void realRun() {
         // run DNS requests for not recently checked, unconnected
         // nodes to avoid the coupon collector's problem
-        PeerNode[] nodesToCheck = Arrays.stream(node.getPeers().myPeers())
+        PeerNode[] nodesToCheck = Arrays.stream(getPeers())
             .filter(peerNode -> !peerNode.isConnected())
             // identify recent nodes by location, because the exact location cannot be used twice
             // (that already triggers the simplest pitch black attack defenses)
@@ -89,7 +89,7 @@ public class DNSRequester implements Runnable {
             // check a randomly chosen node that has not been checked
             // recently to avoid sending bursts of DNS requests
             PeerNode pn = nodesToCheck[node.getFastWeakRandom().nextInt(unconnectedNodesLength)];
-            peerHasHostname = pn.nominalPeer.stream()
+            peerHasHostname = pn.getNominalPeer().stream()
                 .map(Peer::getFreenetAddress)
                 .filter(Objects::nonNull)
                 .anyMatch(FreenetInetAddress::hasHostname);
@@ -107,26 +107,46 @@ public class DNSRequester implements Runnable {
                 }
             }
             // Try new DNS lookup
-            pn.maybeUpdateHandshakeIPs(false);
+            updatePeer(pn);
         }
         int nextWaitTime = getNextWaitTime(peerHasHostname, node.noConnectedPeers());
         try {
-            synchronized(this) {
-                wait(nextWaitTime);  // sleep 1-61s if connected, else 0.1-0.5s (3s for 10 seeds)
-            }
+            sleepUntilNextRun(nextWaitTime);  // sleep 1-61s ...
         } catch (InterruptedException e) {
             // Ignore, just wake up. Just sleeping to not busy wait anyway
         }
     }
 
+    // made available for testing
+    protected void sleepUntilNextRun(long waitTime) throws InterruptedException {
+        synchronized (this) {
+            wait(waitTime);
+        }
+    }
+
+    // made available for testing
+    protected boolean shouldContinue() {
+        return true;
+    }
+
+    // made available for testing
+    protected void updatePeer(PeerNode pn) {
+        pn.maybeUpdateHandshakeIPs(false);
+    }
+
+    // made available for testing
+    protected PeerNode[] getPeers() {
+        return node.getPeers().myPeers();
+    }
+
     /**
+     * Determines the time to wait for the next {@link PeerNode} update.
      *
      * @param peerHasHostname - whether the peer's addresses include a hostname (a DNS name)
+     * @param noConnectedPeers {@code true} if the node has no connections, {@code false} otherwise
      * @return seconds to wait
-     *
-     * protected for testing
      */
-    protected int getNextWaitTime(boolean peerHasHostname, boolean noConnectedPeers) {
+    private int getNextWaitTime(boolean peerHasHostname, boolean noConnectedPeers) {
         // wait longer after DNS requests
         int multiplier = peerHasHostname ? 100 : 1;
         // fast checks during startup (for seednodes), throttled after first connection

--- a/src/freenet/node/DNSRequester.java
+++ b/src/freenet/node/DNSRequester.java
@@ -109,25 +109,39 @@ public class DNSRequester implements Runnable {
             // Try new DNS lookup
             pn.maybeUpdateHandshakeIPs(false);
         }
-        // wait longer after DNS requests
-        int multiplier = peerHasHostname ? 100 : 1;
-        // fast checks during startup (for seednodes), throttled after first connection
-        boolean noConnectedPeers = node.noConnectedPeers();
-        int nextMaxWaitTime = noConnectedPeers
-            ? multiplier * (1 + node.getFastWeakRandom().nextInt(4))
-            : multiplier * (10 + node.getFastWeakRandom().nextInt(600));
+        int textWaitTime = getNextWaitTime(peerHasHostname, node.noConnectedPeers());
         try {
             synchronized(this) {
-                wait(nextMaxWaitTime);  // sleep 1-61s if connected, else 0.1-0.5s (3s for 10 seeds)
+                wait(textWaitTime);  // sleep 1-61s if connected, else 0.1-0.5s (3s for 10 seeds)
             }
         } catch (InterruptedException e) {
             // Ignore, just wake up. Just sleeping to not busy wait anyway
         }
     }
 
-	public void forceRun() {
-		synchronized(this) {
-			notifyAll();
-		}
-	}
+    /**
+     *
+     * @param peerHasHostname - whether the peer's addresses include a hostname (a DNS name)
+     * @return seconds to wait
+     *
+     * protected for testing
+     */
+    protected int getNextWaitTime(boolean peerHasHostname, boolean noConnectedPeers) {
+        // wait longer after DNS requests
+        int multiplier = peerHasHostname ? 100 : 1;
+        // fast checks during startup (for seednodes), throttled after first connection
+        int lowerBound = noConnectedPeers ? 1 : 10;
+        int maxOfRandomInt = noConnectedPeers ? 4 : 600;
+        return getRandomWaitTimeValue(multiplier, lowerBound, maxOfRandomInt);
+    }
+
+    private int getRandomWaitTimeValue(int multiplier, int lowerBound, int maxOfRandomInt) {
+        return multiplier * (lowerBound + node.getFastWeakRandom().nextInt(maxOfRandomInt));
+    }
+
+    public void forceRun() {
+        synchronized(this) {
+            notifyAll();
+        }
+    }
 }

--- a/src/freenet/node/PeerNode.java
+++ b/src/freenet/node/PeerNode.java
@@ -143,7 +143,12 @@ public abstract class PeerNode implements USKRetrieverCallback, BasePeerNode, Pe
 	private Peer detectedPeer = null;
 	/** My OutgoingPacketMangler i.e. the object which encrypts packets sent to this node */
 	private final OutgoingPacketMangler outgoingMangler;
-	/** Advertised addresses */
+	/**
+	 * Advertised addresses
+	 *
+	 * @deprecated Use {@link #getNominalPeer()} instead
+	 */
+	@Deprecated
 	protected List<Peer> nominalPeer;
 	/** The PeerNode's report of our IP address */
 	private Peer remoteDetectedPeer;
@@ -778,6 +783,10 @@ public abstract class PeerNode implements USKRetrieverCallback, BasePeerNode, Pe
 
 	private void sortNominalPeer() {
 		nominalPeer.sort(Peer.PEER_COMPARATOR);
+	}
+
+	public List<Peer> getNominalPeer() {
+		return nominalPeer;
 	}
 
 	/**

--- a/test/freenet/node/DNSRequesterTest.java
+++ b/test/freenet/node/DNSRequesterTest.java
@@ -1,56 +1,264 @@
 package freenet.node;
 
+import freenet.io.comm.Peer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.Arrays;
-import java.util.Collection;
+public class DNSRequesterTest {
 
-import org.hamcrest.Matchers;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
-
-@RunWith(Parameterized.class)
-public class DNSRequesterTest  {
-
-	private final boolean peerHasHostname;
-	private final boolean noConnectedPeers;
-	private final int expectedTime;
-
-	private Node node;
-	private DNSRequester dnsRequester;
-
-	@Parameters(name = "{index}: hostname: {0}, noConnected: {1} -> {2}")
-	public static Collection<Object[]> data() {
-		return Arrays.asList(new Object[][] {
-				{false, true, 2}, // shortest: has no hostname and has no connections
-				{false, false, 11}, // has no hostname and has connections
-				{true, true, 200}, // has hostname and has no connections
-				{true, false, 1100}, // longest: has hostname and has connections
+	@Test
+	public void dnsRequesterWillNotUpdateAnythingIfNoPeersArePresent() {
+		runDNSRequester(quitAfterFirstRun(), () -> new PeerNode[0], dnsRequester -> {
+			assertThat(dnsRequester.updatedPeerNodes, empty());
 		});
 	}
 
-	public DNSRequesterTest(boolean peerHasHostname, boolean noConnectedPeers, int expectedTime) {
-		this.peerHasHostname = peerHasHostname;
-		this.noConnectedPeers = noConnectedPeers;
-		this.expectedTime = expectedTime;
+	@Test
+	public void dnsRequesterDoesNotUpdateConnectedPeers() {
+		when(peerNode.isConnected()).thenReturn(true);
+		runDNSRequester(quitAfterFirstRun(), () -> new PeerNode[] { peerNode }, dnsRequester -> {
+			assertThat(dnsRequester.updatedPeerNodes, empty());
+		});
 	}
 
-	@Before
-	public void setup(){
-		this.node = mock(Node.class, RETURNS_DEEP_STUBS);
-		when(node.getFastWeakRandom().nextInt(anyInt())).thenReturn(1);
-		this.dnsRequester = new DNSRequester(node);
-	}
 	@Test
-	public void shouldMatchExpectedTime() {
-		assertThat(dnsRequester.getNextWaitTime(peerHasHostname, noConnectedPeers), Matchers.equalTo(expectedTime));
+	public void dnsRequesterUpdateSinglePeerIfOnePeerIsPresent() {
+		runDNSRequester(quitAfterFirstRun(), () -> new PeerNode[] { peerNode }, dnsRequester -> {
+			assertThat(dnsRequester.updatedPeerNodes, contains(peerNode));
+		});
+	}
+
+	@Test
+	public void dnsRequesterWaitsVeryShortTimeIfPeerHasNoHostnameAndNoNodeIsConnected() {
+		when(node.noConnectedPeers()).thenReturn(true);
+		when(peerNode.getNominalPeer()).thenReturn(asList(peerWithoutHostname));
+		when(node.getFastWeakRandom().nextInt(anyInt())).thenReturn(0, 1);
+		runDNSRequester(quitAfterFirstRun(), () -> new PeerNode[] { peerNode }, dnsRequester -> {
+			assertThat(dnsRequester.waitTimes, contains(2L));
+		});
+	}
+
+	@Test
+	public void dnsRequesterUsesSmallVarianceOnRandomNumberGeneratorIfPeerHasNoHostnameAndNoNodeIsConnected() {
+		when(node.noConnectedPeers()).thenReturn(true);
+		when(peerNode.getNominalPeer()).thenReturn(asList(peerWithoutHostname));
+		when(node.getFastWeakRandom().nextInt(anyInt())).thenReturn(0, 1);
+		runDNSRequester(quitAfterFirstRun(), () -> new PeerNode[] { peerNode }, dnsRequester -> {
+			ArgumentCaptor<Integer> argumentCaptor = ArgumentCaptor.forClass(Integer.class);
+			verify(node.getFastWeakRandom(), times(2)).nextInt(argumentCaptor.capture());
+			assertThat(argumentCaptor.getAllValues().get(1), equalTo(4));
+		});
+	}
+
+	@Test
+	public void dnsRequesterWaitsLongerTimeIfPeerHasHostnameAndNoNodeIsConnected() {
+		when(node.noConnectedPeers()).thenReturn(true);
+		when(peerNode.getNominalPeer()).thenReturn(asList(peerWithHostname));
+		when(node.getFastWeakRandom().nextInt(anyInt())).thenReturn(0, 1);
+		runDNSRequester(quitAfterFirstRun(), () -> new PeerNode[] { peerNode }, dnsRequester -> {
+			assertThat(dnsRequester.waitTimes, contains(200L));
+		});
+	}
+
+	@Test
+	public void dnsRequesterUsesSmallVarianceOnRandomNumberGeneratorIfPeerHasHostnameAndNoNodeIsConnected() {
+		when(node.noConnectedPeers()).thenReturn(true);
+		when(peerNode.getNominalPeer()).thenReturn(asList(peerWithHostname));
+		when(node.getFastWeakRandom().nextInt(anyInt())).thenReturn(0, 1);
+		runDNSRequester(quitAfterFirstRun(), () -> new PeerNode[] { peerNode }, dnsRequester -> {
+			ArgumentCaptor<Integer> argumentCaptor = ArgumentCaptor.forClass(Integer.class);
+			verify(node.getFastWeakRandom(), times(2)).nextInt(argumentCaptor.capture());
+			assertThat(argumentCaptor.getAllValues().get(1), equalTo(4));
+		});
+	}
+
+	@Test
+	public void dnsRequesterWaitsLongerTimeIfPeerHasNoHostnameAndNodesAreConnected() {
+		when(node.noConnectedPeers()).thenReturn(false);
+		when(peerNode.getNominalPeer()).thenReturn(asList(peerWithoutHostname));
+		when(node.getFastWeakRandom().nextInt(anyInt())).thenReturn(0, 500);
+		runDNSRequester(quitAfterFirstRun(), () -> new PeerNode[] { peerNode }, dnsRequester -> {
+			assertThat(dnsRequester.waitTimes, contains(510L));
+		});
+	}
+
+	@Test
+	public void dnsRequesterUsesLargeVarianceOnRandomNumberGeneratorIfPeerHasNoHostnameAndNodesAreConnected() {
+		when(node.noConnectedPeers()).thenReturn(false);
+		when(peerNode.getNominalPeer()).thenReturn(asList(peerWithoutHostname));
+		when(node.getFastWeakRandom().nextInt(anyInt())).thenReturn(0, 500);
+		runDNSRequester(quitAfterFirstRun(), () -> new PeerNode[] { peerNode }, dnsRequester -> {
+			ArgumentCaptor<Integer> argumentCaptor = ArgumentCaptor.forClass(Integer.class);
+			verify(node.getFastWeakRandom(), times(2)).nextInt(argumentCaptor.capture());
+			assertThat(argumentCaptor.getAllValues().get(1), equalTo(600));
+		});
+	}
+
+	@Test
+	public void dnsRequesterWaitsLongestTimeIfPeerHasHostnameAndNodesAreConnected() {
+		when(node.noConnectedPeers()).thenReturn(false);
+		when(peerNode.getNominalPeer()).thenReturn(asList(peerWithHostname));
+		when(node.getFastWeakRandom().nextInt(anyInt())).thenReturn(0, 500);
+		runDNSRequester(quitAfterFirstRun(), () -> new PeerNode[] { peerNode }, dnsRequester -> {
+			assertThat(dnsRequester.waitTimes, contains(51000L));
+		});
+	}
+
+	@Test
+	public void dnsRequesterUsesLargeVarianceOnRandomNumberGeneratorIfPeerHasHostnameAndNodesAreConnected() {
+		when(node.noConnectedPeers()).thenReturn(false);
+		when(peerNode.getNominalPeer()).thenReturn(asList(peerWithHostname));
+		when(node.getFastWeakRandom().nextInt(anyInt())).thenReturn(0, 500);
+		runDNSRequester(quitAfterFirstRun(), () -> new PeerNode[] { peerNode }, dnsRequester -> {
+			ArgumentCaptor<Integer> argumentCaptor = ArgumentCaptor.forClass(Integer.class);
+			verify(node.getFastWeakRandom(), times(2)).nextInt(argumentCaptor.capture());
+			assertThat(argumentCaptor.getAllValues().get(1), equalTo(600));
+		});
+	}
+
+	@Test
+	public void dnsRequesterUpdatesRandomlySelectedPeerNode() {
+		PeerNode[] peerNodes = generateRandomNodes(10);
+		for (int peerIndex = 0; peerIndex < peerNodes.length; peerIndex++) {
+			PeerNode peerNode = peerNodes[peerIndex];
+			when(node.getFastWeakRandom().nextInt(anyInt())).thenReturn(peerIndex, 0);
+			runDNSRequester(quitAfterFirstRun(), () -> peerNodes, dnsRequester -> {
+				assertThat(dnsRequester.updatedPeerNodes, contains(peerNode));
+			});
+		}
+	}
+
+	@Test
+	public void dnsRequesterWaitsRandomlyAfterEachPeerNode() {
+		when(node.noConnectedPeers()).thenReturn(true);
+		when(node.getFastWeakRandom().nextInt(anyInt())).thenReturn(0, 471595564, 0, 1794965883, 0, 2141731345, 0, 1549634095, 0, 274830936);
+		runDNSRequester(quitAfterNRuns(5), () -> new PeerNode[] { peerNode }, dnsRequester -> {
+			assertThat(dnsRequester.waitTimes, contains(471595564L + 1, 1794965883L + 1, 2141731345L + 1, 1549634095L + 1, 274830936L + 1));
+		});
+	}
+
+	@Test
+	public void dnsRequesterDoesNotReRequestUpdateForNodesWhileTheNumberOfRemainingNodesIsLargeEnough() {
+		PeerNode[] peerNodes = generateRandomNodes(100);
+		// the number of known nodes (i.e. nodes not to check again) must not be larger than 81% of the number of remaining nodes.
+		// it takes 46 iterations for the number of remaining nodes to get small enough that the known nodes set gets culled.
+		// 46 > (0.81 * 55), so two elements get removed from the known node set; however, this only gets relevant on the next iteration (see next test).
+		runDNSRequester(quitAfterNRuns(46), () -> peerNodes, dnsRequester -> {
+			assertThat(new HashSet<>(dnsRequester.updatedPeerNodes), hasSize(46));
+		});
+	}
+
+	@Test
+	public void dnsRequesterReRequestUpdateForNodesWhenMoreThan81PercentOfRemainingNodesHaveBeenChecked() {
+		PeerNode[] peerNodes = generateRandomNodes(100);
+		// the number of known nodes (i.e. nodes not to check again) must not be larger than 81% of the number of remaining nodes.
+		// it takes 46 iterations for the number of remaining nodes to get small enough that the known nodes set gets culled.
+		// 46 > (0.81 * 55), so two elements get removed from the known node set; at the next iteration, the oldest node has been
+		// removed from the known nodes set, so the oldest node (i.e., the first in the peerNodes array) will be retried.
+		runDNSRequester(quitAfterNRuns(47), () -> peerNodes, dnsRequester -> {
+			assertThat(new HashSet<>(dnsRequester.updatedPeerNodes), hasSize(46));
+		});
+	}
+
+	@Test(timeout = 5000L)
+	public void dnsRequesterRequestsAllNodesWhenRunningLongEnough() {
+		PeerNode[] peerNodes = generateRandomNodes(100);
+		when(node.getFastWeakRandom().nextInt(anyInt())).thenAnswer(invocation -> (int) (Math.random() * (int) invocation.getArguments()[0]));
+		// in experiments, it took between 300 and 400 iterations to reliably pick every node once, so runtime here should be negligible.
+		runDNSRequester(quitWhen(dnsRequester -> new HashSet<>(dnsRequester.updatedPeerNodes).size() != 100), () -> peerNodes, dnsRequester -> {
+		});
+	}
+
+	private void runDNSRequester(Function<TestDNSRequester, Boolean> shouldContinue, Supplier<PeerNode[]> peerNodes, Consumer<TestDNSRequester> dnsRequesterConsumer) {
+		TestDNSRequester dnsRequester = new TestDNSRequester(node, shouldContinue, peerNodes);
+		dnsRequester.run();
+		dnsRequesterConsumer.accept(dnsRequester);
+	}
+
+	private static PeerNode[] generateRandomNodes(int numberOfNodes) {
+		PeerNode[] peerNodes = new PeerNode[numberOfNodes];
+		Arrays.setAll(peerNodes, index -> when(mock(PeerNode.class, "PeerNode " + index).getLocation()).thenReturn((index + 1) / (double) (numberOfNodes + 1)).getMock());
+		return peerNodes;
+	}
+
+	private Function<TestDNSRequester, Boolean> quitAfterFirstRun() {
+		return quitAfterNRuns(1);
+	}
+
+	private Function<TestDNSRequester, Boolean> quitAfterNRuns(int numberOfRuns) {
+		AtomicInteger runsLeft = new AtomicInteger(numberOfRuns);
+		return dnsRequester -> runsLeft.getAndDecrement() > 0;
+	}
+
+	private Function<TestDNSRequester, Boolean> quitWhen(Predicate<TestDNSRequester> predicate) {
+		return predicate::test;
+	}
+
+	private final Node node = mock(Node.class, RETURNS_DEEP_STUBS);
+	private final PeerNode peerNode = mock(PeerNode.class);
+	private final Peer peerWithHostname = mock(Peer.class, RETURNS_DEEP_STUBS);
+	private final Peer peerWithoutHostname = mock(Peer.class, RETURNS_DEEP_STUBS);
+
+	{
+		when(peerWithHostname.getFreenetAddress().hasHostname()).thenReturn(true);
+	}
+
+	private static class TestDNSRequester extends DNSRequester {
+
+		public final List<PeerNode> updatedPeerNodes = new ArrayList<>();
+		public final List<Long> waitTimes = new ArrayList<>();
+
+		public TestDNSRequester(Node node, Function<TestDNSRequester, Boolean> shouldContinue, Supplier<PeerNode[]> peerNodes) {
+			super(node);
+			this.shouldContinue = shouldContinue;
+			this.peerNodes = peerNodes;
+		}
+
+		@Override
+		protected boolean shouldContinue() {
+			return shouldContinue.apply(this);
+		}
+
+		@Override
+		protected PeerNode[] getPeers() {
+			return peerNodes.get();
+		}
+
+		@Override
+		protected void updatePeer(PeerNode peerNode) {
+			updatedPeerNodes.add(peerNode);
+		}
+
+		@Override
+		protected void sleepUntilNextRun(long waitTime) {
+			waitTimes.add(waitTime);
+		}
+
+		private final Function<TestDNSRequester, Boolean> shouldContinue;
+		private final Supplier<PeerNode[]> peerNodes;
+
 	}
 
 }

--- a/test/freenet/node/DNSRequesterTest.java
+++ b/test/freenet/node/DNSRequesterTest.java
@@ -16,10 +16,8 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
-import junit.framework.TestCase;
-
 @RunWith(Parameterized.class)
-public class DNSRequesterTest extends TestCase {
+public class DNSRequesterTest  {
 
 	private final boolean peerHasHostname;
 	private final boolean noConnectedPeers;

--- a/test/freenet/node/DNSRequesterTest.java
+++ b/test/freenet/node/DNSRequesterTest.java
@@ -19,7 +19,7 @@ import org.junit.runners.Parameterized.Parameters;
 import junit.framework.TestCase;
 
 @RunWith(Parameterized.class)
-public class DNSRequesterWaitTimeTest extends TestCase {
+public class DNSRequesterTest extends TestCase {
 
 	private final boolean peerHasHostname;
 	private final boolean noConnectedPeers;
@@ -38,7 +38,7 @@ public class DNSRequesterWaitTimeTest extends TestCase {
 		});
 	}
 
-	public DNSRequesterWaitTimeTest(boolean peerHasHostname, boolean noConnectedPeers, int expectedTime) {
+	public DNSRequesterTest(boolean peerHasHostname, boolean noConnectedPeers, int expectedTime) {
 		this.peerHasHostname = peerHasHostname;
 		this.noConnectedPeers = noConnectedPeers;
 		this.expectedTime = expectedTime;

--- a/test/freenet/node/DNSRequesterWaitTimeTest.java
+++ b/test/freenet/node/DNSRequesterWaitTimeTest.java
@@ -1,0 +1,58 @@
+package freenet.node;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import junit.framework.TestCase;
+
+@RunWith(Parameterized.class)
+public class DNSRequesterWaitTimeTest extends TestCase {
+
+	private final boolean peerHasHostname;
+	private final boolean noConnectedPeers;
+	private final int expectedTime;
+
+	private Node node;
+	private DNSRequester dnsRequester;
+
+	@Parameters(name = "{index}: hostname: {0}, noConnected: {1} -> {2}")
+	public static Collection<Object[]> data() {
+		return Arrays.asList(new Object[][] {
+				{false, false, 11},
+				{false, true, 2},
+				{true, false, 1100},
+				{true, true, 200},
+		});
+	}
+
+	public DNSRequesterWaitTimeTest(boolean peerHasHostname, boolean noConnectedPeers, int expectedTime) {
+		this.peerHasHostname = peerHasHostname;
+		this.noConnectedPeers = noConnectedPeers;
+		this.expectedTime = expectedTime;
+	}
+
+	@Before
+	public void setup(){
+		this.node = mock(Node.class, RETURNS_DEEP_STUBS);
+		when(node.getFastWeakRandom().nextInt(anyInt())).thenReturn(1);
+		this.dnsRequester = new DNSRequester(node);
+	}
+	@Test
+	public void shouldMatchExpectedTime() {
+		assertThat(dnsRequester.getNextWaitTime(peerHasHostname, noConnectedPeers), Matchers.equalTo(expectedTime));
+	}
+
+}

--- a/test/freenet/node/DNSRequesterWaitTimeTest.java
+++ b/test/freenet/node/DNSRequesterWaitTimeTest.java
@@ -31,10 +31,10 @@ public class DNSRequesterWaitTimeTest extends TestCase {
 	@Parameters(name = "{index}: hostname: {0}, noConnected: {1} -> {2}")
 	public static Collection<Object[]> data() {
 		return Arrays.asList(new Object[][] {
-				{false, false, 11},
-				{false, true, 2},
-				{true, false, 1100},
-				{true, true, 200},
+				{false, true, 2}, // shortest: has no hostname and has no connections
+				{false, false, 11}, // has no hostname and has connections
+				{true, true, 200}, // has hostname and has no connections
+				{true, false, 1100}, // longest: has hostname and has connections
 		});
 	}
 


### PR DESCRIPTION
DNS requests are throttled to reduce visibility of requests on DNS servers.

The throttling caused seednode checks to be delayed by 30s per seed, slowing down initial connection.

The fix reduces the throttling while the node is unconnected and increases the throttling once at least one node is connected.